### PR TITLE
Add AT commands to the ATBrowsers.json file

### DIFF
--- a/data/ATBrowsers.json
+++ b/data/ATBrowsers.json
@@ -22,7 +22,46 @@
       "core_browsers": ["ie"],
       "extended_browsers": ["firefox", "edge", "chrome"],
       "url": "https://www.nuance.com/dragon.html",
-      "description": "http://www.nuance.com/support/dragon-naturallyspeaking/index.htm?link_name=technical_support#dr_support_contact"
+      "description": "http://www.nuance.com/support/dragon-naturallyspeaking/index.htm?link_name=technical_support#dr_support_contact",
+      "commands": {
+        "next_actionable_item": {
+          "name": "Next actionable item",
+          "command": "\"Press Tab\"",
+          "tags": ["general"]
+        },
+        "activate_actionable_item": {
+          "name": "Activate actionable item",
+          "command": "\"Click <text>\"",
+          "note": "If there are multiple choices with the same text, they will be labeled by numbers. Say \"Choose <number>\" to finish.",
+          "tags": ["general"]
+        },
+        "show_dropdown_choices": {
+          "name": "Show drop down choices",
+          "command": "\"Show choices\"",
+          "tags": ["general"]
+        },
+        "choose_dropdown_option": {
+          "name": "Choose drop down option",
+          "command": "\"Choose <option text>\"",
+          "tags": ["general"]
+        },
+        "hide_dropdown_choices": {
+          "name": "Hide drop down choices",
+          "command": "\"Hide choices\"",
+          "tags": ["general"]
+        },
+        "undo_text": {
+          "name": "Undo entered text",
+          "command": "\"Scratch that\"",
+          "tags": ["general"]
+        },
+        "click_type": {
+          "name": "Click Type",
+          "command": "Click <type>",
+          "note": "where type is \"link\", \"button\", \"text field\", \"image\", \"Check box\", \"Radio Button\", etc. Dragon will then flag each matching element with a number. Say \"choose <number>\" to finish.",
+          "tags": ["general"]
+        }
+      }
     },
     "jaws": {
       "id": "jaws",
@@ -34,7 +73,139 @@
       "extended_browsers": ["chrome", "firefox"],
       "url": "https://www.freedomscientific.com/Products/Blindness/JAWS",
       "description": "",
-      "bugs": "https://github.com/FreedomScientific/VFO-standards-support/issues"
+      "bugs": "https://github.com/FreedomScientific/VFO-standards-support/issues",
+      "commands": {
+        "turn_on": {
+          "name": "Turn On",
+          "command": "(none)",
+          "tags": [
+            "general"
+          ]
+        },
+        "turn_off": {
+          "name": "Turn Off",
+          "command": "Insert + F4",
+          "tags": [
+            "general"
+          ]
+        },
+        "enter_forms_mode": {
+          "name": "Enter forms mode",
+          "command": "Enter",
+          "note": "Automatically activated when entering a form control.",
+          "tags": [
+            "general", "forms"
+          ]
+        },
+        "exit_forms_mode": {
+          "name": "Exit forms mode",
+          "command": "Num pad Plus",
+          "tags": [
+            "general", "forms"
+          ]
+        },
+        "stop_reading": {
+          "name": "Stop reading",
+          "command": "Control",
+          "tags": [
+            "reading"
+          ]
+        },
+        "read_next_item": {
+          "name": "Read next item",
+          "command": "Down arrow",
+          "tags": [
+            "reading"
+          ]
+        },
+        "read_previous_item": {
+          "name": "Read previous item",
+          "command": "Up arrow",
+          "tags": [
+            "reading"
+          ]
+        },
+        "read_next_focusable_item": {
+          "command": "Tab",
+          "name": "Read next focusable item",
+          "tags": [
+            "reading",
+            "forms"
+          ]
+        },
+        "read_previous_focusable_item": {
+          "command": "Shift + Tab",
+          "name": "Read previous focusable item",
+          "tags": [
+            "reading",
+            "forms"
+          ]
+        },
+        "activate_button": {
+          "name": "Activate Button",
+          "command": "Enter or Space",
+          "tags": [
+            "forms",
+            "general"
+          ]
+        },
+        "activate_link": {
+          "name": "Activate Link",
+          "command": "Enter",
+          "tags": [
+            "general"
+          ]
+        },
+        "activate_form_control": {
+          "name": "Activate Form Control",
+          "command": "Space",
+          "tags": [
+            "forms"
+          ]
+        },
+        "start_reading_from_current_position": {
+          "name": "Start reading from current position",
+          "command": "Insert + down arrow",
+          "tags": [
+            "reading"
+          ]
+        },
+        "open_element_list": {
+          "name": "Open element list",
+          "command": "Insert + F3",
+          "tags": [
+            "reading"
+          ]
+        },
+        "table_move_to_previous_column": {
+          "name": "Move to previous column",
+          "command": "Control + Alt + Left arrow",
+          "tags": [
+            "tables"
+          ]
+        },
+        "table_move_to_next_column": {
+          "name": "Move to next column",
+          "command": "Control + Alt + Right arrow",
+          "tags": [
+            "tables"
+          ]
+        },
+        "table_move_to_previous_row": {
+          "name": "Move to previous row",
+          "command": "Control + Alt + down arrow",
+          "tags": [
+            "tables"
+          ]
+        },
+        "table_move_to_next_row": {
+          "name": "Move to next row",
+          "command": "Control + Alt + up arrow",
+          "tags": [
+            "tables"
+          ]
+        }
+      }
     },
     "narrator": {
       "id": "narrator",
@@ -46,7 +217,152 @@
       "extended_browsers": ["firefox", "chrome", "ie"],
       "url": "https://support.microsoft.com/en-us/help/22798/windows-10-narrator-get-started",
       "description": "",
-      "bugs": ""
+      "bugs": "",
+      "modifier_key": {
+        "name": "Narrator",
+        "key": "Caps Lock or Insert"
+      },
+      "commands": {
+        "turn_on": {
+          "name": "Turn On",
+          "command": "Windows + Enter",
+          "tags": [
+            "general"
+          ]
+        },
+        "turn_off": {
+          "name": "Turn Off",
+          "command": "Windows + Enter",
+          "tags": [
+            "general"
+          ]
+        },
+        "stop_reading": {
+          "name": "Stop reading",
+          "command": "Control",
+          "tags": [
+            "reading"
+          ]
+        },
+        "toggle_scan_mode": {
+          "name": "Toggle Scan Mode",
+          "command": "Narrator + Spacebar",
+          "note": "Enabled automatically when you use Microsoft Edge.",
+          "tags": [
+            "general"
+          ]
+        },
+        "cycle_view": {
+          "name": "Cycle view",
+          "command": "Narrator + Page Up or Narrator + Page Down",
+          "note": "Cycles the type of item to be read when using the Read next item and Read previous item commands.",
+          "tags": [
+            "reading"
+          ]
+        },
+        "read_next_item": {
+          "name": "Read next item",
+          "command": "Down arrow",
+          "note": "Required scan mode",
+          "tags": [
+            "reading",
+            "scan_mode"
+          ]
+        },
+        "read_previous_item": {
+          "name": "Read previous item",
+          "command": "Up arrow",
+          "note": "Required scan mode",
+          "tags": [
+            "reading",
+            "scan_mode"
+          ]
+        },
+        "read_next_focusable_item": {
+          "command": "Tab",
+          "name": "Read next focusable item",
+          "tags": [
+            "reading",
+            "forms"
+          ]
+        },
+        "read_previous_focusable_item": {
+          "command": "Shift + Tab",
+          "name": "Read previous focusable item",
+          "tags": [
+            "reading",
+            "forms"
+          ]
+        },
+        "activate_button": {
+          "name": "Activate Item (primary action)",
+          "command": "Enter or Space Bar",
+          "note": "Required scan mode",
+          "tags": [
+            "forms",
+            "general",
+            "scan_mode"
+          ]
+        },
+        "activate_link": {
+          "name": "Activate Item (secondary action)",
+          "command": "Shift + enter or Shift + Spacebar",
+          "note": "Required scan mode",
+          "tags": [
+            "general",
+            "scan_mode"
+          ]
+        },
+        "start_reading_from_current_position": {
+          "name": "Start reading from current position",
+          "command": "Narrator + M",
+          "tags": [
+            "reading"
+          ]
+        },
+        "table_move_to_previous_column": {
+          "name": "Move to previous column",
+          "command": "Control + Alt + Left arrow",
+          "tags": [
+            "tables"
+          ]
+        },
+        "table_move_to_next_column": {
+          "name": "Move to next column",
+          "command": "Control + Alt + Right arrow",
+          "tags": [
+            "tables"
+          ]
+        },
+        "table_move_to_previous_row": {
+          "name": "Move to previous row",
+          "command": "Control + Alt + down arrow",
+          "tags": [
+            "tables"
+          ]
+        },
+        "table_move_to_next_row": {
+          "name": "Move to next row",
+          "command": "Control + Alt + up arrow",
+          "tags": [
+            "tables"
+          ]
+        },
+        "table_read_row_header": {
+          "name": "Read row header",
+          "command": "Control + Shift + Alt + Left arrow",
+          "tags": [
+            "tables"
+          ]
+        },
+        "table_read_column_header": {
+          "name": "Read Column Header",
+          "command": "Control + Shift + Alt + Up arrow",
+          "tags": [
+            "tables"
+          ]
+        }
+      }
     },
     "nvda": {
       "id": "nvda",
@@ -58,7 +374,263 @@
       "extended_browsers": ["ie", "edge", "chrome"],
       "url": "https://www.nvaccess.org/",
       "description": "",
-      "bugs": "https://github.com/nvaccess/nvda"
+      "bugs": "https://github.com/nvaccess/nvda",
+      "modifier_key": {
+        "name": "NVDA",
+        "key": "Insert"
+      },
+      "commands": {
+        "turn_on": {
+          "name": "Turn On",
+          "command": "Control + Alt + N",
+          "tags": ["general"]
+        },
+        "turn_off": {
+          "name": "Turn Off",
+          "command": "NVDA + Q",
+          "tags": ["general"]
+        },
+        "toggle_mode": {
+          "name": "Toggle between browse and focus modes",
+          "command": "NVDA + Spacebar",
+          "tags": ["general", "forms", "reading"]
+        },
+        "exit_focus_mode": {
+          "name": "Exit focus mode",
+          "command": "escape",
+          "tags": ["general", "forms"]
+        },
+        "open_long_description": {
+          "name": "Open Long Description",
+          "command": "NVDA+d",
+          "tags": ["reading"]
+        },
+        "stop_speech": {
+          "name": "Stop speech",
+          "command": "Control",
+          "tags": ["reading"]
+        },
+        "next_heading": {
+          "name": "",
+          "command": "h",
+          "tags": ["elements"]
+        },
+        "next_list": {
+          "name": "Next list",
+          "command": "l",
+          "tags": ["elements"]
+        },
+        "next_list_item": {
+          "name": "Next list item",
+          "command": "i",
+          "tags": ["elements"]
+        },
+        "next_table": {
+          "name": "Next table",
+          "command": "t",
+          "tags": ["elements"]
+        },
+        "next_link": {
+          "name": "Next link",
+          "command": "k",
+          "tags": ["elements"]
+        },
+        "next_non_link_text": {
+          "name": "Next non-link text",
+          "command": "n",
+          "tags": ["elements"]
+        },
+        "next_form_field": {
+          "name": "Next form field",
+          "command": "f",
+          "tags": ["elements"]
+        },
+        "next_unvisited_link": {
+          "name": "Next unvisited link",
+          "command": "u",
+          "tags": ["elements"]
+        },
+        "next_visited_link": {
+          "name": "Next visited link",
+          "command": "v",
+          "tags": ["elements"]
+        },
+        "next_edit_field": {
+          "name": "Next edit field",
+          "command": "e",
+          "tags": ["elements"]
+        },
+        "next_button": {
+          "name": "Next button",
+          "command": "b",
+          "tags": ["elements"]
+        },
+        "next_checkbox": {
+          "name": "Next checkbox",
+          "command": "x",
+          "tags": ["elements"]
+        },
+        "next_combo_box": {
+          "name": "Next combo box (select)",
+          "command": "c",
+          "tags": ["elements"]
+        },
+        "next_radio_button": {
+          "name": "Next radio button",
+          "command": "r",
+          "tags": ["elements"]
+        },
+        "next_block_quote": {
+          "name": "Next block quote",
+          "command": "q",
+          "tags": ["elements"]
+        },
+        "next_separator": {
+          "name": "Next separator",
+          "command": "s",
+          "tags": ["elements"]
+        },
+        "next_frame": {
+          "name": "Next frame",
+          "command": "m",
+          "tags": ["elements"]
+        },
+        "next_graphic": {
+          "name": "Next graphic",
+          "command": "g",
+          "tags": ["elements"]
+        },
+        "next_landmark": {
+          "name": "Next landmark",
+          "command": "d",
+          "tags": ["elements"]
+        },
+        "next_embedded_object": {
+          "name": "Next embedded object",
+          "command": "o",
+          "tags": ["elements"]
+        },
+        "next h1": {
+          "name": "Next h1",
+          "command": "1",
+          "tags": ["elements"]
+        },
+        "next h2": {
+          "name": "Next h2",
+          "command": "2",
+          "tags": ["elements"]
+        },
+        "next h3": {
+          "name": "Next h3",
+          "command": "3",
+          "tags": ["elements"]
+        },
+        "next_h4": {
+          "name": "Next h4",
+          "command": "4",
+          "tags": ["elements"]
+        },
+        "next_h5": {
+          "name": "Next h5",
+          "command": "5",
+          "tags": ["elements"]
+        },
+        "next_h6": {
+          "name": "Next h6",
+          "command": "6",
+          "tags": ["elements"]
+        },
+        "next_spelling_error": {
+          "name": "Next spelling error",
+          "command": "w",
+          "tags": ["general"]
+        },
+        "pause_speech": {
+          "name": "Pause speech",
+          "command": "Shift",
+          "tags": ["reading", "general"]
+        },
+        "nvda_menu": {
+          "name": "NVDA Menu",
+          "command": "NVDA + n",
+          "tags": ["general"]
+        },
+        "report_title": {
+          "name": "Report Title",
+          "command": "NVDA + t",
+          "tags": ["general"]
+        },
+        "report_active_window": {
+          "name": "Read active window",
+          "command": "NVDA + b",
+          "tags": ["general"]
+        },
+        "table_move_to_previous_column": {
+          "name": "Move to previous column",
+          "command": "Control + Alt + Left arrow",
+          "tags": ["tables"]
+        },
+        "table_move_to_next_column": {
+          "name": "Move to next column",
+          "command": "Control + Alt + Right arrow",
+          "tags": ["tables"]
+        },
+        "table_move_to_previous_row": {
+          "name": "Move to previous row",
+          "command": "Control + Alt + down arrow",
+          "tags": ["tables"]
+        },
+        "table_move_to_next_row": {
+          "name": "Move to next row",
+          "command": "Control + Alt + up arrow",
+          "tags": ["tables"]
+        },
+        "elements_list": {
+          "name": "Open Elements List",
+          "command": "NVDA + F7",
+          "tags": ["elements", "general"]
+        },
+        "read_next_item": {
+          "command": "down arrow",
+          "name": "Read next item",
+          "tags": ["reading"]
+        },
+        "read_previous_item": {
+          "command": "up arrow",
+          "name": "Read previous item",
+          "tags": ["reading"]
+        },
+        "start_reading": {
+          "name": "start reading from current position",
+          "command": "NVDA + down arrow",
+          "tags": ["reading"]
+        },
+        "read_next_focusable_item": {
+          "command": "Tab",
+          "name": "Read next focusable item",
+          "tags": ["reading", "forms"]
+        },
+        "read_previous_focusable_item": {
+          "command": "Shift + Tab",
+          "name": "Read previous focusable item",
+          "tags": ["reading", "forms"]
+        },
+        "activate_button": {
+          "name": "Activate Button",
+          "command": "Enter or Space",
+          "tags": ["forms", "general"]
+        },
+        "activate_link": {
+          "name": "Activate Link",
+          "command": "Enter",
+          "tags": ["general"]
+        },
+        "activate_form_control": {
+          "name": "Activate Form Control",
+          "command": "Space",
+          "tags": ["forms"]
+        }
+      }
     },
     "talkback": {
       "id": "talkback",
@@ -70,7 +642,109 @@
       "extended_browsers": ["firefox"],
       "url": "https://support.google.com/accessibility/android/answer/6283677?hl=en",
       "description": "",
-      "bugs": "https://www.google.com/accessibility/get-in-touch.html"
+      "bugs": "https://www.google.com/accessibility/get-in-touch.html",
+      "commands": {
+        "turn_on": {
+          "name": "Turn On",
+          "command": "Power button, then hold two fingers",
+          "note": "when setting is enabled",
+          "tags": [
+            "general"
+          ]
+        },
+        "turn_off": {
+          "name": "Turn Off",
+          "command": "In settings (no shortcut)",
+          "tags": [
+            "general"
+          ]
+        },
+        "global_context_menu": {
+          "name": "Global context menu",
+          "command": "Swipe down, then right",
+          "tags": [
+            "general"
+          ]
+        },
+        "local_context_menu": {
+          "name": "Turn Off",
+          "command": "Swipe up, then right",
+          "tags": [
+            "general"
+          ]
+        },
+        "stop_reading": {
+          "name": "Stop reading",
+          "command": "Single tap",
+          "tags": [
+            "reading"
+          ]
+        },
+        "next_item": {
+          "name": "Read next item",
+          "command": "Swipe right",
+          "tags": [
+            "reading"
+          ]
+        },
+        "previous_item": {
+          "name": "Read previous item",
+          "command": "Swipe left",
+          "tags": [
+            "reading"
+          ]
+        },
+        "activate_link": {
+          "name": "Activate link",
+          "command": "double tap",
+          "tags": [
+            "general"
+          ]
+        },
+        "activate_button": {
+          "name": "Activate button",
+          "command": "double tap",
+          "tags": [
+            "general",
+            "forms"
+          ]
+        },
+        "activate_form_control": {
+          "name": "Activate form control",
+          "command": "double tap",
+          "tags": [
+            "forms"
+          ]
+        },
+        "read_from_current_position": {
+          "name": "Read from current position",
+          "command": "GCM, Read from next item",
+          "tags": [
+            "reading"
+          ]
+        },
+        "open_element_list": {
+          "name": "Open element list",
+          "command": "GCM, Quick navigation",
+          "tags": [
+            "general"
+          ]
+        },
+        "home_screen": {
+          "name": "Go to home screen",
+          "command": "Swipe up, then left",
+          "tags": [
+            "general"
+          ]
+        },
+        "go_back": {
+          "name": "Go back",
+          "command": "Swipe down, then left",
+          "tags": [
+            "general"
+          ]
+        }
+      }
     },
     "vo_ios": {
       "id": "vo_ios",
@@ -81,7 +755,93 @@
       "core_browsers": ["ios_saf"],
       "extended_browsers": [],
       "url": "https://www.apple.com/accessibility/iphone/vision/",
-      "description": ""
+      "description": "",
+      "commands": {
+        "turn_on": {
+          "name": "Turn On",
+          "command": "Triple press home (if setting is enabled)",
+          "tags": [
+            "general"
+          ]
+        },
+        "turn_off": {
+          "name": "Turn Off",
+          "command": "Triple press home (if setting is enabled)",
+          "tags": [
+            "general"
+          ]
+        },
+        "open_rotor": {
+          "name": "Activate Form Control",
+          "command": "two-finger + twist",
+          "tags": ["general"]
+        },
+        "next_item": {
+          "name": "Next item",
+          "command": "Swipe Right",
+          "tags": "reading"
+        },
+        "previous_item": {
+          "name": "Previous item",
+          "command": "Swipe Left",
+          "tags": "reading"
+        },
+        "next_rotor_item": {
+          "name": "Next item (as set by the rotor)",
+          "command": "Swipe down",
+          "tags": "reading"
+        },
+        "previous_rotor_item": {
+          "name": "Previous item (as set by the rotor)",
+          "command": "Swipe up",
+          "tags": "reading"
+        },
+        "activate_button": {
+          "name": "Activate Button",
+          "command": "Double tap",
+          "tags": ["forms", "general"]
+        },
+        "activate_link": {
+          "name": "Activate Link",
+          "command": "Double tap",
+          "tags": ["general"]
+        },
+        "activate_form_control": {
+          "name": "Activate Form Control",
+          "command": "Double tap",
+          "tags": ["forms"]
+        },
+        "start_reading": {
+          "name": "Start reading from current position",
+          "command": "two-finger + swipe down",
+          "tags": ["reading"]
+        },
+        "read_all": {
+          "name": "Read all from the top of the screen",
+          "command": "two-finger + swipe up",
+          "tags": ["reading"]
+        },
+        "pause_or_start_reading": {
+          "name": "Pause or stop reading",
+          "command": "two-finger tap",
+          "tags": ["reading"]
+        },
+        "dismiss_return": {
+          "name": "Dismisses an alert or returns to the previous screen.",
+          "command": "Two-finger scrub (move two fingers back and forth three times quickly, making a “z”)",
+          "tags": ["reading"]
+        },
+        "additional_information": {
+          "name": "Read additional information about the current position",
+          "command": "three-finger tap",
+          "tags": ["reading"]
+        },
+        "double_tap": {
+          "name": "Double tap the current item",
+          "command": "triple tap",
+          "tags": ["general"]
+        }
+      }
     },
     "vo_macos": {
       "id": "vo_macos",
@@ -92,7 +852,143 @@
       "core_browsers": ["safari"],
       "extended_browsers": ["chrome", "firefox"],
       "url": "https://www.apple.com/accessibility/mac/vision/",
-      "description": ""
+      "description": "",
+      "modifier_key": {
+        "name": "NVDA",
+        "key": "Control + Option"
+      },
+      "commands": {
+        "turn_on": {
+          "name": "Turn On",
+          "command": "Command + F5",
+          "tags": ["general"]
+        },
+        "turn_off": {
+          "name": "Turn Off",
+          "command": "Command + F5",
+          "tags": ["general"]
+        },
+        "read_next_item": {
+          "command": "VO + Right arrow",
+          "name": "Read next item",
+          "tags": ["reading"]
+        },
+        "read_previous_item": {
+          "command": "VO + Left Arrow",
+          "name": "Read previous item",
+          "tags": ["reading"]
+        },
+        "start_reading": {
+          "name": "start reading from current position",
+          "command": "VO + A",
+          "tags": ["reading"]
+        },
+        "stop_reading": {
+          "name": "start reading from current position",
+          "command": "Control",
+          "tags": ["reading"]
+        },
+        "read_next_focusable_item": {
+          "command": "Tab",
+          "name": "Read next focusable item",
+          "tags": ["reading", "forms"]
+        },
+        "read_previous_focusable_item": {
+          "command": "Shift + Tab",
+          "name": "Read previous focusable item",
+          "tags": ["reading", "forms"]
+        },
+        "open_rotor": {
+          "command": "VO + U",
+          "name": "Open Rotor",
+          "tags": ["general"]
+        },
+        "activate_button": {
+          "name": "Activate Button",
+          "command": "Enter or Space",
+          "tags": ["forms", "general"]
+        },
+        "activate_link": {
+          "name": "Activate Link",
+          "command": "Enter",
+          "tags": ["general"]
+        },
+        "activate_form_control": {
+          "name": "Activate Form Control",
+          "command": "Space",
+          "tags": ["forms"]
+        },
+        "next_heading": {
+          "name": "Next Heading",
+          "command": "VO + Command + H",
+          "tags": ["elements"]
+        },
+        "next_table": {
+          "name": "Next Table",
+          "command": "VO + Command + T",
+          "tags": ["elements"]
+        },
+        "next_link": {
+          "name": "Next Link",
+          "command": "VO + Command + L",
+          "tags": ["elements"]
+        },
+        "next_visited_link": {
+          "name": "Next Visited Link",
+          "command": "VO + Command + V",
+          "tags": ["elements"]
+        },
+        "next_form_control": {
+          "name": "Next Form Control",
+          "command": "VO + Command + J",
+          "tags": ["elements", "forms"]
+        },
+        "next_list": {
+          "name": "Next Table",
+          "command": "VO + Command + X",
+          "tags": ["elements"]
+        },
+        "next_graphic": {
+          "name": "Next Graphic",
+          "command": "VO + Command + G",
+          "tags": ["elements"]
+        },
+        "enter_object": {
+          "name": "Enter an object (such as an iframe)",
+          "command": "VO + Shift + Down Arrow",
+          "tags": ["objects"]
+        },
+        "exit_object": {
+          "name": "Exit an object (such as an iframe)",
+          "command": "VO + Shift + Up Arrow",
+          "tags": ["objects"]
+        },
+        "table_read_column_header": {
+          "name": "Read Column Header",
+          "command": "VO + C",
+          "tags": ["tables"]
+        },
+        "table_move_to_previous_column": {
+          "name": "Move to Previous Column",
+          "command": "VO + Left Arrow",
+          "tags": ["tables"]
+        },
+        "table_move_to_next_column": {
+          "name": "Move to Next Column",
+          "command": "VO + Right Arrow",
+          "tags": ["tables"]
+        },
+        "table_move_to_previous_row": {
+          "name": "Move to Previous Row",
+          "command": "VO + Up Arrow",
+          "tags": ["tables"]
+        },
+        "table_move_to_next_row": {
+          "name": "Move to Next Row",
+          "command": "VO + Down Arrow",
+          "tags": ["tables"]
+        }
+      }
     }
   },
   "browsers": {

--- a/documentation/at/dragon.md
+++ b/documentation/at/dragon.md
@@ -23,17 +23,3 @@ This information is still in development. Feel free to contribute. The following
 ## Guides, Documentation, and resources
 
 * [Nuance documentation](http://support.nuance.com/usersguides/?UsersGuidesProduct=naturallyspeaking)
-
-## Basic Commands
-
-| Task | Speak | Notes |
-|---|---|---|
-| Next actionable item | "Press Tab" | |
-| Activate actionable item | "Click <text>" | If there are multiple choices with the same text, they will be labeled by numbers. Say "Choose <number>" to finish. |
-| Choose drop down option | "Choose {option text}" | |
-| Show drop down choices | "Show choices" | |
-| Hide drop down choices | "Hide choices" | |
-| Undo entered text | "Scratch that" | |
-
-You can also say "Click <type>" where type is "link", "button", "text field", "image", "Check box", "Radio Button", etc. Dragon will then flag each matching element with a number. Say "choose <number>" to finish.
-

--- a/documentation/at/jaws.md
+++ b/documentation/at/jaws.md
@@ -20,24 +20,6 @@ You can [download and install JAWS from Freedom Scientific](https://www.freedoms
 * [JAWS documentation from Freedom Scientific](https://www.freedomscientific.com/products/blindness/jawsdocumentation)
 * [Deque JAWS guide](https://dequeuniversity.com/screenreaders/jaws-keyboard-shortcuts)
 
-## Basic Commands
-
-| Task | Command |
-|---|---|
-| Turn On | (none) |
-| Turn Off | Insert + F4 |
-| Stop Reading | Control |
-| Next Item | Down Arrow |
-| Previous Item | Up Arrow |
-| Next Focusable | Tab |
-| Previous Focusable | Shift + Tab |
-| Activate Link | Enter |
-| Activate Button | Enter or Space |
-| Activate Form Control | Space |
-| Start reading from current position | Insert + Down Arrow |
-| Open Element List | Insert + F3 |
-| Navigate between items | left arrow, right arrow, up arrow, or down arrow |
-
 ## Modes
 
 * Forms Mode: Automatic when in a form element

--- a/documentation/at/narrator.md
+++ b/documentation/at/narrator.md
@@ -2,6 +2,8 @@
 
 Narrator is a screen reader that is built in to the Windows operating system.
 
+All commands listed here assume that Scan mode is enabled.
+
 ## TODO
 
 This information is still in development. Feel free to contribute. The following still needs to be done:
@@ -18,27 +20,10 @@ Narrator is built in to the Windows 10 operating system.
 ## Guides, Documentation, and resources
 
 * [Microsoft documentation](https://support.microsoft.com/en-us/help/22798/windows-10-narrator-get-started)
+* [Narrator Scan Mode Documentation](https://support.microsoft.com/en-us/help/22809)
+* [Narrator commands](https://support.microsoft.com/en-us/help/22806)
 * [Deque PDF guide](https://dequeuniversity.com/assets/pdf/screenreaders/narrator-guide.pdf)
-
-## Basic Commands
-
-| Task | Command |
-|---|---|
-| Turn On | Windows logo + Enter |
-| Turn Off | Windows logo + Enter |
-| Stop Reading | Control |
-| Next Item | Caps Lock + Right Arrow (Caps Lock + Up or Down Arrow to cycle between types) |
-| Previous Item | Caps Lock + Left Arrow (Caps Lock + Up or Down Arrow to cycle between types) |
-| Next Focusable | Tab |
-| Previous Focusable | Shift + Tab |
-| Activate Link | Caps Lock + Enter |
-| Activate Button | Caps Lock + Enter |
-| Activate Form Control | Caps Lock + Enter |
-| Start reading from current position | Caps Lock + M |
-| Open Element List | Not Available |
-| Navigate between items | left arrow, right arrow, up arrow, or down arrow |
 
 ## Modes
 
-* Scan Mode: Caps Lock +  Space
-
+* Scan mode: Scan mode is enabled by default when using the Edge browser.

--- a/documentation/at/nvda.md
+++ b/documentation/at/nvda.md
@@ -21,27 +21,8 @@ This information is still in development. Feel free to contribute. The following
 * [NVDA User Guide](https://www.nvaccess.org/files/nvda/documentation/userGuide.html)
 * [Deque guide](https://dequeuniversity.com/screenreaders/nvda-keyboard-shortcuts)
 
-## Basic Commands
-
-| Task | Command |
-|---|---|
-| Modifier | NV = Insert (can be modified) |
-| Turn On | Control + Alt + N |
-| Turn Off | NV + Q |
-| Stop Reading | Control |
-| Next Item | Down Arrow |
-| Previous Item | Up Arrow |
-| Next Focusable | Tab |
-| Previous Focusable | Shift + Tab |
-| Activate Link | Enter |
-| Activate Button | Enter or Space |
-| Activate Form Control | Space |
-| Start reading from current position | NV + Down Arrow |
-| Open Element List | NV + F7 |
-| Navigate between items | left arrow, right arrow, up arrow, or down arrow |
-
 ## Modes
 
-* Brows/Focus mode: NV + Space Bar
-* Forms Mode: NV + Space Bar (when in a form control)
+* Browse mode: This is the default mode when using a browser.
+* Focus mode: This mode is automatically turned on when using an interactive element, but can also be manually turned on.
 

--- a/documentation/at/talkback.md
+++ b/documentation/at/talkback.md
@@ -23,28 +23,6 @@ The [Android Accessibility Suite can be found on the Google Play Store](https://
   * [Deque TalkBack Commands PDF](https://dequeuniversity.com/assets/pdf/screenreaders/talkback-guide.pdf)
   * [Deque TalkBack Gesture Images PDF](https://dequeuniversity.com/assets/pdf/screenreaders/talkback-images-guide.pdf)
 
-
-## Basic Commands
-
-| Task | Command |
-|---|---|
-| On | Power button, then hold two fingers (when setting is enabled) |
-| Off | In settings (no shortcut) |
-| Global Context Menu | Swipe down, then right |
-| Local Context Menu | Swipe up, then right |
-| Stop reading | Single tap |
-| Next item | Swipe right |
-| Previous item | Swipe left |
-| Activate link | Double tap |
-| Activate button | Double tap |
-| Activate_form_control | Double tap |
-| Start reading from current position | GCM, Read from next item |
-| Open element list | GCM, Quick navigation |
-| Go to home screen | Swipe up, then left |
-| Back | Swipe down, then left |
-| Recent apps | Swipe left, then up |
-| Notifications | Swipe right, then down |
-
 ## Modes
 
 TalkBack does not have the same concept of modes that many other screen readers have.

--- a/documentation/at/vo_ios.md
+++ b/documentation/at/vo_ios.md
@@ -18,22 +18,8 @@ VoiceOver is built in to iOS and you can enable it from your Settings app.
 ## Guides, Documentation, and resources
 
 * [Apple documentation](https://www.apple.com/accessibility/iphone/vision/)
+* [Apple gesture documentation](https://help.apple.com/iphone/12/#/iph3e2e2281)
 * [Deque guides (PDFs)](https://dequeuniversity.com/screenreaders/voiceover-ios-shortcuts)
-
-## Basic Commands
-
-| Task | Command |
-|---|---|
-| On/off | Triple press home (after the setting is enabled) |
-| Stop reading | Two finger tap |
-| Next item (see The Rotor) | Swipe right |
-| Change next item type | two finger rotate (select type) |
-| Previous item | Swipe left |
-| Activate link | Double tap |
-| Activate button | Double tap |
-| Activate_form_control | Double tap |
-| Start reading from current position | Two finger + swipe down |
-| Open element list | Two fingers + triple tap |
 
 ## Modes
 

--- a/documentation/at/vo_macos.md
+++ b/documentation/at/vo_macos.md
@@ -20,25 +20,6 @@ VoiceOver is built in to MacOS and can be enabled from the System Preferences ap
 * [Apple documentation](https://www.apple.com/accessibility/mac/vision/)
 * [Deque guide](https://dequeuniversity.com/screenreaders/voiceover-keyboard-shortcuts)
 
-## Basic Commands
-
-| Task | Command |
-|---|---|
-| Modifier | VO = Control + Option |
-| Turn On | Command + F5 |
-| Turn Off | Command + F5 |
-| Stop Reading | Control |
-| Next Item | VO + Right Arrow |
-| Previous Item | VO + Left Arrow |
-| Next Focusable | Tab |
-| Previous Focusable | Shift + Tab |
-| Activate Link | Enter |
-| Activate Button | Enter or Space |
-| Activate Form Control | Space |
-| Start reading from current position | VO + A |
-| Open Element List (Rotor) | VO + U |
-| Navigate between items | left arrow, right arrow, up arrow, or down arrow, then VO + Space to activate |
-
 ## Modes
 
 VoiceOver does not have the same concept of modes that many other screen readers have.

--- a/routes/index.js
+++ b/routes/index.js
@@ -66,9 +66,27 @@ router.get('/learn/at/:id', function(req, res, next) {
 	let MarkdownIt = require('markdown-it');
 	let md = new MarkdownIt().use(require('markdown-it-anchor'));
 	let result = md.render(markdown);
-	res.render('static-page', {
+	let at_id = req.params.id;
+
+	if (at_id === 'dragon') {
+		at_id = 'dragon_win';
+	}
+
+	res.render('learn-at', {
 		title: req.params.id + ' | Learn | Accessibility Support',
-		result: result
+		markdown: result,
+        ATBrowsers: require(__dirname+'/../data/ATBrowsers.json'),
+		at_id: at_id,
+		command_list_has_notes: function(command_list, tag) {
+			return !!Object.values(command_list).find(function(command) {
+				return command.tags.includes(tag) && command.note;
+			});
+		},
+		command_list_contains_tag: function(command_list, tag) {
+            return !!Object.values(command_list).find(function(command) {
+                return command.tags.includes(tag);
+            });
+        },
 	});
 });
 

--- a/views/command-table.mixin.pug
+++ b/views/command-table.mixin.pug
@@ -1,0 +1,17 @@
+mixin command-table(ATBrowsers, at_id, command_tag, show_notes)
+    if ATBrowsers.at[at_id].commands
+        table
+            thead
+                tr
+                    th Task
+                    th Command
+                    if (show_notes)
+                        th Notes
+            tbody
+                each command in ATBrowsers.at[at_id].commands
+                    if (command.tags.includes(command_tag))
+                        tr
+                            td #{command.name}
+                            td #{command.command}
+                            if (show_notes)
+                                td #{command.note}

--- a/views/learn-at.pug
+++ b/views/learn-at.pug
@@ -1,0 +1,30 @@
+extends layout
+include command-table.mixin.pug
+
+block content
+    div.content
+        != markdown
+
+        if ATBrowsers.at[at_id].commands
+            h2 Commands
+
+            p The following are some common commands.
+
+            if ATBrowsers.at[at_id].modifier_key
+                p The default #{ATBrowsers.at[at_id].modifier_key.name} modifier key is set to: #{ATBrowsers.at[at_id].modifier_key.key}
+
+            if (command_list_contains_tag(ATBrowsers.at[at_id].commands, 'general'))
+                h3 General
+                +command-table(ATBrowsers, at_id, 'general', command_list_has_notes(ATBrowsers.at[at_id].commands, 'general'))
+
+            if (command_list_contains_tag(ATBrowsers.at[at_id].commands, 'reading'))
+                h3 Reading
+                +command-table(ATBrowsers, at_id, 'reading', command_list_has_notes(ATBrowsers.at[at_id].commands, 'reading'))
+
+            if (command_list_contains_tag(ATBrowsers.at[at_id].commands, 'forms'))
+                h3 Forms
+                +command-table(ATBrowsers, at_id, 'forms', command_list_has_notes(ATBrowsers.at[at_id].commands, 'forms'))
+
+            if (command_list_contains_tag(ATBrowsers.at[at_id].commands, 'tables'))
+                h3 Tables
+                +command-table(ATBrowsers, at_id, 'tables', command_list_has_notes(ATBrowsers.at[at_id].commands, 'tables'))


### PR DESCRIPTION
The end goal is to let contributors select from a set list of commands for each AT when submitting test cases.

The first step to the goal is to create to lists in the ATBrowsers.json file. Once this is done, it was trivial to list those commands in the learning documentation.

The next step after this PR is merged is to wire up the lists with the form to submit test case findings.