### PR TITLE
Finish implementing command lists

### DIFF
--- a/data/ATBrowsers.json
+++ b/data/ATBrowsers.json
@@ -25,57 +25,55 @@
       "description": "http://www.nuance.com/support/dragon-naturallyspeaking/index.htm?link_name=technical_support#dr_support_contact",
       "commands": {
         "activate_actionable_item": {
-          "activate_actionable_item": {
-            "command": "\"Click <text>\"",
-            "name": "Activate actionable item",
-            "note": "If there are multiple choices with the same text, they will be labeled by numbers. Say \"Choose <number>\" to finish.",
-            "tags": [
-              "general"
-            ]
-          },
-          "choose_dropdown_option": {
-            "command": "\"Choose <option text>\"",
-            "name": "Choose drop down option",
-            "tags": [
-              "general"
-            ]
-          },
-          "click_type": {
-            "command": "Click <type>",
-            "name": "Click Type",
-            "note": "where type is \"link\", \"button\", \"text field\", \"image\", \"Check box\", \"Radio Button\", etc. Dragon will then flag each matching element with a number. Say \"choose <number>\" to finish.",
-            "tags": [
-              "general"
-            ]
-          },
-          "hide_dropdown_choices": {
-            "command": "\"Hide choices\"",
-            "name": "Hide drop down choices",
-            "tags": [
-              "general"
-            ]
-          },
-          "next_actionable_item": {
-            "command": "\"Press Tab\"",
-            "name": "Next actionable item",
-            "tags": [
-              "general"
-            ]
-          },
-          "show_dropdown_choices": {
-            "command": "\"Show choices\"",
-            "name": "Show drop down choices",
-            "tags": [
-              "general"
-            ]
-          },
-          "undo_text": {
-            "command": "\"Scratch that\"",
-            "name": "Undo entered text",
-            "tags": [
-              "general"
-            ]
-          }
+          "command": "\"Click <text>\"",
+          "name": "Activate actionable item",
+          "note": "If there are multiple choices with the same text, they will be labeled by numbers. Say \"Choose <number>\" to finish.",
+          "tags": [
+            "general"
+          ]
+        },
+        "choose_dropdown_option": {
+          "command": "\"Choose <option text>\"",
+          "name": "Choose drop down option",
+          "tags": [
+            "general"
+          ]
+        },
+        "click_type": {
+          "command": "Click <type>",
+          "name": "Click Type",
+          "note": "where type is \"link\", \"button\", \"text field\", \"image\", \"Check box\", \"Radio Button\", etc. Dragon will then flag each matching element with a number. Say \"choose <number>\" to finish.",
+          "tags": [
+            "general"
+          ]
+        },
+        "hide_dropdown_choices": {
+          "command": "\"Hide choices\"",
+          "name": "Hide drop down choices",
+          "tags": [
+            "general"
+          ]
+        },
+        "next_actionable_item": {
+          "command": "\"Press Tab\"",
+          "name": "Next actionable item",
+          "tags": [
+            "general"
+          ]
+        },
+        "show_dropdown_choices": {
+          "command": "\"Show choices\"",
+          "name": "Show drop down choices",
+          "tags": [
+            "general"
+          ]
+        },
+        "undo_text": {
+          "command": "\"Scratch that\"",
+          "name": "Undo entered text",
+          "tags": [
+            "general"
+          ]
         }
       }
     },

--- a/data/ATBrowsers.json
+++ b/data/ATBrowsers.json
@@ -137,34 +137,38 @@
             "reading"
           ]
         },
-        "read_next_focusable_item": {
+        "next_focusable_item": {
           "command": "Tab",
           "name": "Read next focusable item",
           "tags": [
             "forms",
-            "reading"
+            "reading",
+            "common"
           ]
         },
-        "read_next_item": {
+        "next_item": {
           "command": "Down arrow",
           "name": "Read next item",
           "tags": [
-            "reading"
+            "reading",
+            "common"
           ]
         },
-        "read_previous_focusable_item": {
+        "previous_focusable_item": {
           "command": "Shift + Tab",
           "name": "Read previous focusable item",
           "tags": [
             "forms",
-            "reading"
+            "reading",
+            "common"
           ]
         },
-        "read_previous_item": {
+        "previous_item": {
           "command": "Up arrow",
           "name": "Read previous item",
           "tags": [
-            "reading"
+            "reading",
+            "common"
           ]
         },
         "start_reading_from_current_position": {
@@ -268,38 +272,42 @@
             "reading"
           ]
         },
-        "read_next_focusable_item": {
+        "next_focusable_item": {
           "command": "Tab",
           "name": "Read next focusable item",
           "tags": [
             "forms",
-            "reading"
+            "reading",
+            "common"
           ]
         },
-        "read_next_item": {
+        "next_item": {
           "command": "Down arrow",
           "name": "Read next item",
           "note": "Required scan mode",
           "tags": [
             "reading",
-            "scan_mode"
+            "scan_mode",
+            "common"
           ]
         },
-        "read_previous_focusable_item": {
+        "previous_focusable_item": {
           "command": "Shift + Tab",
           "name": "Read previous focusable item",
           "tags": [
             "forms",
-            "reading"
+            "reading",
+            "common"
           ]
         },
-        "read_previous_item": {
+        "previous_item": {
           "command": "Up arrow",
           "name": "Read previous item",
           "note": "Required scan mode",
           "tags": [
             "reading",
-            "scan_mode"
+            "scan_mode",
+            "common"
           ]
         },
         "start_reading_from_current_position": {
@@ -647,34 +655,38 @@
             "reading"
           ]
         },
-        "read_next_focusable_item": {
+        "next_focusable_item": {
           "command": "Tab",
           "name": "Read next focusable item",
           "tags": [
             "forms",
-            "reading"
+            "reading",
+            "common"
           ]
         },
-        "read_next_item": {
+        "next_item": {
           "command": "down arrow",
           "name": "Read next item",
           "tags": [
-            "reading"
+            "reading",
+            "common"
           ]
         },
-        "read_previous_focusable_item": {
+        "previous_focusable_item": {
           "command": "Shift + Tab",
           "name": "Read previous focusable item",
           "tags": [
             "forms",
-            "reading"
+            "reading",
+            "common"
           ]
         },
-        "read_previous_item": {
+        "previous_item": {
           "command": "up arrow",
           "name": "Read previous item",
           "tags": [
-            "reading"
+            "reading",
+            "common"
           ]
         },
         "report_active_window": {
@@ -820,13 +832,6 @@
             "general"
           ]
         },
-        "next_item": {
-          "command": "Swipe right",
-          "name": "Read next item",
-          "tags": [
-            "reading"
-          ]
-        },
         "open_element_list": {
           "command": "GCM, Quick navigation",
           "name": "Open element list",
@@ -834,18 +839,27 @@
             "general"
           ]
         },
-        "previous_item": {
-          "command": "Swipe left",
-          "name": "Read previous item",
-          "tags": [
-            "reading"
-          ]
-        },
-        "read_from_current_position": {
+        "from_current_position": {
           "command": "GCM, Read from next item",
           "name": "Read from current position",
           "tags": [
             "reading"
+          ]
+        },
+        "next_item": {
+          "command": "Swipe right",
+          "name": "Read next item",
+          "tags": [
+            "reading",
+            "common"
+          ]
+        },
+        "previous_item": {
+          "command": "Swipe left",
+          "name": "Read previous item",
+          "tags": [
+            "reading",
+            "common"
           ]
         },
         "stop_reading": {
@@ -929,12 +943,12 @@
         "next_item": {
           "command": "Swipe Right",
           "name": "Next item",
-          "tags": "reading"
+          "tags": ["reading", "common"]
         },
         "next_rotor_item": {
           "command": "Swipe down",
           "name": "Next item (as set by the rotor)",
-          "tags": "reading"
+          "tags": ["reading", "common"]
         },
         "open_rotor": {
           "command": "two-finger + twist",
@@ -953,12 +967,14 @@
         "previous_item": {
           "command": "Swipe Left",
           "name": "Previous item",
-          "tags": "reading"
+          "tags": ["reading",
+            "common"]
         },
         "previous_rotor_item": {
           "command": "Swipe up",
           "name": "Previous item (as set by the rotor)",
-          "tags": "reading"
+          "tags": ["reading",
+            "common"]
         },
         "read_all": {
           "command": "two-finger + swipe up",
@@ -1098,7 +1114,7 @@
             "general"
           ]
         },
-        "read_next_focusable_item": {
+        "next_focusable_item": {
           "command": "Tab",
           "name": "Read next focusable item",
           "tags": [
@@ -1106,26 +1122,29 @@
             "reading"
           ]
         },
-        "read_next_item": {
+        "next_item": {
           "command": "VO + Right arrow",
           "name": "Read next item",
           "tags": [
-            "reading"
+            "reading",
+            "common"
           ]
         },
-        "read_previous_focusable_item": {
+        "previous_focusable_item": {
           "command": "Shift + Tab",
           "name": "Read previous focusable item",
           "tags": [
             "forms",
-            "reading"
+            "reading",
+            "common"
           ]
         },
-        "read_previous_item": {
+        "previous_item": {
           "command": "VO + Left Arrow",
           "name": "Read previous item",
           "tags": [
-            "reading"
+            "reading",
+            "common"
           ]
         },
         "start_reading": {

--- a/data/ATBrowsers.json
+++ b/data/ATBrowsers.json
@@ -1225,6 +1225,10 @@
   },
   "command_tags": [
     {
+      "id": "common",
+      "name": "Common"
+    },
+    {
       "id": "general",
       "name": "General"
     },

--- a/data/ATBrowsers.json
+++ b/data/ATBrowsers.json
@@ -24,7 +24,7 @@
       "url": "https://www.nuance.com/dragon.html",
       "description": "http://www.nuance.com/support/dragon-naturallyspeaking/index.htm?link_name=technical_support#dr_support_contact",
       "commands": {
-        "next_actionable_item": {
+        "activate_actionable_item": {
           "activate_actionable_item": {
             "command": "\"Click <text>\"",
             "name": "Activate actionable item",
@@ -444,21 +444,21 @@
             "general"
           ]
         },
-        "next h1": {
+        "next_h1": {
           "command": "1",
           "name": "Next h1",
           "tags": [
             "elements"
           ]
         },
-        "next h2": {
+        "next_h2": {
           "command": "2",
           "name": "Next h2",
           "tags": [
             "elements"
           ]
         },
-        "next h3": {
+        "next_h3": {
           "command": "3",
           "name": "Next h3",
           "tags": [

--- a/data/ATBrowsers.json
+++ b/data/ATBrowsers.json
@@ -130,6 +130,23 @@
             "general"
           ]
         },
+        "next_focusable_item": {
+          "command": "Tab",
+          "name": "Read next focusable item",
+          "tags": [
+            "common",
+            "forms",
+            "reading"
+          ]
+        },
+        "next_item": {
+          "command": "Down arrow",
+          "name": "Read next item",
+          "tags": [
+            "common",
+            "reading"
+          ]
+        },
         "open_element_list": {
           "command": "Insert + F3",
           "name": "Open element list",
@@ -137,38 +154,21 @@
             "reading"
           ]
         },
-        "next_focusable_item": {
-          "command": "Tab",
-          "name": "Read next focusable item",
-          "tags": [
-            "forms",
-            "reading",
-            "common"
-          ]
-        },
-        "next_item": {
-          "command": "Down arrow",
-          "name": "Read next item",
-          "tags": [
-            "reading",
-            "common"
-          ]
-        },
         "previous_focusable_item": {
           "command": "Shift + Tab",
           "name": "Read previous focusable item",
           "tags": [
+            "common",
             "forms",
-            "reading",
-            "common"
+            "reading"
           ]
         },
         "previous_item": {
           "command": "Up arrow",
           "name": "Read previous item",
           "tags": [
-            "reading",
-            "common"
+            "common",
+            "reading"
           ]
         },
         "start_reading_from_current_position": {
@@ -276,9 +276,9 @@
           "command": "Tab",
           "name": "Read next focusable item",
           "tags": [
+            "common",
             "forms",
-            "reading",
-            "common"
+            "reading"
           ]
         },
         "next_item": {
@@ -286,18 +286,18 @@
           "name": "Read next item",
           "note": "Required scan mode",
           "tags": [
+            "common",
             "reading",
-            "scan_mode",
-            "common"
+            "scan_mode"
           ]
         },
         "previous_focusable_item": {
           "command": "Shift + Tab",
           "name": "Read previous focusable item",
           "tags": [
+            "common",
             "forms",
-            "reading",
-            "common"
+            "reading"
           ]
         },
         "previous_item": {
@@ -305,9 +305,9 @@
           "name": "Read previous item",
           "note": "Required scan mode",
           "tags": [
+            "common",
             "reading",
-            "scan_mode",
-            "common"
+            "scan_mode"
           ]
         },
         "start_reading_from_current_position": {
@@ -507,6 +507,15 @@
             "elements"
           ]
         },
+        "next_focusable_item": {
+          "command": "Tab",
+          "name": "Read next focusable item",
+          "tags": [
+            "common",
+            "forms",
+            "reading"
+          ]
+        },
         "next_form_field": {
           "command": "f",
           "name": "Next form field",
@@ -554,6 +563,14 @@
           "name": "",
           "tags": [
             "elements"
+          ]
+        },
+        "next_item": {
+          "command": "down arrow",
+          "name": "Read next item",
+          "tags": [
+            "common",
+            "reading"
           ]
         },
         "next_landmark": {
@@ -655,38 +672,21 @@
             "reading"
           ]
         },
-        "next_focusable_item": {
-          "command": "Tab",
-          "name": "Read next focusable item",
-          "tags": [
-            "forms",
-            "reading",
-            "common"
-          ]
-        },
-        "next_item": {
-          "command": "down arrow",
-          "name": "Read next item",
-          "tags": [
-            "reading",
-            "common"
-          ]
-        },
         "previous_focusable_item": {
           "command": "Shift + Tab",
           "name": "Read previous focusable item",
           "tags": [
+            "common",
             "forms",
-            "reading",
-            "common"
+            "reading"
           ]
         },
         "previous_item": {
           "command": "up arrow",
           "name": "Read previous item",
           "tags": [
-            "reading",
-            "common"
+            "common",
+            "reading"
           ]
         },
         "report_active_window": {
@@ -804,6 +804,13 @@
             "general"
           ]
         },
+        "from_current_position": {
+          "command": "GCM, Read from next item",
+          "name": "Read from current position",
+          "tags": [
+            "reading"
+          ]
+        },
         "global_context_menu": {
           "command": "Swipe down, then right",
           "name": "Global context menu",
@@ -832,6 +839,14 @@
             "general"
           ]
         },
+        "next_item": {
+          "command": "Swipe right",
+          "name": "Read next item",
+          "tags": [
+            "common",
+            "reading"
+          ]
+        },
         "open_element_list": {
           "command": "GCM, Quick navigation",
           "name": "Open element list",
@@ -839,27 +854,12 @@
             "general"
           ]
         },
-        "from_current_position": {
-          "command": "GCM, Read from next item",
-          "name": "Read from current position",
-          "tags": [
-            "reading"
-          ]
-        },
-        "next_item": {
-          "command": "Swipe right",
-          "name": "Read next item",
-          "tags": [
-            "reading",
-            "common"
-          ]
-        },
         "previous_item": {
           "command": "Swipe left",
           "name": "Read previous item",
           "tags": [
-            "reading",
-            "common"
+            "common",
+            "reading"
           ]
         },
         "stop_reading": {
@@ -943,12 +943,18 @@
         "next_item": {
           "command": "Swipe Right",
           "name": "Next item",
-          "tags": ["reading", "common"]
+          "tags": [
+            "common",
+            "reading"
+          ]
         },
         "next_rotor_item": {
           "command": "Swipe down",
           "name": "Next item (as set by the rotor)",
-          "tags": ["reading", "common"]
+          "tags": [
+            "common",
+            "reading"
+          ]
         },
         "open_rotor": {
           "command": "two-finger + twist",
@@ -967,14 +973,18 @@
         "previous_item": {
           "command": "Swipe Left",
           "name": "Previous item",
-          "tags": ["reading",
-            "common"]
+          "tags": [
+            "common",
+            "reading"
+          ]
         },
         "previous_rotor_item": {
           "command": "Swipe up",
           "name": "Previous item (as set by the rotor)",
-          "tags": ["reading",
-            "common"]
+          "tags": [
+            "common",
+            "reading"
+          ]
         },
         "read_all": {
           "command": "two-finger + swipe up",
@@ -1057,6 +1067,14 @@
             "objects"
           ]
         },
+        "next_focusable_item": {
+          "command": "Tab",
+          "name": "Read next focusable item",
+          "tags": [
+            "forms",
+            "reading"
+          ]
+        },
         "next_form_control": {
           "command": "VO + Command + J",
           "name": "Next Form Control",
@@ -1077,6 +1095,14 @@
           "name": "Next Heading",
           "tags": [
             "elements"
+          ]
+        },
+        "next_item": {
+          "command": "VO + Right arrow",
+          "name": "Read next item",
+          "tags": [
+            "common",
+            "reading"
           ]
         },
         "next_link": {
@@ -1114,37 +1140,21 @@
             "general"
           ]
         },
-        "next_focusable_item": {
-          "command": "Tab",
-          "name": "Read next focusable item",
-          "tags": [
-            "forms",
-            "reading"
-          ]
-        },
-        "next_item": {
-          "command": "VO + Right arrow",
-          "name": "Read next item",
-          "tags": [
-            "reading",
-            "common"
-          ]
-        },
         "previous_focusable_item": {
           "command": "Shift + Tab",
           "name": "Read previous focusable item",
           "tags": [
+            "common",
             "forms",
-            "reading",
-            "common"
+            "reading"
           ]
         },
         "previous_item": {
           "command": "VO + Left Arrow",
           "name": "Read previous item",
           "tags": [
-            "reading",
-            "common"
+            "common",
+            "reading"
           ]
         },
         "start_reading": {

--- a/data/ATBrowsers.json
+++ b/data/ATBrowsers.json
@@ -25,41 +25,57 @@
       "description": "http://www.nuance.com/support/dragon-naturallyspeaking/index.htm?link_name=technical_support#dr_support_contact",
       "commands": {
         "next_actionable_item": {
-          "name": "Next actionable item",
-          "command": "\"Press Tab\"",
-          "tags": ["general"]
-        },
-        "activate_actionable_item": {
-          "name": "Activate actionable item",
-          "command": "\"Click <text>\"",
-          "note": "If there are multiple choices with the same text, they will be labeled by numbers. Say \"Choose <number>\" to finish.",
-          "tags": ["general"]
-        },
-        "show_dropdown_choices": {
-          "name": "Show drop down choices",
-          "command": "\"Show choices\"",
-          "tags": ["general"]
-        },
-        "choose_dropdown_option": {
-          "name": "Choose drop down option",
-          "command": "\"Choose <option text>\"",
-          "tags": ["general"]
-        },
-        "hide_dropdown_choices": {
-          "name": "Hide drop down choices",
-          "command": "\"Hide choices\"",
-          "tags": ["general"]
-        },
-        "undo_text": {
-          "name": "Undo entered text",
-          "command": "\"Scratch that\"",
-          "tags": ["general"]
-        },
-        "click_type": {
-          "name": "Click Type",
-          "command": "Click <type>",
-          "note": "where type is \"link\", \"button\", \"text field\", \"image\", \"Check box\", \"Radio Button\", etc. Dragon will then flag each matching element with a number. Say \"choose <number>\" to finish.",
-          "tags": ["general"]
+          "activate_actionable_item": {
+            "command": "\"Click <text>\"",
+            "name": "Activate actionable item",
+            "note": "If there are multiple choices with the same text, they will be labeled by numbers. Say \"Choose <number>\" to finish.",
+            "tags": [
+              "general"
+            ]
+          },
+          "choose_dropdown_option": {
+            "command": "\"Choose <option text>\"",
+            "name": "Choose drop down option",
+            "tags": [
+              "general"
+            ]
+          },
+          "click_type": {
+            "command": "Click <type>",
+            "name": "Click Type",
+            "note": "where type is \"link\", \"button\", \"text field\", \"image\", \"Check box\", \"Radio Button\", etc. Dragon will then flag each matching element with a number. Say \"choose <number>\" to finish.",
+            "tags": [
+              "general"
+            ]
+          },
+          "hide_dropdown_choices": {
+            "command": "\"Hide choices\"",
+            "name": "Hide drop down choices",
+            "tags": [
+              "general"
+            ]
+          },
+          "next_actionable_item": {
+            "command": "\"Press Tab\"",
+            "name": "Next actionable item",
+            "tags": [
+              "general"
+            ]
+          },
+          "show_dropdown_choices": {
+            "command": "\"Show choices\"",
+            "name": "Show drop down choices",
+            "tags": [
+              "general"
+            ]
+          },
+          "undo_text": {
+            "command": "\"Scratch that\"",
+            "name": "Undo entered text",
+            "tags": [
+              "general"
+            ]
+          }
         }
       }
     },
@@ -75,52 +91,48 @@
       "description": "",
       "bugs": "https://github.com/FreedomScientific/VFO-standards-support/issues",
       "commands": {
-        "turn_on": {
-          "name": "Turn On",
-          "command": "(none)",
+        "activate_button": {
+          "command": "Enter or Space",
+          "name": "Activate Button",
           "tags": [
+            "forms",
             "general"
           ]
         },
-        "turn_off": {
-          "name": "Turn Off",
-          "command": "Insert + F4",
+        "activate_form_control": {
+          "command": "Space",
+          "name": "Activate Form Control",
+          "tags": [
+            "forms"
+          ]
+        },
+        "activate_link": {
+          "command": "Enter",
+          "name": "Activate Link",
           "tags": [
             "general"
           ]
         },
         "enter_forms_mode": {
-          "name": "Enter forms mode",
           "command": "Enter",
+          "name": "Enter forms mode",
           "note": "Automatically activated when entering a form control.",
           "tags": [
-            "general", "forms"
+            "forms",
+            "general"
           ]
         },
         "exit_forms_mode": {
-          "name": "Exit forms mode",
           "command": "Num pad Plus",
+          "name": "Exit forms mode",
           "tags": [
-            "general", "forms"
+            "forms",
+            "general"
           ]
         },
-        "stop_reading": {
-          "name": "Stop reading",
-          "command": "Control",
-          "tags": [
-            "reading"
-          ]
-        },
-        "read_next_item": {
-          "name": "Read next item",
-          "command": "Down arrow",
-          "tags": [
-            "reading"
-          ]
-        },
-        "read_previous_item": {
-          "name": "Read previous item",
-          "command": "Up arrow",
+        "open_element_list": {
+          "command": "Insert + F3",
+          "name": "Open element list",
           "tags": [
             "reading"
           ]
@@ -129,80 +141,86 @@
           "command": "Tab",
           "name": "Read next focusable item",
           "tags": [
-            "reading",
-            "forms"
+            "forms",
+            "reading"
+          ]
+        },
+        "read_next_item": {
+          "command": "Down arrow",
+          "name": "Read next item",
+          "tags": [
+            "reading"
           ]
         },
         "read_previous_focusable_item": {
           "command": "Shift + Tab",
           "name": "Read previous focusable item",
           "tags": [
-            "reading",
-            "forms"
-          ]
-        },
-        "activate_button": {
-          "name": "Activate Button",
-          "command": "Enter or Space",
-          "tags": [
             "forms",
-            "general"
+            "reading"
           ]
         },
-        "activate_link": {
-          "name": "Activate Link",
-          "command": "Enter",
+        "read_previous_item": {
+          "command": "Up arrow",
+          "name": "Read previous item",
           "tags": [
-            "general"
-          ]
-        },
-        "activate_form_control": {
-          "name": "Activate Form Control",
-          "command": "Space",
-          "tags": [
-            "forms"
+            "reading"
           ]
         },
         "start_reading_from_current_position": {
-          "name": "Start reading from current position",
           "command": "Insert + down arrow",
+          "name": "Start reading from current position",
           "tags": [
             "reading"
           ]
         },
-        "open_element_list": {
-          "name": "Open element list",
-          "command": "Insert + F3",
+        "stop_reading": {
+          "command": "Control",
+          "name": "Stop reading",
           "tags": [
             "reading"
-          ]
-        },
-        "table_move_to_previous_column": {
-          "name": "Move to previous column",
-          "command": "Control + Alt + Left arrow",
-          "tags": [
-            "tables"
           ]
         },
         "table_move_to_next_column": {
-          "name": "Move to next column",
           "command": "Control + Alt + Right arrow",
-          "tags": [
-            "tables"
-          ]
-        },
-        "table_move_to_previous_row": {
-          "name": "Move to previous row",
-          "command": "Control + Alt + down arrow",
+          "name": "Move to next column",
           "tags": [
             "tables"
           ]
         },
         "table_move_to_next_row": {
-          "name": "Move to next row",
           "command": "Control + Alt + up arrow",
+          "name": "Move to next row",
           "tags": [
             "tables"
+          ]
+        },
+        "table_move_to_previous_column": {
+          "command": "Control + Alt + Left arrow",
+          "name": "Move to previous column",
+          "tags": [
+            "tables"
+          ]
+        },
+        "table_move_to_previous_row": {
+          "command": "Control + Alt + down arrow",
+          "name": "Move to previous row",
+          "tags": [
+            "tables"
+          ]
+        },
+        "turn_off": {
+          "command": "Insert + F4",
+          "name": "Turn Off",
+          "tags": [
+            "general"
+          ]
+        },
+        "turn_on": {
+          "command": "(none)",
+          "name": "Turn On",
+          "tags": [
+            "general"
           ]
         }
       }
@@ -223,80 +241,9 @@
         "key": "Caps Lock or Insert"
       },
       "commands": {
-        "turn_on": {
-          "name": "Turn On",
-          "command": "Windows + Enter",
-          "tags": [
-            "general"
-          ]
-        },
-        "turn_off": {
-          "name": "Turn Off",
-          "command": "Windows + Enter",
-          "tags": [
-            "general"
-          ]
-        },
-        "stop_reading": {
-          "name": "Stop reading",
-          "command": "Control",
-          "tags": [
-            "reading"
-          ]
-        },
-        "toggle_scan_mode": {
-          "name": "Toggle Scan Mode",
-          "command": "Narrator + Spacebar",
-          "note": "Enabled automatically when you use Microsoft Edge.",
-          "tags": [
-            "general"
-          ]
-        },
-        "cycle_view": {
-          "name": "Cycle view",
-          "command": "Narrator + Page Up or Narrator + Page Down",
-          "note": "Cycles the type of item to be read when using the Read next item and Read previous item commands.",
-          "tags": [
-            "reading"
-          ]
-        },
-        "read_next_item": {
-          "name": "Read next item",
-          "command": "Down arrow",
-          "note": "Required scan mode",
-          "tags": [
-            "reading",
-            "scan_mode"
-          ]
-        },
-        "read_previous_item": {
-          "name": "Read previous item",
-          "command": "Up arrow",
-          "note": "Required scan mode",
-          "tags": [
-            "reading",
-            "scan_mode"
-          ]
-        },
-        "read_next_focusable_item": {
-          "command": "Tab",
-          "name": "Read next focusable item",
-          "tags": [
-            "reading",
-            "forms"
-          ]
-        },
-        "read_previous_focusable_item": {
-          "command": "Shift + Tab",
-          "name": "Read previous focusable item",
-          "tags": [
-            "reading",
-            "forms"
-          ]
-        },
         "activate_button": {
-          "name": "Activate Item (primary action)",
           "command": "Enter or Space Bar",
+          "name": "Activate Item (primary action)",
           "note": "Required scan mode",
           "tags": [
             "forms",
@@ -305,61 +252,132 @@
           ]
         },
         "activate_link": {
-          "name": "Activate Item (secondary action)",
           "command": "Shift + enter or Shift + Spacebar",
+          "name": "Activate Item (secondary action)",
           "note": "Required scan mode",
           "tags": [
             "general",
             "scan_mode"
           ]
         },
-        "start_reading_from_current_position": {
-          "name": "Start reading from current position",
-          "command": "Narrator + M",
+        "cycle_view": {
+          "command": "Narrator + Page Up or Narrator + Page Down",
+          "name": "Cycle view",
+          "note": "Cycles the type of item to be read when using the Read next item and Read previous item commands.",
           "tags": [
             "reading"
           ]
         },
-        "table_move_to_previous_column": {
-          "name": "Move to previous column",
-          "command": "Control + Alt + Left arrow",
+        "read_next_focusable_item": {
+          "command": "Tab",
+          "name": "Read next focusable item",
           "tags": [
-            "tables"
+            "forms",
+            "reading"
+          ]
+        },
+        "read_next_item": {
+          "command": "Down arrow",
+          "name": "Read next item",
+          "note": "Required scan mode",
+          "tags": [
+            "reading",
+            "scan_mode"
+          ]
+        },
+        "read_previous_focusable_item": {
+          "command": "Shift + Tab",
+          "name": "Read previous focusable item",
+          "tags": [
+            "forms",
+            "reading"
+          ]
+        },
+        "read_previous_item": {
+          "command": "Up arrow",
+          "name": "Read previous item",
+          "note": "Required scan mode",
+          "tags": [
+            "reading",
+            "scan_mode"
+          ]
+        },
+        "start_reading_from_current_position": {
+          "command": "Narrator + M",
+          "name": "Start reading from current position",
+          "tags": [
+            "reading"
+          ]
+        },
+        "stop_reading": {
+          "command": "Control",
+          "name": "Stop reading",
+          "tags": [
+            "reading"
           ]
         },
         "table_move_to_next_column": {
-          "name": "Move to next column",
           "command": "Control + Alt + Right arrow",
-          "tags": [
-            "tables"
-          ]
-        },
-        "table_move_to_previous_row": {
-          "name": "Move to previous row",
-          "command": "Control + Alt + down arrow",
+          "name": "Move to next column",
           "tags": [
             "tables"
           ]
         },
         "table_move_to_next_row": {
-          "name": "Move to next row",
           "command": "Control + Alt + up arrow",
+          "name": "Move to next row",
           "tags": [
             "tables"
           ]
         },
-        "table_read_row_header": {
-          "name": "Read row header",
-          "command": "Control + Shift + Alt + Left arrow",
+        "table_move_to_previous_column": {
+          "command": "Control + Alt + Left arrow",
+          "name": "Move to previous column",
+          "tags": [
+            "tables"
+          ]
+        },
+        "table_move_to_previous_row": {
+          "command": "Control + Alt + down arrow",
+          "name": "Move to previous row",
           "tags": [
             "tables"
           ]
         },
         "table_read_column_header": {
-          "name": "Read Column Header",
           "command": "Control + Shift + Alt + Up arrow",
+          "name": "Read Column Header",
           "tags": [
             "tables"
+          ]
+        },
+        "table_read_row_header": {
+          "command": "Control + Shift + Alt + Left arrow",
+          "name": "Read row header",
+          "tags": [
+            "tables"
+          ]
+        },
+        "toggle_scan_mode": {
+          "command": "Narrator + Spacebar",
+          "name": "Toggle Scan Mode",
+          "note": "Enabled automatically when you use Microsoft Edge.",
+          "tags": [
+            "general"
+          ]
+        },
+        "turn_off": {
+          "command": "Windows + Enter",
+          "name": "Turn Off",
+          "tags": [
+            "general"
+          ]
+        },
+        "turn_on": {
+          "command": "Windows + Enter",
+          "name": "Turn On",
+          "tags": [
+            "general"
           ]
         }
       }
@@ -380,255 +398,363 @@
         "key": "Insert"
       },
       "commands": {
-        "turn_on": {
-          "name": "Turn On",
-          "command": "Control + Alt + N",
-          "tags": ["general"]
+        "activate_button": {
+          "command": "Enter or Space",
+          "name": "Activate Button",
+          "tags": [
+            "forms",
+            "general"
+          ]
         },
-        "turn_off": {
-          "name": "Turn Off",
-          "command": "NVDA + Q",
-          "tags": ["general"]
+        "activate_form_control": {
+          "command": "Space",
+          "name": "Activate Form Control",
+          "tags": [
+            "forms"
+          ]
         },
-        "toggle_mode": {
-          "name": "Toggle between browse and focus modes",
-          "command": "NVDA + Spacebar",
-          "tags": ["general", "forms", "reading"]
-        },
-        "exit_focus_mode": {
-          "name": "Exit focus mode",
-          "command": "escape",
-          "tags": ["general", "forms"]
-        },
-        "open_long_description": {
-          "name": "Open Long Description",
-          "command": "NVDA+d",
-          "tags": ["reading"]
-        },
-        "stop_speech": {
-          "name": "Stop speech",
-          "command": "Control",
-          "tags": ["reading"]
-        },
-        "next_heading": {
-          "name": "",
-          "command": "h",
-          "tags": ["elements"]
-        },
-        "next_list": {
-          "name": "Next list",
-          "command": "l",
-          "tags": ["elements"]
-        },
-        "next_list_item": {
-          "name": "Next list item",
-          "command": "i",
-          "tags": ["elements"]
-        },
-        "next_table": {
-          "name": "Next table",
-          "command": "t",
-          "tags": ["elements"]
-        },
-        "next_link": {
-          "name": "Next link",
-          "command": "k",
-          "tags": ["elements"]
-        },
-        "next_non_link_text": {
-          "name": "Next non-link text",
-          "command": "n",
-          "tags": ["elements"]
-        },
-        "next_form_field": {
-          "name": "Next form field",
-          "command": "f",
-          "tags": ["elements"]
-        },
-        "next_unvisited_link": {
-          "name": "Next unvisited link",
-          "command": "u",
-          "tags": ["elements"]
-        },
-        "next_visited_link": {
-          "name": "Next visited link",
-          "command": "v",
-          "tags": ["elements"]
-        },
-        "next_edit_field": {
-          "name": "Next edit field",
-          "command": "e",
-          "tags": ["elements"]
-        },
-        "next_button": {
-          "name": "Next button",
-          "command": "b",
-          "tags": ["elements"]
-        },
-        "next_checkbox": {
-          "name": "Next checkbox",
-          "command": "x",
-          "tags": ["elements"]
-        },
-        "next_combo_box": {
-          "name": "Next combo box (select)",
-          "command": "c",
-          "tags": ["elements"]
-        },
-        "next_radio_button": {
-          "name": "Next radio button",
-          "command": "r",
-          "tags": ["elements"]
-        },
-        "next_block_quote": {
-          "name": "Next block quote",
-          "command": "q",
-          "tags": ["elements"]
-        },
-        "next_separator": {
-          "name": "Next separator",
-          "command": "s",
-          "tags": ["elements"]
-        },
-        "next_frame": {
-          "name": "Next frame",
-          "command": "m",
-          "tags": ["elements"]
-        },
-        "next_graphic": {
-          "name": "Next graphic",
-          "command": "g",
-          "tags": ["elements"]
-        },
-        "next_landmark": {
-          "name": "Next landmark",
-          "command": "d",
-          "tags": ["elements"]
-        },
-        "next_embedded_object": {
-          "name": "Next embedded object",
-          "command": "o",
-          "tags": ["elements"]
-        },
-        "next h1": {
-          "name": "Next h1",
-          "command": "1",
-          "tags": ["elements"]
-        },
-        "next h2": {
-          "name": "Next h2",
-          "command": "2",
-          "tags": ["elements"]
-        },
-        "next h3": {
-          "name": "Next h3",
-          "command": "3",
-          "tags": ["elements"]
-        },
-        "next_h4": {
-          "name": "Next h4",
-          "command": "4",
-          "tags": ["elements"]
-        },
-        "next_h5": {
-          "name": "Next h5",
-          "command": "5",
-          "tags": ["elements"]
-        },
-        "next_h6": {
-          "name": "Next h6",
-          "command": "6",
-          "tags": ["elements"]
-        },
-        "next_spelling_error": {
-          "name": "Next spelling error",
-          "command": "w",
-          "tags": ["general"]
-        },
-        "pause_speech": {
-          "name": "Pause speech",
-          "command": "Shift",
-          "tags": ["reading", "general"]
-        },
-        "nvda_menu": {
-          "name": "NVDA Menu",
-          "command": "NVDA + n",
-          "tags": ["general"]
-        },
-        "report_title": {
-          "name": "Report Title",
-          "command": "NVDA + t",
-          "tags": ["general"]
-        },
-        "report_active_window": {
-          "name": "Read active window",
-          "command": "NVDA + b",
-          "tags": ["general"]
-        },
-        "table_move_to_previous_column": {
-          "name": "Move to previous column",
-          "command": "Control + Alt + Left arrow",
-          "tags": ["tables"]
-        },
-        "table_move_to_next_column": {
-          "name": "Move to next column",
-          "command": "Control + Alt + Right arrow",
-          "tags": ["tables"]
-        },
-        "table_move_to_previous_row": {
-          "name": "Move to previous row",
-          "command": "Control + Alt + down arrow",
-          "tags": ["tables"]
-        },
-        "table_move_to_next_row": {
-          "name": "Move to next row",
-          "command": "Control + Alt + up arrow",
-          "tags": ["tables"]
+        "activate_link": {
+          "command": "Enter",
+          "name": "Activate Link",
+          "tags": [
+            "general"
+          ]
         },
         "elements_list": {
-          "name": "Open Elements List",
           "command": "NVDA + F7",
-          "tags": ["elements", "general"]
+          "name": "Open Elements List",
+          "tags": [
+            "elements",
+            "general"
+          ]
         },
-        "read_next_item": {
-          "command": "down arrow",
-          "name": "Read next item",
-          "tags": ["reading"]
+        "exit_focus_mode": {
+          "command": "escape",
+          "name": "Exit focus mode",
+          "tags": [
+            "forms",
+            "general"
+          ]
         },
-        "read_previous_item": {
-          "command": "up arrow",
-          "name": "Read previous item",
-          "tags": ["reading"]
+        "next h1": {
+          "command": "1",
+          "name": "Next h1",
+          "tags": [
+            "elements"
+          ]
         },
-        "start_reading": {
-          "name": "start reading from current position",
-          "command": "NVDA + down arrow",
-          "tags": ["reading"]
+        "next h2": {
+          "command": "2",
+          "name": "Next h2",
+          "tags": [
+            "elements"
+          ]
+        },
+        "next h3": {
+          "command": "3",
+          "name": "Next h3",
+          "tags": [
+            "elements"
+          ]
+        },
+        "next_block_quote": {
+          "command": "q",
+          "name": "Next block quote",
+          "tags": [
+            "elements"
+          ]
+        },
+        "next_button": {
+          "command": "b",
+          "name": "Next button",
+          "tags": [
+            "elements"
+          ]
+        },
+        "next_checkbox": {
+          "command": "x",
+          "name": "Next checkbox",
+          "tags": [
+            "elements"
+          ]
+        },
+        "next_combo_box": {
+          "command": "c",
+          "name": "Next combo box (select)",
+          "tags": [
+            "elements"
+          ]
+        },
+        "next_edit_field": {
+          "command": "e",
+          "name": "Next edit field",
+          "tags": [
+            "elements"
+          ]
+        },
+        "next_embedded_object": {
+          "command": "o",
+          "name": "Next embedded object",
+          "tags": [
+            "elements"
+          ]
+        },
+        "next_form_field": {
+          "command": "f",
+          "name": "Next form field",
+          "tags": [
+            "elements"
+          ]
+        },
+        "next_frame": {
+          "command": "m",
+          "name": "Next frame",
+          "tags": [
+            "elements"
+          ]
+        },
+        "next_graphic": {
+          "command": "g",
+          "name": "Next graphic",
+          "tags": [
+            "elements"
+          ]
+        },
+        "next_h4": {
+          "command": "4",
+          "name": "Next h4",
+          "tags": [
+            "elements"
+          ]
+        },
+        "next_h5": {
+          "command": "5",
+          "name": "Next h5",
+          "tags": [
+            "elements"
+          ]
+        },
+        "next_h6": {
+          "command": "6",
+          "name": "Next h6",
+          "tags": [
+            "elements"
+          ]
+        },
+        "next_heading": {
+          "command": "h",
+          "name": "",
+          "tags": [
+            "elements"
+          ]
+        },
+        "next_landmark": {
+          "command": "d",
+          "name": "Next landmark",
+          "tags": [
+            "elements"
+          ]
+        },
+        "next_link": {
+          "command": "k",
+          "name": "Next link",
+          "tags": [
+            "elements"
+          ]
+        },
+        "next_list": {
+          "command": "l",
+          "name": "Next list",
+          "tags": [
+            "elements"
+          ]
+        },
+        "next_list_item": {
+          "command": "i",
+          "name": "Next list item",
+          "tags": [
+            "elements"
+          ]
+        },
+        "next_non_link_text": {
+          "command": "n",
+          "name": "Next non-link text",
+          "tags": [
+            "elements"
+          ]
+        },
+        "next_radio_button": {
+          "command": "r",
+          "name": "Next radio button",
+          "tags": [
+            "elements"
+          ]
+        },
+        "next_separator": {
+          "command": "s",
+          "name": "Next separator",
+          "tags": [
+            "elements"
+          ]
+        },
+        "next_spelling_error": {
+          "command": "w",
+          "name": "Next spelling error",
+          "tags": [
+            "general"
+          ]
+        },
+        "next_table": {
+          "command": "t",
+          "name": "Next table",
+          "tags": [
+            "elements"
+          ]
+        },
+        "next_unvisited_link": {
+          "command": "u",
+          "name": "Next unvisited link",
+          "tags": [
+            "elements"
+          ]
+        },
+        "next_visited_link": {
+          "command": "v",
+          "name": "Next visited link",
+          "tags": [
+            "elements"
+          ]
+        },
+        "nvda_menu": {
+          "command": "NVDA + n",
+          "name": "NVDA Menu",
+          "tags": [
+            "general"
+          ]
+        },
+        "open_long_description": {
+          "command": "NVDA+d",
+          "name": "Open Long Description",
+          "tags": [
+            "reading"
+          ]
+        },
+        "pause_speech": {
+          "command": "Shift",
+          "name": "Pause speech",
+          "tags": [
+            "general",
+            "reading"
+          ]
         },
         "read_next_focusable_item": {
           "command": "Tab",
           "name": "Read next focusable item",
-          "tags": ["reading", "forms"]
+          "tags": [
+            "forms",
+            "reading"
+          ]
+        },
+        "read_next_item": {
+          "command": "down arrow",
+          "name": "Read next item",
+          "tags": [
+            "reading"
+          ]
         },
         "read_previous_focusable_item": {
           "command": "Shift + Tab",
           "name": "Read previous focusable item",
-          "tags": ["reading", "forms"]
+          "tags": [
+            "forms",
+            "reading"
+          ]
         },
-        "activate_button": {
-          "name": "Activate Button",
-          "command": "Enter or Space",
-          "tags": ["forms", "general"]
+        "read_previous_item": {
+          "command": "up arrow",
+          "name": "Read previous item",
+          "tags": [
+            "reading"
+          ]
         },
-        "activate_link": {
-          "name": "Activate Link",
-          "command": "Enter",
-          "tags": ["general"]
+        "report_active_window": {
+          "command": "NVDA + b",
+          "name": "Read active window",
+          "tags": [
+            "general"
+          ]
         },
-        "activate_form_control": {
-          "name": "Activate Form Control",
-          "command": "Space",
-          "tags": ["forms"]
+        "report_title": {
+          "command": "NVDA + t",
+          "name": "Report Title",
+          "tags": [
+            "general"
+          ]
+        },
+        "start_reading": {
+          "command": "NVDA + down arrow",
+          "name": "start reading from current position",
+          "tags": [
+            "reading"
+          ]
+        },
+        "stop_speech": {
+          "command": "Control",
+          "name": "Stop speech",
+          "tags": [
+            "reading"
+          ]
+        },
+        "table_move_to_next_column": {
+          "command": "Control + Alt + Right arrow",
+          "name": "Move to next column",
+          "tags": [
+            "tables"
+          ]
+        },
+        "table_move_to_next_row": {
+          "command": "Control + Alt + up arrow",
+          "name": "Move to next row",
+          "tags": [
+            "tables"
+          ]
+        },
+        "table_move_to_previous_column": {
+          "command": "Control + Alt + Left arrow",
+          "name": "Move to previous column",
+          "tags": [
+            "tables"
+          ]
+        },
+        "table_move_to_previous_row": {
+          "command": "Control + Alt + down arrow",
+          "name": "Move to previous row",
+          "tags": [
+            "tables"
+          ]
+        },
+        "toggle_mode": {
+          "command": "NVDA + Spacebar",
+          "name": "Toggle between browse and focus modes",
+          "tags": [
+            "forms",
+            "general",
+            "reading"
+          ]
+        },
+        "turn_off": {
+          "command": "NVDA + Q",
+          "name": "Turn Off",
+          "tags": [
+            "general"
+          ]
+        },
+        "turn_on": {
+          "command": "Control + Alt + N",
+          "name": "Turn On",
+          "tags": [
+            "general"
+          ]
         }
       }
     },
@@ -644,102 +770,102 @@
       "description": "",
       "bugs": "https://www.google.com/accessibility/get-in-touch.html",
       "commands": {
-        "turn_on": {
-          "name": "Turn On",
-          "command": "Power button, then hold two fingers",
-          "note": "when setting is enabled",
+        "activate_button": {
+          "command": "double tap",
+          "name": "Activate button",
           "tags": [
+            "forms",
             "general"
           ]
         },
-        "turn_off": {
-          "name": "Turn Off",
-          "command": "In settings (no shortcut)",
+        "activate_form_control": {
+          "command": "double tap",
+          "name": "Activate form control",
+          "tags": [
+            "forms"
+          ]
+        },
+        "activate_link": {
+          "command": "double tap",
+          "name": "Activate link",
           "tags": [
             "general"
           ]
         },
         "global_context_menu": {
-          "name": "Global context menu",
           "command": "Swipe down, then right",
-          "tags": [
-            "general"
-          ]
-        },
-        "local_context_menu": {
-          "name": "Turn Off",
-          "command": "Swipe up, then right",
-          "tags": [
-            "general"
-          ]
-        },
-        "stop_reading": {
-          "name": "Stop reading",
-          "command": "Single tap",
-          "tags": [
-            "reading"
-          ]
-        },
-        "next_item": {
-          "name": "Read next item",
-          "command": "Swipe right",
-          "tags": [
-            "reading"
-          ]
-        },
-        "previous_item": {
-          "name": "Read previous item",
-          "command": "Swipe left",
-          "tags": [
-            "reading"
-          ]
-        },
-        "activate_link": {
-          "name": "Activate link",
-          "command": "double tap",
-          "tags": [
-            "general"
-          ]
-        },
-        "activate_button": {
-          "name": "Activate button",
-          "command": "double tap",
-          "tags": [
-            "general",
-            "forms"
-          ]
-        },
-        "activate_form_control": {
-          "name": "Activate form control",
-          "command": "double tap",
-          "tags": [
-            "forms"
-          ]
-        },
-        "read_from_current_position": {
-          "name": "Read from current position",
-          "command": "GCM, Read from next item",
-          "tags": [
-            "reading"
-          ]
-        },
-        "open_element_list": {
-          "name": "Open element list",
-          "command": "GCM, Quick navigation",
-          "tags": [
-            "general"
-          ]
-        },
-        "home_screen": {
-          "name": "Go to home screen",
-          "command": "Swipe up, then left",
+          "name": "Global context menu",
           "tags": [
             "general"
           ]
         },
         "go_back": {
-          "name": "Go back",
           "command": "Swipe down, then left",
+          "name": "Go back",
+          "tags": [
+            "general"
+          ]
+        },
+        "home_screen": {
+          "command": "Swipe up, then left",
+          "name": "Go to home screen",
+          "tags": [
+            "general"
+          ]
+        },
+        "local_context_menu": {
+          "command": "Swipe up, then right",
+          "name": "Turn Off",
+          "tags": [
+            "general"
+          ]
+        },
+        "next_item": {
+          "command": "Swipe right",
+          "name": "Read next item",
+          "tags": [
+            "reading"
+          ]
+        },
+        "open_element_list": {
+          "command": "GCM, Quick navigation",
+          "name": "Open element list",
+          "tags": [
+            "general"
+          ]
+        },
+        "previous_item": {
+          "command": "Swipe left",
+          "name": "Read previous item",
+          "tags": [
+            "reading"
+          ]
+        },
+        "read_from_current_position": {
+          "command": "GCM, Read from next item",
+          "name": "Read from current position",
+          "tags": [
+            "reading"
+          ]
+        },
+        "stop_reading": {
+          "command": "Single tap",
+          "name": "Stop reading",
+          "tags": [
+            "reading"
+          ]
+        },
+        "turn_off": {
+          "command": "In settings (no shortcut)",
+          "name": "Turn Off",
+          "tags": [
+            "general"
+          ]
+        },
+        "turn_on": {
+          "command": "Power button, then hold two fingers",
+          "name": "Turn On",
+          "note": "when setting is enabled",
           "tags": [
             "general"
           ]
@@ -757,89 +883,110 @@
       "url": "https://www.apple.com/accessibility/iphone/vision/",
       "description": "",
       "commands": {
-        "turn_on": {
-          "name": "Turn On",
-          "command": "Triple press home (if setting is enabled)",
+        "activate_button": {
+          "command": "Double tap",
+          "name": "Activate Button",
           "tags": [
+            "forms",
             "general"
           ]
         },
-        "turn_off": {
-          "name": "Turn Off",
-          "command": "Triple press home (if setting is enabled)",
-          "tags": [
-            "general"
-          ]
-        },
-        "open_rotor": {
+        "activate_form_control": {
+          "command": "Double tap",
           "name": "Activate Form Control",
-          "command": "two-finger + twist",
-          "tags": ["general"]
+          "tags": [
+            "forms"
+          ]
+        },
+        "activate_link": {
+          "command": "Double tap",
+          "name": "Activate Link",
+          "tags": [
+            "general"
+          ]
+        },
+        "additional_information": {
+          "command": "three-finger tap",
+          "name": "Read additional information about the current position",
+          "tags": [
+            "reading"
+          ]
+        },
+        "dismiss_return": {
+          "command": "Two-finger scrub (move two fingers back and forth three times quickly, making a “z”)",
+          "name": "Dismisses an alert or returns to the previous screen.",
+          "tags": [
+            "reading"
+          ]
+        },
+        "double_tap": {
+          "command": "triple tap",
+          "name": "Double tap the current item",
+          "tags": [
+            "general"
+          ]
         },
         "next_item": {
-          "name": "Next item",
           "command": "Swipe Right",
-          "tags": "reading"
-        },
-        "previous_item": {
-          "name": "Previous item",
-          "command": "Swipe Left",
+          "name": "Next item",
           "tags": "reading"
         },
         "next_rotor_item": {
-          "name": "Next item (as set by the rotor)",
           "command": "Swipe down",
+          "name": "Next item (as set by the rotor)",
+          "tags": "reading"
+        },
+        "open_rotor": {
+          "command": "two-finger + twist",
+          "name": "Activate Form Control",
+          "tags": [
+            "general"
+          ]
+        },
+        "pause_or_start_reading": {
+          "command": "two-finger tap",
+          "name": "Pause or stop reading",
+          "tags": [
+            "reading"
+          ]
+        },
+        "previous_item": {
+          "command": "Swipe Left",
+          "name": "Previous item",
           "tags": "reading"
         },
         "previous_rotor_item": {
-          "name": "Previous item (as set by the rotor)",
           "command": "Swipe up",
+          "name": "Previous item (as set by the rotor)",
           "tags": "reading"
         },
-        "activate_button": {
-          "name": "Activate Button",
-          "command": "Double tap",
-          "tags": ["forms", "general"]
-        },
-        "activate_link": {
-          "name": "Activate Link",
-          "command": "Double tap",
-          "tags": ["general"]
-        },
-        "activate_form_control": {
-          "name": "Activate Form Control",
-          "command": "Double tap",
-          "tags": ["forms"]
+        "read_all": {
+          "command": "two-finger + swipe up",
+          "name": "Read all from the top of the screen",
+          "tags": [
+            "reading"
+          ]
         },
         "start_reading": {
-          "name": "Start reading from current position",
           "command": "two-finger + swipe down",
-          "tags": ["reading"]
+          "name": "Start reading from current position",
+          "tags": [
+            "reading"
+          ]
         },
-        "read_all": {
-          "name": "Read all from the top of the screen",
-          "command": "two-finger + swipe up",
-          "tags": ["reading"]
+        "turn_off": {
+          "command": "Triple press home (if setting is enabled)",
+          "name": "Turn Off",
+          "tags": [
+            "general"
+          ]
         },
-        "pause_or_start_reading": {
-          "name": "Pause or stop reading",
-          "command": "two-finger tap",
-          "tags": ["reading"]
-        },
-        "dismiss_return": {
-          "name": "Dismisses an alert or returns to the previous screen.",
-          "command": "Two-finger scrub (move two fingers back and forth three times quickly, making a “z”)",
-          "tags": ["reading"]
-        },
-        "additional_information": {
-          "name": "Read additional information about the current position",
-          "command": "three-finger tap",
-          "tags": ["reading"]
-        },
-        "double_tap": {
-          "name": "Double tap the current item",
-          "command": "triple tap",
-          "tags": ["general"]
+        "turn_on": {
+          "command": "Triple press home (if setting is enabled)",
+          "name": "Turn On",
+          "tags": [
+            "general"
+          ]
         }
       }
     },
@@ -858,139 +1005,213 @@
         "key": "Control + Option"
       },
       "commands": {
-        "turn_on": {
-          "name": "Turn On",
-          "command": "Command + F5",
-          "tags": ["general"]
+        "activate_button": {
+          "command": "Enter or Space",
+          "name": "Activate Button",
+          "tags": [
+            "forms",
+            "general"
+          ]
         },
-        "turn_off": {
-          "name": "Turn Off",
-          "command": "Command + F5",
-          "tags": ["general"]
+        "activate_form_control": {
+          "command": "Space",
+          "name": "Activate Form Control",
+          "tags": [
+            "forms"
+          ]
         },
-        "read_next_item": {
-          "command": "VO + Right arrow",
-          "name": "Read next item",
-          "tags": ["reading"]
+        "activate_link": {
+          "command": "Enter",
+          "name": "Activate Link",
+          "tags": [
+            "general"
+          ]
         },
-        "read_previous_item": {
-          "command": "VO + Left Arrow",
-          "name": "Read previous item",
-          "tags": ["reading"]
+        "enter_object": {
+          "command": "VO + Shift + Down Arrow",
+          "name": "Enter an object (such as an iframe)",
+          "tags": [
+            "objects"
+          ]
         },
-        "start_reading": {
-          "name": "start reading from current position",
-          "command": "VO + A",
-          "tags": ["reading"]
+        "exit_object": {
+          "command": "VO + Shift + Up Arrow",
+          "name": "Exit an object (such as an iframe)",
+          "tags": [
+            "objects"
+          ]
         },
-        "stop_reading": {
-          "name": "start reading from current position",
-          "command": "Control",
-          "tags": ["reading"]
+        "next_form_control": {
+          "command": "VO + Command + J",
+          "name": "Next Form Control",
+          "tags": [
+            "elements",
+            "forms"
+          ]
         },
-        "read_next_focusable_item": {
-          "command": "Tab",
-          "name": "Read next focusable item",
-          "tags": ["reading", "forms"]
+        "next_graphic": {
+          "command": "VO + Command + G",
+          "name": "Next Graphic",
+          "tags": [
+            "elements"
+          ]
         },
-        "read_previous_focusable_item": {
-          "command": "Shift + Tab",
-          "name": "Read previous focusable item",
-          "tags": ["reading", "forms"]
+        "next_heading": {
+          "command": "VO + Command + H",
+          "name": "Next Heading",
+          "tags": [
+            "elements"
+          ]
+        },
+        "next_link": {
+          "command": "VO + Command + L",
+          "name": "Next Link",
+          "tags": [
+            "elements"
+          ]
+        },
+        "next_list": {
+          "command": "VO + Command + X",
+          "name": "Next Table",
+          "tags": [
+            "elements"
+          ]
+        },
+        "next_table": {
+          "command": "VO + Command + T",
+          "name": "Next Table",
+          "tags": [
+            "elements"
+          ]
+        },
+        "next_visited_link": {
+          "command": "VO + Command + V",
+          "name": "Next Visited Link",
+          "tags": [
+            "elements"
+          ]
         },
         "open_rotor": {
           "command": "VO + U",
           "name": "Open Rotor",
-          "tags": ["general"]
+          "tags": [
+            "general"
+          ]
         },
-        "activate_button": {
-          "name": "Activate Button",
-          "command": "Enter or Space",
-          "tags": ["forms", "general"]
+        "read_next_focusable_item": {
+          "command": "Tab",
+          "name": "Read next focusable item",
+          "tags": [
+            "forms",
+            "reading"
+          ]
         },
-        "activate_link": {
-          "name": "Activate Link",
-          "command": "Enter",
-          "tags": ["general"]
+        "read_next_item": {
+          "command": "VO + Right arrow",
+          "name": "Read next item",
+          "tags": [
+            "reading"
+          ]
         },
-        "activate_form_control": {
-          "name": "Activate Form Control",
-          "command": "Space",
-          "tags": ["forms"]
+        "read_previous_focusable_item": {
+          "command": "Shift + Tab",
+          "name": "Read previous focusable item",
+          "tags": [
+            "forms",
+            "reading"
+          ]
         },
-        "next_heading": {
-          "name": "Next Heading",
-          "command": "VO + Command + H",
-          "tags": ["elements"]
-        },
-        "next_table": {
-          "name": "Next Table",
-          "command": "VO + Command + T",
-          "tags": ["elements"]
-        },
-        "next_link": {
-          "name": "Next Link",
-          "command": "VO + Command + L",
-          "tags": ["elements"]
-        },
-        "next_visited_link": {
-          "name": "Next Visited Link",
-          "command": "VO + Command + V",
-          "tags": ["elements"]
-        },
-        "next_form_control": {
-          "name": "Next Form Control",
-          "command": "VO + Command + J",
-          "tags": ["elements", "forms"]
-        },
-        "next_list": {
-          "name": "Next Table",
-          "command": "VO + Command + X",
-          "tags": ["elements"]
-        },
-        "next_graphic": {
-          "name": "Next Graphic",
-          "command": "VO + Command + G",
-          "tags": ["elements"]
-        },
-        "enter_object": {
-          "name": "Enter an object (such as an iframe)",
-          "command": "VO + Shift + Down Arrow",
-          "tags": ["objects"]
-        },
-        "exit_object": {
-          "name": "Exit an object (such as an iframe)",
-          "command": "VO + Shift + Up Arrow",
-          "tags": ["objects"]
-        },
-        "table_read_column_header": {
-          "name": "Read Column Header",
-          "command": "VO + C",
-          "tags": ["tables"]
-        },
-        "table_move_to_previous_column": {
-          "name": "Move to Previous Column",
+        "read_previous_item": {
           "command": "VO + Left Arrow",
-          "tags": ["tables"]
+          "name": "Read previous item",
+          "tags": [
+            "reading"
+          ]
+        },
+        "start_reading": {
+          "command": "VO + A",
+          "name": "start reading from current position",
+          "tags": [
+            "reading"
+          ]
+        },
+        "stop_reading": {
+          "command": "Control",
+          "name": "start reading from current position",
+          "tags": [
+            "reading"
+          ]
         },
         "table_move_to_next_column": {
-          "name": "Move to Next Column",
           "command": "VO + Right Arrow",
-          "tags": ["tables"]
-        },
-        "table_move_to_previous_row": {
-          "name": "Move to Previous Row",
-          "command": "VO + Up Arrow",
-          "tags": ["tables"]
+          "name": "Move to Next Column",
+          "tags": [
+            "tables"
+          ]
         },
         "table_move_to_next_row": {
-          "name": "Move to Next Row",
           "command": "VO + Down Arrow",
-          "tags": ["tables"]
+          "name": "Move to Next Row",
+          "tags": [
+            "tables"
+          ]
+        },
+        "table_move_to_previous_column": {
+          "command": "VO + Left Arrow",
+          "name": "Move to Previous Column",
+          "tags": [
+            "tables"
+          ]
+        },
+        "table_move_to_previous_row": {
+          "command": "VO + Up Arrow",
+          "name": "Move to Previous Row",
+          "tags": [
+            "tables"
+          ]
+        },
+        "table_read_column_header": {
+          "command": "VO + C",
+          "name": "Read Column Header",
+          "tags": [
+            "tables"
+          ]
+        },
+        "turn_off": {
+          "command": "Command + F5",
+          "name": "Turn Off",
+          "tags": [
+            "general"
+          ]
+        },
+        "turn_on": {
+          "command": "Command + F5",
+          "name": "Turn On",
+          "tags": [
+            "general"
+          ]
         }
       }
     }
   },
+  "command_tags": [
+    {
+      "id": "general",
+      "name": "General"
+    },
+    {
+      "id": "reading",
+      "name": "Reading"
+    },
+    {
+      "id": "forms",
+      "name": "Forms"
+    },
+    {
+      "id": "tables",
+      "name": "Tables"
+    }
+  ],
   "browsers": {
     "chrome": {
       "title": "Google Chrome"

--- a/data/schema/dev-test.json
+++ b/data/schema/dev-test.json
@@ -67,11 +67,7 @@
             "type": "object",
             "properties": {
               "command": {
-                "description": "The keyboard command, touch gesture, or voice command used to access the target element.",
-                "type": "string"
-              },
-              "command_name": {
-                "description": "The command name (purpose of the command)",
+                "description": "The id of the keyboard command. It MUST be a property name in the relevant ATBrowsers.at[at].commands object",
                 "type": "string"
               },
               "output": {
@@ -82,7 +78,7 @@
                 "enum": ["pass", "fail", "partial"]
               }
             },
-            "required": ["command", "command_name", "output", "result"]
+            "required": ["command", "output", "result"]
           }
         },
         "notes": {

--- a/data/schema/test.json
+++ b/data/schema/test.json
@@ -69,9 +69,6 @@
               "command": {
                 "type": "string"
               },
-              "command_name": {
-                "type": "string"
-              },
               "output": {
                 "type": "string"
               },
@@ -86,7 +83,6 @@
             },
             "required": [
               "command",
-              "command_name",
               "output",
               "result"
             ]

--- a/data/tests/aria_gridcell(aria-selected-false)_aam.json
+++ b/data/tests/aria_gridcell(aria-selected-false)_aam.json
@@ -36,8 +36,7 @@
           "date": "2018-10-26",
           "output": [
             {
-              "command": "tab",
-              "command_name": "Next focusable item",
+              "command": "next_focusable_item",
               "output": "target Row 2 Name Column 2",
               "result": "fail"
             }
@@ -56,8 +55,7 @@
           "date": "2018-10-26",
           "output": [
             {
-              "command": "tab",
-              "command_name": "Next focusable item",
+              "command": "next_focusable_item",
               "output": "target, table 2 columns, 3 rows",
               "result": "fail"
             }

--- a/data/tests/aria_gridcell_aam.json
+++ b/data/tests/aria_gridcell_aam.json
@@ -28,8 +28,7 @@
           "date": "2018-10-26",
           "output": [
             {
-              "command": "tab",
-              "command_name": "Next focusable item",
+              "command": "next_focusable_item",
               "output": "target Row 2 Name Column 2",
               "result": "pass"
             }
@@ -48,8 +47,7 @@
           "date": "2018-10-26",
           "output": [
             {
-              "command": "tab",
-              "command_name": "Next focusable item",
+              "command": "next_focusable_item",
               "output": "target, table 2 columns, 3 rows",
               "result": "fail"
             }

--- a/data/tests/aria_hidden_text_input_custom.json
+++ b/data/tests/aria_hidden_text_input_custom.json
@@ -37,14 +37,12 @@
           "support": "y",
           "output": [
             {
-              "command": "down arrow",
-              "command_name": "read next item",
+              "command": "next_item",
               "output": "(target not read)",
               "result": "pass"
             },
             {
-              "command": "tab",
-              "command_name": "next focusable item",
+              "command": "next_focusable_item",
               "output": "Your name edit has auto complete",
               "result": "pass"
             }
@@ -64,14 +62,12 @@
           "date": "2018-08-19",
           "output": [
             {
-              "command": "VO+left/right arrows",
-              "command_name": "Read previous/next item",
+              "command": "next_item",
               "output": "(nothing)",
               "result": "pass"
             },
             {
-              "command": "Tab",
-              "command_name": "Next focusable element",
+              "command": "next_focusable_item",
               "output": "(nothing)",
               "result": "pass"
             }

--- a/data/tests/css_generated_content_aam.json
+++ b/data/tests/css_generated_content_aam.json
@@ -35,8 +35,7 @@
           "support": "y",
           "output": [
             {
-              "command": "down arrow",
-              "command_name": "read next item",
+              "command": "next_item",
               "output": "This is generated content.",
               "result": "pass"
             }
@@ -50,8 +49,7 @@
           "support": "n",
           "output": [
             {
-              "command": "down arrow",
-              "command_name": "read next item",
+              "command": "next_item",
               "output": "is generated",
               "result": "fail"
             }
@@ -65,8 +63,7 @@
           "support": "y",
           "output": [
             {
-              "command": "down arrow",
-              "command_name": "read next item",
+              "command": "next_item",
               "output": "This is generated content.",
               "result": "pass"
             }
@@ -84,8 +81,7 @@
           "support": "y",
           "output": [
             {
-              "command": "down arrow",
-              "command_name": "read next item",
+              "command": "next_item",
               "output": "This is generated content.",
               "result": "pass"
             }
@@ -104,14 +100,12 @@
           "date": "2018-08-12",
           "output": [
             {
-              "command": "swipe right/left",
-              "command_name": "next/previous line",
+              "command": "next_item",
               "output": "this. is generated. content.",
               "result": "pass"
             },
             {
-              "command": "Two finger + swipe down",
-              "command_name": "read from current position",
+              "command": "start_reading",
               "output": "this is generated content",
               "result": "pass"
             }
@@ -130,14 +124,12 @@
           "date": "2018-08-19",
           "output": [
             {
-              "command": "VO+left/right",
-              "command_name": "previous/next item",
+              "command": "next_item",
               "output": "This is generated content.",
               "result": "pass"
             },
             {
-              "command": "VO+a",
-              "command_name": "Read all from here",
+              "command": "start_reading",
               "output": "This is generated content.",
               "result": "pass"
             }

--- a/data/tests/html_canvas_fallback_text_aam.json
+++ b/data/tests/html_canvas_fallback_text_aam.json
@@ -27,14 +27,12 @@
           "support": "p",
           "output": [
             {
-              "command": "VO+right/left arrow",
-              "command_name": "read next/previous item",
+              "command": "next_item",
               "output": "This is fallback text.",
               "result": "partial"
             },
             {
-              "command": "VO+A",
-              "command_name": "read from here",
+              "command": "start_reading",
               "output": "This is fallback text.",
               "result": "partial"
             }

--- a/data/tests/html_label_element_explicit_aam.json
+++ b/data/tests/html_label_element_explicit_aam.json
@@ -71,8 +71,7 @@
           "support": "y",
           "output": [
             {
-              "command": "tab",
-              "command_name": "next focusable item",
+              "command": "next_focusable_item",
               "output": "your name, edit text",
               "result": "pass"
             }
@@ -86,14 +85,12 @@
           "support": "y",
           "output": [
             {
-              "command": "VO + right/left arrow",
-              "command_name": "next/previous item",
+              "command": "next_item",
               "output": "your name, edit text",
               "result": "pass"
             },
             {
-              "command": "tab / shift + tab",
-              "command_name": "next/previous focusable item",
+              "command": "next_focusable_item",
               "output": "your name, edit text",
               "result": "pass"
             }

--- a/data/tests/html_li_element_in_ol_with_sub_ol_aam.json
+++ b/data/tests/html_li_element_in_ol_with_sub_ol_aam.json
@@ -37,8 +37,7 @@
           "date": "2018-10-19",
           "output": [
             {
-              "command": "up/down arrows",
-              "command_name": "Read next/previous item",
+              "command": "next_item",
               "output": "List with three items. 1. Target.",
               "result": "pass"
             }
@@ -56,8 +55,7 @@
           "date": "2018-10-19",
           "output": [
             {
-              "command": "VO + left/right arrows",
-              "command_name": "Read next/previous item",
+              "command": "next_item",
               "output": "Target 1 of 3",
               "result": "pass"
             }

--- a/data/tests/html_li_element_in_ul_with_sub_ul_aam.json
+++ b/data/tests/html_li_element_in_ul_with_sub_ul_aam.json
@@ -38,8 +38,7 @@
           "date": "2018-10-19",
           "output": [
             {
-              "command": "up/down arrows",
-              "command_name": "Read next/previous item",
+              "command": "next_item",
               "output": "List with three items. Bullet Target.",
               "result": "pass"
             }
@@ -57,8 +56,7 @@
           "date": "2018-10-19",
           "output": [
             {
-              "command": "VO + left/right arrows",
-              "command_name": "Read next/previous item",
+              "command": "next_item",
               "output": "Target 1 of 3",
               "result": "pass"
             }

--- a/data/tests/html_option_element_with_lang_aam.json
+++ b/data/tests/html_option_element_with_lang_aam.json
@@ -36,8 +36,7 @@
           "date": "2018-10-19",
           "output": [
             {
-              "command": "up/down arrows",
-              "command_name": "Select next/previous item",
+              "command": "next_item",
               "output": "中文 (简体)",
               "result": "pass"
             }
@@ -56,8 +55,7 @@
           "date": "2018-10-19",
           "output": [
             {
-              "command": "up/down arrows",
-              "command_name": "Read next/previous item",
+              "command": "next_item",
               "output": "(attempts to speak characters as english ideographs)",
               "result": "fail"
             }

--- a/data/tests/html_p_element_with_lang_aam.json
+++ b/data/tests/html_p_element_with_lang_aam.json
@@ -36,8 +36,7 @@
           "date": "2018-10-19",
           "output": [
             {
-              "command": "up/down arrows",
-              "command_name": "Select next/previous item",
+              "command": "next_item",
               "output": "中文 (简体)",
               "result": "pass"
             }
@@ -56,8 +55,7 @@
           "date": "2018-10-19",
           "output": [
             {
-              "command": "VO + left/right arrows",
-              "command_name": "Select next/previous item",
+              "command": "next_item",
               "output": "中文 (简体)",
               "result": "pass"
             }

--- a/data/tests/html_td_element_with_th(scope-row)_custom.json
+++ b/data/tests/html_td_element_with_th(scope-row)_custom.json
@@ -28,14 +28,12 @@
           "date": "2018-07-29",
           "output": [
             {
-              "command": "Control + Option + left/right arrows",
-              "command_name": "Read cell to left/right",
+              "command": "table_move_to_next_column",
               "output": "target, column 2 of 2",
               "result": "fail"
             },
             {
-              "command": "Control + Option + up/down arrows",
-              "command_name": "Read cell above/below",
+              "command": "table_move_to_next_row",
               "output": "Row 1 of 2 Row one header, target",
               "result": "fail"
             }
@@ -52,17 +50,14 @@
           "os_version": "1803",
           "support": "p",
           "date": "2018-07-30",
-          "output": "target, non-selected, row 1 of 2 column 2 of 2",
           "output": [
             {
-              "command": "Caps Lock + right/left arrows",
-              "command_name": "Read next/previous item",
+              "command": "table_move_to_next_column",
               "output": "target, non-selected, row 1 of 2 column 2 of 2",
               "result": "fail"
             },
             {
-              "command": "Control + Alt + up/down Arrow",
-              "command_name": "Cell above",
+              "command": "table_move_to_next_row",
               "output": "target, non-selected, row 1 of 2 column 2 of 2",
               "result": "fail"
             }
@@ -81,14 +76,12 @@
           "date": "2018-07-30",
           "output": [
             {
-              "command": "Down Arrow",
-              "command_name": "Read next item",
+              "command": "table_move_to_next_column",
               "output": "Row 1 column 2 target",
               "result": "pass"
             },
             {
-              "command": "Up Arrow",
-              "command_name": "Read previous item",
+              "command": "table_move_to_next_row",
               "output": "Row one header column 2 target",
               "result": "fail"
             }

--- a/public/js/feature-test.js
+++ b/public/js/feature-test.js
@@ -462,6 +462,21 @@ getJson(window.location.pathname+'.json', function(data) {
 	getJson('/ATBrowsers.json', function(data) {
 		ATBrowsers = data;
 
+        var at_value = sessionStorage.getItem('at');
+        var browser_value = sessionStorage.getItem('browser');
+
+        // IF at_value isn't set, set it to the first option.
+        if (!at_value) {
+            at_value = 'dragon_win';
+            sessionStorage.setItem('at', at_value);
+        }
+
+        // If browser_value isn't set, set it to the first core browser for the current AT
+        if (!browser_value) {
+            browser_value = ATBrowsers.at[at_value].core_browsers[0];
+            sessionStorage.setItem('browser', browser_value);
+        }
+
 		// Now that we have the data, init search
 		initFeatureTest();
 		displayTestingPrefs();

--- a/public/js/feature-test.js
+++ b/public/js/feature-test.js
@@ -159,45 +159,56 @@ var createCommandOutputRow = function(outputObject, focus) {
 	legend.innerText = 'Output row ' + key;
 	fieldset.appendChild(legend);
 
-	// command used
-	var div = document.createElement('div');
-	div.classList.add('control');
-	var label = document.createElement('label');
-	label.innerText = 'The command used (required)';
-	var span = document.createElement('span');
-	var id = 'output_'+key+'_command';
-	label.setAttribute('for', id);
-	span.innerText = '(list the keystrokes, or describe the gesture or voice command)';
-	span.id = id + '_description';
-	label.setAttribute('aria-describedby', span.id);
-	var commandInput = document.createElement('input');
-	commandInput.setAttribute('type', 'text');
-	commandInput.setAttribute('id', id);
-	commandInput.setAttribute('name', id);
-	div.appendChild(label);
-	div.insertBefore(span, label.nextSibling);
-	div.appendChild(commandInput);
-	fieldset.appendChild(div);
 
-	if (outputObject) {
-		commandInput.value = outputObject.command;
-	}
+    var div = document.createElement('div');
+    div.classList.add('control');
+    var id = 'output_'+key+'_command';
+    var command_select = document.createElement('select');
+    command_select.setAttribute('id', id);
+    command_select.setAttribute('name', id);
+    var label = document.createElement('label');
+    label.innerText = 'The command used (required)';
+    label.setAttribute('for', id);
+    div.appendChild(label);
 
-	// command name used
-	var div = document.createElement('div');
-	div.classList.add('control');
-	var label = document.createElement('label');
-	label.innerText = 'The command name (required)';
-	var span = document.createElement('span');
-	var id = 'output_'+key+'_command_name';
-	label.setAttribute('for', id);
-	var input = document.createElement('input');
-	input.setAttribute('type', 'text');
-	input.setAttribute('id', id);
-	input.setAttribute('name', id);
-	div.appendChild(label);
-	div.appendChild(input);
-	fieldset.appendChild(div);
+    // Default null state
+	var option = document.createElement('option');
+	option.innerText = '-- select an option --';
+	option.setAttribute('value', '');
+	command_select.appendChild(option);
+
+    var at_value = sessionStorage.getItem('at');
+	var keys = Object.getOwnPropertyNames(ATBrowsers.at[at_value].commands);
+    for (var i=0; i<ATBrowsers.command_tags.length; i++) {
+    	var tag = ATBrowsers.command_tags[i];
+    	var optgroup = null;
+        for (var ii=0; ii<keys.length; ii++) {
+        	var command = ATBrowsers.at[at_value].commands[keys[ii]];
+        	if (!command.tags.includes(tag.id)) {
+        		continue;
+			}
+			if (!optgroup) {
+				// Create the optgroup
+				optgroup = document.createElement('optgroup');
+				optgroup.setAttribute('label', tag.name);
+				command_select.appendChild(optgroup);
+			}
+			// Create the option
+            var option = document.createElement('option');
+            option.innerText = command.name;
+            option.innerText += ' ('+command.command+')';
+            option.setAttribute('value', keys[ii]);
+
+            if (outputObject && outputObject.command_name === keys[ii]) {
+            	option.setAttribute('selected', 'selected');
+            }
+
+            optgroup.appendChild(option);
+        }
+    }
+
+    div.appendChild(command_select);
+    fieldset.appendChild(div);
 
 	if (outputObject) {
 		input.value = outputObject.command_name;
@@ -330,7 +341,6 @@ function initFeatureTest() {
 		for (var i=0; i<currentRows.length; i++) {
 			var idPrefix = '#output_'+(i+1);
 			var command = document.querySelector(idPrefix+'_command');
-			var command_name = document.querySelector(idPrefix+'_command_name');
 			var output = document.querySelector(idPrefix+'_command');
 			var result = document.querySelector(idPrefix+'_result');
 
@@ -338,19 +348,14 @@ function initFeatureTest() {
 				errors.push(generateErrorLink(idPrefix+'_command', "Output row " + (i+1) + " command is required"));
 				command.setAttribute('aria-invalid', 'true');
 			}
-			if (!command_name.value) {
-				errors.push(generateErrorLink(idPrefix+'_command_name', "Output row " + (i+1) + " command name is required"));
-				command_name.setAttribute('aria-invalid', 'true');
-			}
 			if (!output.value) {
-				errors.push(generateErrorLink(idPrefix+'_command', "Output row " + (i+1) + " output is required"));
+				errors.push(generateErrorLink(idPrefix+'_output', "Output row " + (i+1) + " output is required"));
 				output.setAttribute('aria-invalid', 'true');
 			}
 			if (!result.value) {
 				errors.push(generateErrorLink(idPrefix+'_result', "Output row " + (i+1) + " result is required"));
 				result.setAttribute('aria-invalid', 'true');
 			}
-
 		}
 
 		if (errors.length) {

--- a/test.js
+++ b/test.js
@@ -11,6 +11,7 @@ let ajv = new Ajv({schemas: [
 let buildDir = __dirname+'/build';
 let devDir = __dirname+'/data';
 let tech = require(buildDir+"/tech.json");
+let ATBrowsers = require(devDir+'/ATBrowsers.json');
 
 describe('Development tests', function () {
 	let testFiles = fs.readdirSync(devDir+'/tests');
@@ -20,13 +21,28 @@ describe('Development tests', function () {
 			return;
 		}
 
+        let test = require(devDir + '/tests/' + file);
 		it(file + ' should conform to the dev-test schema', function () {
-			let test = require(devDir + '/tests/' + file);
 			let valid = ajv.validate('http://accessibilitysupported.com/dev-test.json', test);
 			if (!valid) {
 				console.log(ajv.errors);
 			}
 			expect(valid).to.be.equal(true);
+		});
+
+		let at_keys = Object.getOwnPropertyNames(test.at);
+		at_keys.forEach(function(at_id) {
+			let browser_keys = Object.getOwnPropertyNames(test.at[at_id].browsers);
+			browser_keys.forEach(function(browser_key) {
+				if (!test.at[at_id].browsers[browser_key].output) {
+					return;
+				}
+				test.at[at_id].browsers[browser_key].output.forEach(function(output, index) {
+					it(at_id + '.' + browser_key + '.output['+index+'].command should be valid', function() {
+                        expect(ATBrowsers.at[at_id].commands[output.command]).to.be.not.undefined;
+					})
+				});
+			});
 		});
 
 	});

--- a/views/learn-at.pug
+++ b/views/learn-at.pug
@@ -13,18 +13,7 @@ block content
             if ATBrowsers.at[at_id].modifier_key
                 p The default #{ATBrowsers.at[at_id].modifier_key.name} modifier key is set to: #{ATBrowsers.at[at_id].modifier_key.key}
 
-            if (command_list_contains_tag(ATBrowsers.at[at_id].commands, 'general'))
-                h3 General
-                +command-table(ATBrowsers, at_id, 'general', command_list_has_notes(ATBrowsers.at[at_id].commands, 'general'))
-
-            if (command_list_contains_tag(ATBrowsers.at[at_id].commands, 'reading'))
-                h3 Reading
-                +command-table(ATBrowsers, at_id, 'reading', command_list_has_notes(ATBrowsers.at[at_id].commands, 'reading'))
-
-            if (command_list_contains_tag(ATBrowsers.at[at_id].commands, 'forms'))
-                h3 Forms
-                +command-table(ATBrowsers, at_id, 'forms', command_list_has_notes(ATBrowsers.at[at_id].commands, 'forms'))
-
-            if (command_list_contains_tag(ATBrowsers.at[at_id].commands, 'tables'))
-                h3 Tables
-                +command-table(ATBrowsers, at_id, 'tables', command_list_has_notes(ATBrowsers.at[at_id].commands, 'tables'))
+            each command_tag in ATBrowsers.command_tags
+                if (command_list_contains_tag(ATBrowsers.at[at_id].commands, command_tag.id))
+                    h3 #{command_tag.name}
+                    +command-table(ATBrowsers, at_id, command_tag.id, command_list_has_notes(ATBrowsers.at[at_id].commands, command_tag.id))

--- a/views/test-case-support-point.pug
+++ b/views/test-case-support-point.pug
@@ -43,14 +43,12 @@ block content
                 thead
                     tr
                         th Command
-                        th Command name
                         th Result
                         th Output
                 tbody
                     each output in test.at[atId].browsers[browserId].output
                         tr
-                            td=output.command
-                            td=output.command_name
+                            td=output.command + " (" + ATBrowsers.at[atId].commands[output.command].command + ")"
                             td=output.result
                             td=output.output
 


### PR DESCRIPTION

* [x] list commands in the ATBrowser.json file for each AT
* [x] convert the command_name and command_key inputs to a select sourced with options from the command list for the currently selected AT
* [x] give the same id to common commands
* [x] alphabetize command lists
* [x] wire up command list tas to "learning" documentation
* [x] update the command property in the test output to reference a command from the command list
* [x] tag common commands
* [x] update test schema to reference command lists
* [x] update templates to get the command and command name values
* [x] make sure tests work
* [x] set the default AT when testing (if localStorage is not set)
* [x] validate command names in tests

