### PR TITLE
Add a few tests for the HTML LI elements

### DIFF
--- a/data/schema/dev-test.json
+++ b/data/schema/dev-test.json
@@ -113,6 +113,9 @@
         },
         "value": {
           "type": "string"
+        },
+        "optional": {
+          "type": "boolean"
         }
       },
       "required": ["title", "value"]

--- a/data/tech/html/li_element.json
+++ b/data/tech/html/li_element.json
@@ -10,7 +10,8 @@
     }
   ],
   "tests": [
-    "html_li_element_in_ul_with_sub_ul_aam"
+    "html_li_element_in_ul_with_sub_ul_aam",
+    "html_li_element_in_ol_with_sub_ol_aam"
   ],
   "date_updated": "2018-10-19"
 }

--- a/data/tech/html/li_element.json
+++ b/data/tech/html/li_element.json
@@ -1,0 +1,16 @@
+{
+  "id": "li_element",
+  "title": "li element",
+  "type": "element",
+  "description": "",
+  "references": [
+    {
+      "title": "HTML5 spec for li",
+      "url": "https://w3c.github.io/html/grouping-content.html#the-li-element"
+    }
+  ],
+  "tests": [
+    "html_li_element_in_ul_with_sub_ul_aam"
+  ],
+  "date_updated": "2018-10-19"
+}

--- a/data/tech/html/ol_element.json
+++ b/data/tech/html/ol_element.json
@@ -1,0 +1,16 @@
+{
+  "id": "ol_element",
+  "title": "ol element",
+  "type": "element",
+  "description": "",
+  "references": [
+    {
+      "title": "HTML5 spec for ol",
+      "url": "https://w3c.github.io/html/grouping-content.html#the-ol-element"
+    }
+  ],
+  "tests": [
+    "html_li_element_in_ol_with_sub_ol_aam"
+  ],
+  "date_updated": "2018-10-19"
+}

--- a/data/tech/html/ul_element.json
+++ b/data/tech/html/ul_element.json
@@ -1,0 +1,16 @@
+{
+  "id": "ul_element",
+  "title": "ul element",
+  "type": "element",
+  "description": "",
+  "references": [
+    {
+      "title": "HTML5 spec for ul",
+      "url": "https://w3c.github.io/html/grouping-content.html#the-ul-element"
+    }
+  ],
+  "tests": [
+    "html_li_element_in_ul_with_sub_ul_aam"
+  ],
+  "date_updated": "2018-10-19"
+}

--- a/data/tests/html/html_li_element_in_ol_with_sub_ol_aam.html
+++ b/data/tests/html/html_li_element_in_ol_with_sub_ol_aam.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>HTML LI element in OL with sub OL</title>
+</head>
+<body>
+<p>Use the screen reader to announce the target element.</p>
+<ol>
+    <li id="target">
+        Target
+        <ol>
+            <li>Sub OL list item 1</li>
+            <li>Sub OL list item 2</li>
+        </ol>
+    </li>
+    <li>
+        Parent OL list item 2
+    </li>
+    <li>
+        Parent OL list item 3
+    </li>
+</ol>
+</body>
+</html>

--- a/data/tests/html/html_li_element_in_ul_with_sub_ul_aam.html
+++ b/data/tests/html/html_li_element_in_ul_with_sub_ul_aam.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>HTML LI element in UL with sub UL</title>
+</head>
+<body>
+    <p>Use the screen reader to announce the target element.</p>
+    <ul>
+       <li id="target">
+           Target
+           <ul>
+               <li>Sub UL list item 1</li>
+               <li>Sub UL list item 2</li>
+           </ul>
+       </li>
+        <li>
+            Parent UL list item 2
+        </li>
+        <li>
+            Parent UL list item 3
+        </li>
+    </ul>
+</body>
+</html>

--- a/data/tests/html_li_element_in_ol_with_sub_ol_aam.json
+++ b/data/tests/html_li_element_in_ol_with_sub_ol_aam.json
@@ -1,0 +1,69 @@
+{
+  "type": "aam",
+  "title": "HTML LI element in a OL with a sub OL",
+  "description": "This test ensures that the number of items in a list are being computed correctly when there is a sub-list.",
+  "supports_sr": true,
+  "supports_vc": false,
+  "css_target": "#target",
+  "expected": {
+    "role": "listitem",
+    "accessible_name": "Target",
+    "accessible_description": "",
+    "states_and_properties": [
+      {
+        "title": "setsize",
+        "value": "3"
+      },
+      {
+        "title": "posinset",
+        "value": "1"
+      }
+    ]
+  },
+  "history": [
+    {
+      "date": "2018-10-19",
+      "message": "Test created"
+    }
+  ],
+  "at": {
+    "nvda": {
+      "browsers": {
+        "firefox": {
+          "at_version": "2018.3.2",
+          "browser_version": "62",
+          "os_version": "17763",
+          "support": "y",
+          "date": "2018-10-19",
+          "output": [
+            {
+              "command": "up/down arrows",
+              "command_name": "Read next/previous item",
+              "output": "List with three items. 1. Target.",
+              "result": "pass"
+            }
+          ]
+        }
+      }
+    },
+    "vo_macos": {
+      "browsers": {
+        "safari": {
+          "at_version": "10.14",
+          "browser_version": "12",
+          "os_version": "10.14",
+          "support": "y",
+          "date": "2018-10-19",
+          "output": [
+            {
+              "command": "up/down arrows",
+              "command_name": "Read next/previous item",
+              "output": "Target 1 of 3",
+              "result": "pass"
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/data/tests/html_li_element_in_ul_with_sub_ul_aam.json
+++ b/data/tests/html_li_element_in_ul_with_sub_ul_aam.json
@@ -1,0 +1,70 @@
+{
+  "type": "aam",
+  "title": "HTML LI element in a UL with a sub UL",
+  "description": "This test ensures that the number of items in a list are being computed correctly when there is a sub-list.",
+  "supports_sr": true,
+  "supports_vc": false,
+  "css_target": "#target",
+  "expected": {
+    "role": "listitem",
+    "accessible_name": "Target",
+    "accessible_description": "",
+    "states_and_properties": [
+      {
+        "title": "setsize",
+        "value": "2"
+      },
+      {
+        "title": "posinset",
+        "value": "1",
+        "optional": true
+      }
+    ]
+  },
+  "history": [
+    {
+      "date": "2018-10-19",
+      "message": "Test created"
+    }
+  ],
+  "at": {
+    "nvda": {
+      "browsers": {
+        "firefox": {
+          "at_version": "2018.3.2",
+          "browser_version": "62",
+          "os_version": "17763",
+          "support": "y",
+          "date": "2018-10-19",
+          "output": [
+            {
+              "command": "up/down arrows",
+              "command_name": "Read next/previous item",
+              "output": "List with two items. Bullet Target.",
+              "result": "pass"
+            }
+          ]
+        }
+      }
+    },
+    "vo_macos": {
+      "browsers": {
+        "safari": {
+          "at_version": "10.14",
+          "browser_version": "12",
+          "os_version": "10.14",
+          "support": "y",
+          "date": "2018-10-19",
+          "output": [
+            {
+              "command": "up/down arrows",
+              "command_name": "Read next/previous item",
+              "output": "Target 1 of 2",
+              "result": "pass"
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/data/tests/html_li_element_in_ul_with_sub_ul_aam.json
+++ b/data/tests/html_li_element_in_ul_with_sub_ul_aam.json
@@ -12,7 +12,7 @@
     "states_and_properties": [
       {
         "title": "setsize",
-        "value": "2"
+        "value": "3"
       },
       {
         "title": "posinset",
@@ -40,7 +40,7 @@
             {
               "command": "up/down arrows",
               "command_name": "Read next/previous item",
-              "output": "List with two items. Bullet Target.",
+              "output": "List with three items. Bullet Target.",
               "result": "pass"
             }
           ]
@@ -59,7 +59,7 @@
             {
               "command": "up/down arrows",
               "command_name": "Read next/previous item",
-              "output": "Target 1 of 2",
+              "output": "Target 1 of 3",
               "result": "pass"
             }
           ]

--- a/views/test-case.pug
+++ b/views/test-case.pug
@@ -69,7 +69,7 @@ block content
                                 each instruction in test.sr_instructions
                                     li= instruction
                             else
-                            li The test passes if the screen reader output includes the expected name, role, and properties (the exact order and vocabulary will differ between screen readers). The expected name, role, and properties can be found after the instructions. If some commands work and others do not, the test should be marked as 'partial support'.
+                            li The test passes if the screen reader output includes the expected name, role, and properties. The exact order and vocabulary will differ between screen readers. The expected name, role, and properties can be found after the instructions. If some commands work and others do not, the test should be marked as 'partial support'.
                             li Use the form to create an issue for the given browser/screen reader combination. Please include detailed notes about what commands were used.
 
                     if (test.supports_vc)
@@ -86,6 +86,7 @@ block content
                                 li Use the form to create an issue for the given browser/voice command software combination.
 
                     h3 Expected name, role, and properties
+                    p Optional states and properties will be marked as "optional". This information is not required for understanding. Some screen readers might choose to announce this information, while other may not. The test still passes if optional information is not announced.
                     table
                         tr
                             th(scope="row") Role

--- a/views/test-case.pug
+++ b/views/test-case.pug
@@ -97,8 +97,9 @@ block content
                             th(scope="row") Accessible Description
                             td= test.expected.accessible_description || '(none)'
                         each state_or_property in test.expected.states_and_properties
-                            th(scope="row")= state_or_property.title
-                            td= state_or_property.value
+                            tr
+                                th(scope="row")= (state_or_property.optional===true?'(optional) ':'') + state_or_property.title
+                                td= state_or_property.value
 
                     p(class="note") Note: Screen readers will usually announce an element in the format: <span class='inline-quote'>"&lt;role&gt;, &lt;accessible name&gt;, &lt;other states and properties&gt;, &lt;accessible description&gt;"</span>. The order in which the name, role, and properties are announced might differ between screen readers. The exact vocabulary used will also differ.
 


### PR DESCRIPTION
This adds some tests for HTML LI elements. The goal is to verify HTML-AAM implementation and ensure that sub list items are not being included in the parent's `setsize` property.