### PR TITLE
Import figure tests from Scott O'hara 

### DIFF
--- a/data/tech/html/figcaption_element.json
+++ b/data/tech/html/figcaption_element.json
@@ -1,0 +1,17 @@
+{
+  "id": "figcaption_element",
+  "title": "figcaption element",
+  "type": "element",
+  "description": "",
+  "references": [
+    {
+      "title": "HTML5 spec for figcaption",
+      "url": "https://w3c.github.io/html/grouping-content.html#the-figcaption-element"
+    },
+    {
+      "title": "HTML AAM spec for figcaption",
+      "url": "https://www.w3.org/TR/html-aam-1.0/#figure-and-figcaption-elements"
+    }
+  ],
+  "date_updated": "2019-01-21"
+}

--- a/data/tech/html/figcaption_element.json
+++ b/data/tech/html/figcaption_element.json
@@ -5,8 +5,12 @@
   "description": "",
   "references": [
     {
-      "title": "HTML5 spec for figcaption",
+      "title": "W3C HTML5 spec for figcaption",
       "url": "https://w3c.github.io/html/grouping-content.html#the-figcaption-element"
+    },
+    {
+      "title": "WHATWG HTML5 spec for figcaption",
+      "url": "https://html.spec.whatwg.org/multipage/grouping-content.html#the-figcaption-element"
     },
     {
       "title": "HTML AAM spec for figcaption",

--- a/data/tech/html/figure_element.json
+++ b/data/tech/html/figure_element.json
@@ -1,0 +1,17 @@
+{
+  "id": "figure_element",
+  "title": "figure element",
+  "type": "element",
+  "description": "",
+  "references": [
+    {
+      "title": "HTML5 spec for figure",
+      "url": "https://w3c.github.io/html/grouping-content.html#the-figure-element"
+    },
+    {
+      "title": "HTML AAM spec for figure",
+      "url": "https://www.w3.org/TR/html-aam-1.0/#figure-and-figcaption-elements"
+    }
+  ],
+  "date_updated": "2019-01-21"
+}

--- a/data/tech/html/figure_element.json
+++ b/data/tech/html/figure_element.json
@@ -9,6 +9,10 @@
       "url": "https://w3c.github.io/html/grouping-content.html#the-figure-element"
     },
     {
+      "title": "WHATWG HTML5 spec for figure",
+      "url": "https://html.spec.whatwg.org/multipage/grouping-content.html#the-figure-element"
+    },
+    {
       "title": "HTML AAM spec for figure",
       "url": "https://www.w3.org/TR/html-aam-1.0/#figure-and-figcaption-elements"
     }

--- a/data/tests/html/html_figure_tests.html
+++ b/data/tests/html/html_figure_tests.html
@@ -1,0 +1,130 @@
+
+<html lang="en"><head>
+    <meta charset="utf-8">
+    <title>Figure and figcaption tests</title>
+</head><body>
+
+<h1>Figure &amp; figcaption tests</h1>
+
+<div>
+    <h2>Test 1</h2>
+    <figure id="target_1">
+        <img src="earth.jpg" alt="Accessible Name">
+        <figcaption>
+            Content caption.
+        </figcaption>
+    </figure>
+</div>
+
+<div>
+    <h2>Test 2</h2>
+    <figure id="target_2">
+        <img src="earth.jpg">
+        <figcaption>
+            Content caption.
+        </figcaption>
+    </figure>
+</div>
+
+<div>
+    <h2>Test 3</h2>
+    <figure id="target_3">
+        <img src="earth.jpg" alt="">
+        <figcaption>
+            Content caption.
+        </figcaption>
+    </figure>
+</div>
+
+<div>
+    <h2>Test 4</h2>
+    <figure id="target_4" aria-label="ARIA label">
+        <img src="earth.jpg" alt="">
+        <figcaption>
+            Content caption.
+        </figcaption>
+    </figure>
+</div>
+
+<div>
+    <h2>Test 5</h2>
+    <figure id="target_5" aria-label="ARIA label">
+        <img src="earth.jpg" alt="Accessible Name">
+        <figcaption>
+            Content caption.
+        </figcaption>
+    </figure>
+</div>
+
+<div>
+    <h2>Test 6</h2>
+    <figure id="target_6">
+        <img src="earth.jpg" alt="Accessible Name">
+    </figure>
+</div>
+
+<div>
+    <h2>Test 7</h2>
+    <figure id="target_7" aria-labelledby="lby">
+        <img src="earth.jpg" alt="Accessible Name">
+        <figcaption id="lby">
+            Content caption.
+        </figcaption>
+    </figure>
+</div>
+
+<div>
+    <h2>Test 8</h2>
+    <figure id="target_8" role="figure">
+        <img src="earth.jpg" alt="Accessible Name">
+        <figcaption>
+            Content caption.
+        </figcaption>
+    </figure>
+</div>
+
+<div>
+    <h2>Test 9</h2>
+    <figure id="target_9" role="figure" aria-labelledby="figID">
+        <img src="earth.jpg" alt="Accessible Name">
+        <figcaption id="figID">
+            Content caption.
+        </figcaption>
+    </figure>
+</div>
+
+<div>
+    <h2>Test 10</h2>
+    <figure id="target_10" role="figure" aria-label="ARIA label">
+        <img src="earth.jpg" alt="Accessible Name">
+        <figcaption>
+            Content caption.
+        </figcaption>
+    </figure>
+</div>
+
+<div>
+    <h2>Test 11</h2>
+    <figure id="target_11">
+        <p>Non-image figure content</p>
+        <figcaption>
+            Content caption.
+        </figcaption>
+    </figure>
+</div>
+
+<div>
+    <h2>Test 12</h2>
+    <figure id="target_12">
+        <p>Non-image figure content</p>
+    </figure>
+</div>
+
+<div>
+    <h2>Test 13</h2>
+    <figure id="target_13" aria-label="ARIA label">
+        <p>Non-image figure content</p>
+    </figure>
+</div>
+
+</body></html>

--- a/data/tests/tech/html/html_figure/test_0.json
+++ b/data/tests/tech/html/html_figure/test_0.json
@@ -25,9 +25,9 @@
       "browsers": {
         "ie": {
           "at_version": "2019",
-          "browser_version": "44",
+          "browser_version": "11",
           "os_version": "1809",
-          "date": "2019-01-14",
+          "date": "2019-01-21",
           "output": [
             {
               "command": "next_item",
@@ -40,7 +40,7 @@
           "at_version": "2019",
           "browser_version": "64.0.2",
           "os_version": "1809",
-          "date": "2019-01-14",
+          "date": "2019-01-21",
           "output": [
             {
               "command": "next_item",
@@ -57,7 +57,7 @@
           "at_version": "1804",
           "browser_version": "42",
           "os_version": "1804",
-          "date": "2019-01-14",
+          "date": "2019-01-21",
           "output": [
             {
               "command": "next_item",
@@ -75,7 +75,7 @@
           "at_version": "2018.4.1",
           "browser_version": "64.0.2",
           "os_version": "1809",
-          "date": "2019-01-14",
+          "date": "2019-01-21",
           "output": [
             {
               "command": "next_item",
@@ -89,10 +89,10 @@
     "vo_macos": {
       "browsers": {
         "safari": {
-          "at_version": "10.14",
+          "at_version": "10.14.2",
           "browser_version": "12.0.2",
-          "os_version": "10.14",
-          "date": "2019-01-14",
+          "os_version": "10.14.2",
+          "date": "2019-01-21",
           "output": [
             {
               "command": "next_item",
@@ -109,7 +109,7 @@
           "at_version": "12.1",
           "browser_version": "12.1.2",
           "os_version": "12.1",
-          "date": "2019-01-14",
+          "date": "2019-01-21",
           "output": [
             {
               "command": "next_item",
@@ -123,10 +123,10 @@
     "talkback": {
       "browsers": {
         "and_chr": {
-          "at_version": "7.2",
+          "at_version": "8.1",
           "browser_version": "70",
-          "os_version": "7.2",
-          "date": "2019-01-14",
+          "os_version": "8.1",
+          "date": "2019-01-21",
           "output": [
             {
               "command": "next_item",

--- a/data/tests/tech/html/html_figure/test_0.json
+++ b/data/tests/tech/html/html_figure/test_0.json
@@ -1,0 +1,141 @@
+{
+  "type": "assertion",
+  "title": "Figure test 0",
+  "description": "This test was originally imported from the article titled '[how do you figure?'](https://www.scottohara.me/blog/2019/01/21/how-do-you-figure.html)' by Scott O'Hara.",
+  "features": [
+    "html/figure_element",
+    "html/figcaption_element"
+  ],
+  "supports_sr": true,
+  "supports_vc": false,
+  "css_target": "#target_0",
+  "html_file": "html_figure_tests.html",
+  "assertion": {
+    "aspect": "role",
+    "value": "figure"
+  },
+  "history": [
+    {
+      "date": "2019-01-21",
+      "message": "Test created. Thank you @scottaohara."
+    }
+  ],
+  "at": {
+    "jaws": {
+      "browsers": {
+        "ie": {
+          "at_version": "2019",
+          "browser_version": "44",
+          "os_version": "1809",
+          "date": "2019-01-14",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "(unknown)",
+              "result": "fail"
+            }
+          ]
+        },
+        "firefox": {
+          "at_version": "2019",
+          "browser_version": "64.0.2",
+          "os_version": "1809",
+          "date": "2019-01-14",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "figure role with \"Content caption\" as the accessible name.",
+              "result": "pass"
+            }
+          ]
+        }
+      }
+    },
+    "narrator": {
+      "browsers": {
+        "edge": {
+          "at_version": "1804",
+          "browser_version": "42",
+          "os_version": "1804",
+          "date": "2019-01-14",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "(unknown)",
+              "result": "partial"
+            }
+          ],
+          "notes": "no announced role, but relationship made"
+        }
+      }
+    },
+    "nvda": {
+      "browsers": {
+        "firefox": {
+          "at_version": "2018.4.1",
+          "browser_version": "64.0.2",
+          "os_version": "1809",
+          "date": "2019-01-14",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "(unknown)",
+              "result": "fail"
+            }
+          ]
+        }
+      }
+    },
+    "vo_macos": {
+      "browsers": {
+        "safari": {
+          "at_version": "10.14",
+          "browser_version": "12.0.2",
+          "os_version": "10.14",
+          "date": "2019-01-14",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "figure role with \"Content caption\" as the accessible name.",
+              "result": "pass"
+            }
+          ]
+        }
+      }
+    },
+    "vo_ios": {
+      "browsers": {
+        "ios_saf": {
+          "at_version": "12.1",
+          "browser_version": "12.1.2",
+          "os_version": "12.1",
+          "date": "2019-01-14",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "(unknown)",
+              "result": "fail"
+            }
+          ]
+        }
+      }
+    },
+    "talkback": {
+      "browsers": {
+        "and_chr": {
+          "at_version": "7.2",
+          "browser_version": "70",
+          "os_version": "7.2",
+          "date": "2019-01-14",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "(unknown)",
+              "result": "fail"
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/data/tests/tech/html/html_figure/test_0.json
+++ b/data/tests/tech/html/html_figure/test_0.json
@@ -123,7 +123,7 @@
     "talkback": {
       "browsers": {
         "and_chr": {
-          "at_version": "8.1",
+          "at_version": "7.2",
           "browser_version": "70",
           "os_version": "8.1",
           "date": "2019-01-21",

--- a/data/tests/tech/html/html_figure/test_1.json
+++ b/data/tests/tech/html/html_figure/test_1.json
@@ -25,9 +25,9 @@
       "browsers": {
         "ie": {
           "at_version": "2019",
-          "browser_version": "44",
+          "browser_version": "11",
           "os_version": "1809",
-          "date": "2019-01-14",
+          "date": "2019-01-21",
           "output": [
             {
               "command": "next_item",
@@ -40,7 +40,7 @@
           "at_version": "2019",
           "browser_version": "64.0.2",
           "os_version": "1809",
-          "date": "2019-01-14",
+          "date": "2019-01-21",
           "output": [
             {
               "command": "next_item",
@@ -57,7 +57,7 @@
           "at_version": "1804",
           "browser_version": "42",
           "os_version": "1804",
-          "date": "2019-01-14",
+          "date": "2019-01-21",
           "output": [
             {
               "command": "next_item",
@@ -75,7 +75,7 @@
           "at_version": "2018.4.1",
           "browser_version": "64.0.2",
           "os_version": "1809",
-          "date": "2019-01-14",
+          "date": "2019-01-21",
           "output": [
             {
               "command": "next_item",
@@ -89,10 +89,10 @@
     "vo_macos": {
       "browsers": {
         "safari": {
-          "at_version": "10.14",
+          "at_version": "10.14.2",
           "browser_version": "12.0.2",
-          "os_version": "10.14",
-          "date": "2019-01-14",
+          "os_version": "10.14.2",
+          "date": "2019-01-21",
           "output": [
             {
               "command": "next_item",
@@ -109,7 +109,7 @@
           "at_version": "12.1",
           "browser_version": "12.1.2",
           "os_version": "12.1",
-          "date": "2019-01-14",
+          "date": "2019-01-21",
           "output": [
             {
               "command": "next_item",
@@ -123,10 +123,10 @@
     "talkback": {
       "browsers": {
         "and_chr": {
-          "at_version": "7.2",
+          "at_version": "8.1",
           "browser_version": "70",
-          "os_version": "7.2",
-          "date": "2019-01-14",
+          "os_version": "8.1",
+          "date": "2019-01-21",
           "output": [
             {
               "command": "next_item",

--- a/data/tests/tech/html/html_figure/test_1.json
+++ b/data/tests/tech/html/html_figure/test_1.json
@@ -123,7 +123,7 @@
     "talkback": {
       "browsers": {
         "and_chr": {
-          "at_version": "8.1",
+          "at_version": "7.2",
           "browser_version": "70",
           "os_version": "8.1",
           "date": "2019-01-21",

--- a/data/tests/tech/html/html_figure/test_1.json
+++ b/data/tests/tech/html/html_figure/test_1.json
@@ -1,0 +1,141 @@
+{
+  "type": "assertion",
+  "title": "Figure test 1",
+  "description": "This test was originally imported from the article titled '[how do you figure?'](https://www.scottohara.me/blog/2019/01/21/how-do-you-figure.html)' by Scott O'Hara.",
+  "features": [
+    "html/figure_element",
+    "html/figcaption_element"
+  ],
+  "supports_sr": true,
+  "supports_vc": false,
+  "css_target": "#target_1",
+  "html_file": "html_figure_tests.html",
+  "assertion": {
+    "aspect": "role",
+    "value": "figure"
+  },
+  "history": [
+    {
+      "date": "2019-01-21",
+      "message": "Test created. Thank you @scottaohara."
+    }
+  ],
+  "at": {
+    "jaws": {
+      "browsers": {
+        "ie": {
+          "at_version": "2019",
+          "browser_version": "44",
+          "os_version": "1809",
+          "date": "2019-01-14",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "(unknown)",
+              "result": "fail"
+            }
+          ]
+        },
+        "firefox": {
+          "at_version": "2019",
+          "browser_version": "64.0.2",
+          "os_version": "1809",
+          "date": "2019-01-14",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "Note: Image \"should\" announce as \"earth.jpg\" but screen readers may ignore.",
+              "result": "pass"
+            }
+          ]
+        }
+      }
+    },
+    "narrator": {
+      "browsers": {
+        "edge": {
+          "at_version": "1804",
+          "browser_version": "42",
+          "os_version": "1804",
+          "date": "2019-01-14",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "(unknown)",
+              "result": "partial"
+            }
+          ],
+          "notes": "no announced role, but relationship made"
+        }
+      }
+    },
+    "nvda": {
+      "browsers": {
+        "firefox": {
+          "at_version": "2018.4.1",
+          "browser_version": "64.0.2",
+          "os_version": "1809",
+          "date": "2019-01-14",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "(unknown)",
+              "result": "fail"
+            }
+          ]
+        }
+      }
+    },
+    "vo_macos": {
+      "browsers": {
+        "safari": {
+          "at_version": "10.14",
+          "browser_version": "12.0.2",
+          "os_version": "10.14",
+          "date": "2019-01-14",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "Note: Image \"should\" announce as \"earth.jpg\" but screen readers may ignore.",
+              "result": "pass"
+            }
+          ]
+        }
+      }
+    },
+    "vo_ios": {
+      "browsers": {
+        "ios_saf": {
+          "at_version": "12.1",
+          "browser_version": "12.1.2",
+          "os_version": "12.1",
+          "date": "2019-01-14",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "(unknown)",
+              "result": "fail"
+            }
+          ]
+        }
+      }
+    },
+    "talkback": {
+      "browsers": {
+        "and_chr": {
+          "at_version": "7.2",
+          "browser_version": "70",
+          "os_version": "7.2",
+          "date": "2019-01-14",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "(unknown)",
+              "result": "fail"
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/data/tests/tech/html/html_figure/test_10.json
+++ b/data/tests/tech/html/html_figure/test_10.json
@@ -25,9 +25,9 @@
       "browsers": {
         "ie": {
           "at_version": "2019",
-          "browser_version": "44",
+          "browser_version": "11",
           "os_version": "1809",
-          "date": "2019-01-14",
+          "date": "2019-01-21",
           "output": [
             {
               "command": "next_item",
@@ -40,7 +40,7 @@
           "at_version": "2019",
           "browser_version": "64.0.2",
           "os_version": "1809",
-          "date": "2019-01-14",
+          "date": "2019-01-21",
           "output": [
             {
               "command": "next_item",
@@ -57,7 +57,7 @@
           "at_version": "1804",
           "browser_version": "42",
           "os_version": "1804",
-          "date": "2019-01-14",
+          "date": "2019-01-21",
           "output": [
             {
               "command": "next_item",
@@ -75,7 +75,7 @@
           "at_version": "2018.4.1",
           "browser_version": "64.0.2",
           "os_version": "1809",
-          "date": "2019-01-14",
+          "date": "2019-01-21",
           "output": [
             {
               "command": "next_item",
@@ -89,10 +89,10 @@
     "vo_macos": {
       "browsers": {
         "safari": {
-          "at_version": "10.14",
+          "at_version": "10.14.2",
           "browser_version": "12.0.2",
-          "os_version": "10.14",
-          "date": "2019-01-14",
+          "os_version": "10.14.2",
+          "date": "2019-01-21",
           "output": [
             {
               "command": "next_item",
@@ -109,7 +109,7 @@
           "at_version": "12.1",
           "browser_version": "12.1.2",
           "os_version": "12.1",
-          "date": "2019-01-14",
+          "date": "2019-01-21",
           "output": [
             {
               "command": "next_item",
@@ -123,10 +123,10 @@
     "talkback": {
       "browsers": {
         "and_chr": {
-          "at_version": "7.2",
+          "at_version": "8.1",
           "browser_version": "70",
-          "os_version": "7.2",
-          "date": "2019-01-14",
+          "os_version": "8.1",
+          "date": "2019-01-21",
           "output": [
             {
               "command": "next_item",

--- a/data/tests/tech/html/html_figure/test_10.json
+++ b/data/tests/tech/html/html_figure/test_10.json
@@ -123,7 +123,7 @@
     "talkback": {
       "browsers": {
         "and_chr": {
-          "at_version": "8.1",
+          "at_version": "7.2",
           "browser_version": "70",
           "os_version": "8.1",
           "date": "2019-01-21",

--- a/data/tests/tech/html/html_figure/test_10.json
+++ b/data/tests/tech/html/html_figure/test_10.json
@@ -1,0 +1,141 @@
+{
+  "type": "assertion",
+  "title": "Figure test 10",
+  "description": "This test was originally imported from the article titled '[how do you figure?'](https://www.scottohara.me/blog/2019/01/21/how-do-you-figure.html)' by Scott O'Hara.",
+  "features": [
+    "html/figure_element",
+    "html/figcaption_element"
+  ],
+  "supports_sr": true,
+  "supports_vc": false,
+  "css_target": "#target_10",
+  "html_file": "html_figure_tests.html",
+  "assertion": {
+    "aspect": "role",
+    "value": "figure"
+  },
+  "history": [
+    {
+      "date": "2019-01-21",
+      "message": "Test created. Thank you @scottaohara."
+    }
+  ],
+  "at": {
+    "jaws": {
+      "browsers": {
+        "ie": {
+          "at_version": "2019",
+          "browser_version": "44",
+          "os_version": "1809",
+          "date": "2019-01-14",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "(unknown)",
+              "result": "fail"
+            }
+          ]
+        },
+        "firefox": {
+          "at_version": "2019",
+          "browser_version": "64.0.2",
+          "os_version": "1809",
+          "date": "2019-01-14",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "figure role with \"Content caption.\" as the accessible name.",
+              "result": "pass"
+            }
+          ]
+        }
+      }
+    },
+    "narrator": {
+      "browsers": {
+        "edge": {
+          "at_version": "1804",
+          "browser_version": "42",
+          "os_version": "1804",
+          "date": "2019-01-14",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "(unknown)",
+              "result": "partial"
+            }
+          ],
+          "notes": "no announced role, but relationship made"
+        }
+      }
+    },
+    "nvda": {
+      "browsers": {
+        "firefox": {
+          "at_version": "2018.4.1",
+          "browser_version": "64.0.2",
+          "os_version": "1809",
+          "date": "2019-01-14",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "(unknown)",
+              "result": "fail"
+            }
+          ]
+        }
+      }
+    },
+    "vo_macos": {
+      "browsers": {
+        "safari": {
+          "at_version": "10.14",
+          "browser_version": "12.0.2",
+          "os_version": "10.14",
+          "date": "2019-01-14",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "figure role with \"Content caption.\" as the accessible name.",
+              "result": "pass"
+            }
+          ]
+        }
+      }
+    },
+    "vo_ios": {
+      "browsers": {
+        "ios_saf": {
+          "at_version": "12.1",
+          "browser_version": "12.1.2",
+          "os_version": "12.1",
+          "date": "2019-01-14",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "(unknown)",
+              "result": "fail"
+            }
+          ]
+        }
+      }
+    },
+    "talkback": {
+      "browsers": {
+        "and_chr": {
+          "at_version": "7.2",
+          "browser_version": "70",
+          "os_version": "7.2",
+          "date": "2019-01-14",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "(unknown)",
+              "result": "fail"
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/data/tests/tech/html/html_figure/test_11.json
+++ b/data/tests/tech/html/html_figure/test_11.json
@@ -122,7 +122,7 @@
     "talkback": {
       "browsers": {
         "and_chr": {
-          "at_version": "8.1",
+          "at_version": "7.2",
           "browser_version": "70",
           "os_version": "8.1",
           "date": "2019-01-21",

--- a/data/tests/tech/html/html_figure/test_11.json
+++ b/data/tests/tech/html/html_figure/test_11.json
@@ -1,0 +1,140 @@
+{
+  "type": "assertion",
+  "title": "Figure test 11",
+  "description": "This test was originally imported from the article titled '[how do you figure?'](https://www.scottohara.me/blog/2019/01/21/how-do-you-figure.html)' by Scott O'Hara.",
+  "features": [
+    "html/figure_element",
+    "html/figcaption_element"
+  ],
+  "supports_sr": true,
+  "supports_vc": false,
+  "css_target": "#target_11",
+  "html_file": "html_figure_tests.html",
+  "assertion": {
+    "aspect": "role",
+    "value": "figure"
+  },
+  "history": [
+    {
+      "date": "2019-01-21",
+      "message": "Test created. Thank you @scottaohara."
+    }
+  ],
+  "at": {
+    "jaws": {
+      "browsers": {
+        "ie": {
+          "at_version": "2019",
+          "browser_version": "44",
+          "os_version": "1809",
+          "date": "2019-01-14",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "(unknown)",
+              "result": "fail"
+            }
+          ]
+        },
+        "firefox": {
+          "at_version": "2019",
+          "browser_version": "64.0.2",
+          "os_version": "1809",
+          "date": "2019-01-14",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "figure role with no accessible name.",
+              "result": "pass"
+            }
+          ]
+        }
+      }
+    },
+    "narrator": {
+      "browsers": {
+        "edge": {
+          "at_version": "1804",
+          "browser_version": "42",
+          "os_version": "1804",
+          "date": "2019-01-14",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "(unknown)",
+              "result": "fail"
+            }
+          ]
+        }
+      }
+    },
+    "nvda": {
+      "browsers": {
+        "firefox": {
+          "at_version": "2018.4.1",
+          "browser_version": "64.0.2",
+          "os_version": "1809",
+          "date": "2019-01-14",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "(unknown)",
+              "result": "fail"
+            }
+          ]
+        }
+      }
+    },
+    "vo_macos": {
+      "browsers": {
+        "safari": {
+          "at_version": "10.14",
+          "browser_version": "12.0.2",
+          "os_version": "10.14",
+          "date": "2019-01-14",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "(unknown)",
+              "result": "fail"
+            }
+          ]
+        }
+      }
+    },
+    "vo_ios": {
+      "browsers": {
+        "ios_saf": {
+          "at_version": "12.1",
+          "browser_version": "12.1.2",
+          "os_version": "12.1",
+          "date": "2019-01-14",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "(unknown)",
+              "result": "fail"
+            }
+          ]
+        }
+      }
+    },
+    "talkback": {
+      "browsers": {
+        "and_chr": {
+          "at_version": "7.2",
+          "browser_version": "70",
+          "os_version": "7.2",
+          "date": "2019-01-14",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "(unknown)",
+              "result": "fail"
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/data/tests/tech/html/html_figure/test_11.json
+++ b/data/tests/tech/html/html_figure/test_11.json
@@ -25,9 +25,9 @@
       "browsers": {
         "ie": {
           "at_version": "2019",
-          "browser_version": "44",
+          "browser_version": "11",
           "os_version": "1809",
-          "date": "2019-01-14",
+          "date": "2019-01-21",
           "output": [
             {
               "command": "next_item",
@@ -40,7 +40,7 @@
           "at_version": "2019",
           "browser_version": "64.0.2",
           "os_version": "1809",
-          "date": "2019-01-14",
+          "date": "2019-01-21",
           "output": [
             {
               "command": "next_item",
@@ -57,7 +57,7 @@
           "at_version": "1804",
           "browser_version": "42",
           "os_version": "1804",
-          "date": "2019-01-14",
+          "date": "2019-01-21",
           "output": [
             {
               "command": "next_item",
@@ -74,7 +74,7 @@
           "at_version": "2018.4.1",
           "browser_version": "64.0.2",
           "os_version": "1809",
-          "date": "2019-01-14",
+          "date": "2019-01-21",
           "output": [
             {
               "command": "next_item",
@@ -88,10 +88,10 @@
     "vo_macos": {
       "browsers": {
         "safari": {
-          "at_version": "10.14",
+          "at_version": "10.14.2",
           "browser_version": "12.0.2",
-          "os_version": "10.14",
-          "date": "2019-01-14",
+          "os_version": "10.14.2",
+          "date": "2019-01-21",
           "output": [
             {
               "command": "next_item",
@@ -108,7 +108,7 @@
           "at_version": "12.1",
           "browser_version": "12.1.2",
           "os_version": "12.1",
-          "date": "2019-01-14",
+          "date": "2019-01-21",
           "output": [
             {
               "command": "next_item",
@@ -122,10 +122,10 @@
     "talkback": {
       "browsers": {
         "and_chr": {
-          "at_version": "7.2",
+          "at_version": "8.1",
           "browser_version": "70",
-          "os_version": "7.2",
-          "date": "2019-01-14",
+          "os_version": "8.1",
+          "date": "2019-01-21",
           "output": [
             {
               "command": "next_item",

--- a/data/tests/tech/html/html_figure/test_12.json
+++ b/data/tests/tech/html/html_figure/test_12.json
@@ -25,9 +25,9 @@
       "browsers": {
         "ie": {
           "at_version": "2019",
-          "browser_version": "44",
+          "browser_version": "11",
           "os_version": "1809",
-          "date": "2019-01-14",
+          "date": "2019-01-21",
           "output": [
             {
               "command": "next_item",
@@ -40,7 +40,7 @@
           "at_version": "2019",
           "browser_version": "64.0.2",
           "os_version": "1809",
-          "date": "2019-01-14",
+          "date": "2019-01-21",
           "output": [
             {
               "command": "next_item",
@@ -57,7 +57,7 @@
           "at_version": "1804",
           "browser_version": "42",
           "os_version": "1804",
-          "date": "2019-01-14",
+          "date": "2019-01-21",
           "output": [
             {
               "command": "next_item",
@@ -75,7 +75,7 @@
           "at_version": "2018.4.1",
           "browser_version": "64.0.2",
           "os_version": "1809",
-          "date": "2019-01-14",
+          "date": "2019-01-21",
           "output": [
             {
               "command": "next_item",
@@ -89,10 +89,10 @@
     "vo_macos": {
       "browsers": {
         "safari": {
-          "at_version": "10.14",
+          "at_version": "10.14.2",
           "browser_version": "12.0.2",
-          "os_version": "10.14",
-          "date": "2019-01-14",
+          "os_version": "10.14.2",
+          "date": "2019-01-21",
           "output": [
             {
               "command": "next_item",
@@ -109,7 +109,7 @@
           "at_version": "12.1",
           "browser_version": "12.1.2",
           "os_version": "12.1",
-          "date": "2019-01-14",
+          "date": "2019-01-21",
           "output": [
             {
               "command": "next_item",
@@ -123,10 +123,10 @@
     "talkback": {
       "browsers": {
         "and_chr": {
-          "at_version": "7.2",
+          "at_version": "8.1",
           "browser_version": "70",
-          "os_version": "7.2",
-          "date": "2019-01-14",
+          "os_version": "8.1",
+          "date": "2019-01-21",
           "output": [
             {
               "command": "next_item",

--- a/data/tests/tech/html/html_figure/test_12.json
+++ b/data/tests/tech/html/html_figure/test_12.json
@@ -123,7 +123,7 @@
     "talkback": {
       "browsers": {
         "and_chr": {
-          "at_version": "8.1",
+          "at_version": "7.2",
           "browser_version": "70",
           "os_version": "8.1",
           "date": "2019-01-21",

--- a/data/tests/tech/html/html_figure/test_12.json
+++ b/data/tests/tech/html/html_figure/test_12.json
@@ -1,0 +1,141 @@
+{
+  "type": "assertion",
+  "title": "Figure test 12",
+  "description": "This test was originally imported from the article titled '[how do you figure?'](https://www.scottohara.me/blog/2019/01/21/how-do-you-figure.html)' by Scott O'Hara.",
+  "features": [
+    "html/figure_element",
+    "html/figcaption_element"
+  ],
+  "supports_sr": true,
+  "supports_vc": false,
+  "css_target": "#target_12",
+  "html_file": "html_figure_tests.html",
+  "assertion": {
+    "aspect": "role",
+    "value": "figure"
+  },
+  "history": [
+    {
+      "date": "2019-01-21",
+      "message": "Test created. Thank you @scottaohara."
+    }
+  ],
+  "at": {
+    "jaws": {
+      "browsers": {
+        "ie": {
+          "at_version": "2019",
+          "browser_version": "44",
+          "os_version": "1809",
+          "date": "2019-01-14",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "(unknown)",
+              "result": "fail"
+            }
+          ]
+        },
+        "firefox": {
+          "at_version": "2019",
+          "browser_version": "64.0.2",
+          "os_version": "1809",
+          "date": "2019-01-14",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "figure role with \"ARIA label\" as the accessible name.",
+              "result": "pass"
+            }
+          ]
+        }
+      }
+    },
+    "narrator": {
+      "browsers": {
+        "edge": {
+          "at_version": "1804",
+          "browser_version": "42",
+          "os_version": "1804",
+          "date": "2019-01-14",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "(unknown)",
+              "result": "partial"
+            }
+          ],
+          "notes": "no announced role, but relationship made"
+        }
+      }
+    },
+    "nvda": {
+      "browsers": {
+        "firefox": {
+          "at_version": "2018.4.1",
+          "browser_version": "64.0.2",
+          "os_version": "1809",
+          "date": "2019-01-14",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "(unknown)",
+              "result": "fail"
+            }
+          ]
+        }
+      }
+    },
+    "vo_macos": {
+      "browsers": {
+        "safari": {
+          "at_version": "10.14",
+          "browser_version": "12.0.2",
+          "os_version": "10.14",
+          "date": "2019-01-14",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "figure role with \"ARIA label\" as the accessible name.",
+              "result": "pass"
+            }
+          ]
+        }
+      }
+    },
+    "vo_ios": {
+      "browsers": {
+        "ios_saf": {
+          "at_version": "12.1",
+          "browser_version": "12.1.2",
+          "os_version": "12.1",
+          "date": "2019-01-14",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "(unknown)",
+              "result": "fail"
+            }
+          ]
+        }
+      }
+    },
+    "talkback": {
+      "browsers": {
+        "and_chr": {
+          "at_version": "7.2",
+          "browser_version": "70",
+          "os_version": "7.2",
+          "date": "2019-01-14",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "(unknown)",
+              "result": "fail"
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/data/tests/tech/html/html_figure/test_2.json
+++ b/data/tests/tech/html/html_figure/test_2.json
@@ -25,9 +25,9 @@
       "browsers": {
         "ie": {
           "at_version": "2019",
-          "browser_version": "44",
+          "browser_version": "11",
           "os_version": "1809",
-          "date": "2019-01-14",
+          "date": "2019-01-21",
           "output": [
             {
               "command": "next_item",
@@ -40,7 +40,7 @@
           "at_version": "2019",
           "browser_version": "64.0.2",
           "os_version": "1809",
-          "date": "2019-01-14",
+          "date": "2019-01-21",
           "output": [
             {
               "command": "next_item",
@@ -57,7 +57,7 @@
           "at_version": "1804",
           "browser_version": "42",
           "os_version": "1804",
-          "date": "2019-01-14",
+          "date": "2019-01-21",
           "output": [
             {
               "command": "next_item",
@@ -75,7 +75,7 @@
           "at_version": "2018.4.1",
           "browser_version": "64.0.2",
           "os_version": "1809",
-          "date": "2019-01-14",
+          "date": "2019-01-21",
           "output": [
             {
               "command": "next_item",
@@ -89,10 +89,10 @@
     "vo_macos": {
       "browsers": {
         "safari": {
-          "at_version": "10.14",
+          "at_version": "10.14.2",
           "browser_version": "12.0.2",
-          "os_version": "10.14",
-          "date": "2019-01-14",
+          "os_version": "10.14.2",
+          "date": "2019-01-21",
           "output": [
             {
               "command": "next_item",
@@ -109,7 +109,7 @@
           "at_version": "12.1",
           "browser_version": "12.1.2",
           "os_version": "12.1",
-          "date": "2019-01-14",
+          "date": "2019-01-21",
           "output": [
             {
               "command": "next_item",
@@ -123,10 +123,10 @@
     "talkback": {
       "browsers": {
         "and_chr": {
-          "at_version": "7.2",
+          "at_version": "8.1",
           "browser_version": "70",
-          "os_version": "7.2",
-          "date": "2019-01-14",
+          "os_version": "8.1",
+          "date": "2019-01-21",
           "output": [
             {
               "command": "next_item",

--- a/data/tests/tech/html/html_figure/test_2.json
+++ b/data/tests/tech/html/html_figure/test_2.json
@@ -123,7 +123,7 @@
     "talkback": {
       "browsers": {
         "and_chr": {
-          "at_version": "8.1",
+          "at_version": "7.2",
           "browser_version": "70",
           "os_version": "8.1",
           "date": "2019-01-21",

--- a/data/tests/tech/html/html_figure/test_2.json
+++ b/data/tests/tech/html/html_figure/test_2.json
@@ -1,0 +1,141 @@
+{
+  "type": "assertion",
+  "title": "Figure test 2",
+  "description": "This test was originally imported from the article titled '[how do you figure?'](https://www.scottohara.me/blog/2019/01/21/how-do-you-figure.html)' by Scott O'Hara.",
+  "features": [
+    "html/figure_element",
+    "html/figcaption_element"
+  ],
+  "supports_sr": true,
+  "supports_vc": false,
+  "css_target": "#target_2",
+  "html_file": "html_figure_tests.html",
+  "assertion": {
+    "aspect": "role",
+    "value": "figure"
+  },
+  "history": [
+    {
+      "date": "2019-01-21",
+      "message": "Test created. Thank you @scottaohara."
+    }
+  ],
+  "at": {
+    "jaws": {
+      "browsers": {
+        "ie": {
+          "at_version": "2019",
+          "browser_version": "44",
+          "os_version": "1809",
+          "date": "2019-01-14",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "(unknown)",
+              "result": "fail"
+            }
+          ]
+        },
+        "firefox": {
+          "at_version": "2019",
+          "browser_version": "64.0.2",
+          "os_version": "1809",
+          "date": "2019-01-14",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "Note: Image \"should\" be ignored.",
+              "result": "pass"
+            }
+          ]
+        }
+      }
+    },
+    "narrator": {
+      "browsers": {
+        "edge": {
+          "at_version": "1804",
+          "browser_version": "42",
+          "os_version": "1804",
+          "date": "2019-01-14",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "(unknown)",
+              "result": "fail"
+            }
+          ],
+          "notes": "fail (all content ignored!)"
+        }
+      }
+    },
+    "nvda": {
+      "browsers": {
+        "firefox": {
+          "at_version": "2018.4.1",
+          "browser_version": "64.0.2",
+          "os_version": "1809",
+          "date": "2019-01-14",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "(unknown)",
+              "result": "fail"
+            }
+          ]
+        }
+      }
+    },
+    "vo_macos": {
+      "browsers": {
+        "safari": {
+          "at_version": "10.14",
+          "browser_version": "12.0.2",
+          "os_version": "10.14",
+          "date": "2019-01-14",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "Note: Image \"should\" be ignored.",
+              "result": "pass"
+            }
+          ]
+        }
+      }
+    },
+    "vo_ios": {
+      "browsers": {
+        "ios_saf": {
+          "at_version": "12.1",
+          "browser_version": "12.1.2",
+          "os_version": "12.1",
+          "date": "2019-01-14",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "(unknown)",
+              "result": "fail"
+            }
+          ]
+        }
+      }
+    },
+    "talkback": {
+      "browsers": {
+        "and_chr": {
+          "at_version": "7.2",
+          "browser_version": "70",
+          "os_version": "7.2",
+          "date": "2019-01-14",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "(unknown)",
+              "result": "fail"
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/data/tests/tech/html/html_figure/test_3.json
+++ b/data/tests/tech/html/html_figure/test_3.json
@@ -25,9 +25,9 @@
       "browsers": {
         "ie": {
           "at_version": "2019",
-          "browser_version": "44",
+          "browser_version": "11",
           "os_version": "1809",
-          "date": "2019-01-14",
+          "date": "2019-01-21",
           "output": [
             {
               "command": "next_item",
@@ -40,7 +40,7 @@
           "at_version": "2019",
           "browser_version": "64.0.2",
           "os_version": "1809",
-          "date": "2019-01-14",
+          "date": "2019-01-21",
           "output": [
             {
               "command": "next_item",
@@ -57,7 +57,7 @@
           "at_version": "1804",
           "browser_version": "42",
           "os_version": "1804",
-          "date": "2019-01-14",
+          "date": "2019-01-21",
           "output": [
             {
               "command": "next_item",
@@ -75,7 +75,7 @@
           "at_version": "2018.4.1",
           "browser_version": "64.0.2",
           "os_version": "1809",
-          "date": "2019-01-14",
+          "date": "2019-01-21",
           "output": [
             {
               "command": "next_item",
@@ -89,10 +89,10 @@
     "vo_macos": {
       "browsers": {
         "safari": {
-          "at_version": "10.14",
+          "at_version": "10.14.2",
           "browser_version": "12.0.2",
-          "os_version": "10.14",
-          "date": "2019-01-14",
+          "os_version": "10.14.2",
+          "date": "2019-01-21",
           "output": [
             {
               "command": "next_item",
@@ -109,7 +109,7 @@
           "at_version": "12.1",
           "browser_version": "12.1.2",
           "os_version": "12.1",
-          "date": "2019-01-14",
+          "date": "2019-01-21",
           "output": [
             {
               "command": "next_item",
@@ -123,10 +123,10 @@
     "talkback": {
       "browsers": {
         "and_chr": {
-          "at_version": "7.2",
+          "at_version": "8.1",
           "browser_version": "70",
-          "os_version": "7.2",
-          "date": "2019-01-14",
+          "os_version": "8.1",
+          "date": "2019-01-21",
           "output": [
             {
               "command": "next_item",

--- a/data/tests/tech/html/html_figure/test_3.json
+++ b/data/tests/tech/html/html_figure/test_3.json
@@ -123,7 +123,7 @@
     "talkback": {
       "browsers": {
         "and_chr": {
-          "at_version": "8.1",
+          "at_version": "7.2",
           "browser_version": "70",
           "os_version": "8.1",
           "date": "2019-01-21",

--- a/data/tests/tech/html/html_figure/test_3.json
+++ b/data/tests/tech/html/html_figure/test_3.json
@@ -1,0 +1,141 @@
+{
+  "type": "assertion",
+  "title": "Figure test 3",
+  "description": "This test was originally imported from the article titled '[how do you figure?'](https://www.scottohara.me/blog/2019/01/21/how-do-you-figure.html)' by Scott O'Hara.",
+  "features": [
+    "html/figure_element",
+    "html/figcaption_element"
+  ],
+  "supports_sr": true,
+  "supports_vc": false,
+  "css_target": "#target_3",
+  "html_file": "html_figure_tests.html",
+  "assertion": {
+    "aspect": "role",
+    "value": "figure"
+  },
+  "history": [
+    {
+      "date": "2019-01-21",
+      "message": "Test created. Thank you @scottaohara."
+    }
+  ],
+  "at": {
+    "jaws": {
+      "browsers": {
+        "ie": {
+          "at_version": "2019",
+          "browser_version": "44",
+          "os_version": "1809",
+          "date": "2019-01-14",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "(unknown)",
+              "result": "fail"
+            }
+          ]
+        },
+        "firefox": {
+          "at_version": "2019",
+          "browser_version": "64.0.2",
+          "os_version": "1809",
+          "date": "2019-01-14",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "Note: Image should be ignored.",
+              "result": "pass"
+            }
+          ]
+        }
+      }
+    },
+    "narrator": {
+      "browsers": {
+        "edge": {
+          "at_version": "1804",
+          "browser_version": "42",
+          "os_version": "1804",
+          "date": "2019-01-14",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "(unknown)",
+              "result": "partial"
+            }
+          ],
+          "notes": "no announced role, but relationship made"
+        }
+      }
+    },
+    "nvda": {
+      "browsers": {
+        "firefox": {
+          "at_version": "2018.4.1",
+          "browser_version": "64.0.2",
+          "os_version": "1809",
+          "date": "2019-01-14",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "(unknown)",
+              "result": "fail"
+            }
+          ]
+        }
+      }
+    },
+    "vo_macos": {
+      "browsers": {
+        "safari": {
+          "at_version": "10.14",
+          "browser_version": "12.0.2",
+          "os_version": "10.14",
+          "date": "2019-01-14",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "Note: Image should be ignored.",
+              "result": "pass"
+            }
+          ]
+        }
+      }
+    },
+    "vo_ios": {
+      "browsers": {
+        "ios_saf": {
+          "at_version": "12.1",
+          "browser_version": "12.1.2",
+          "os_version": "12.1",
+          "date": "2019-01-14",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "(unknown)",
+              "result": "fail"
+            }
+          ]
+        }
+      }
+    },
+    "talkback": {
+      "browsers": {
+        "and_chr": {
+          "at_version": "7.2",
+          "browser_version": "70",
+          "os_version": "7.2",
+          "date": "2019-01-14",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "(unknown)",
+              "result": "fail"
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/data/tests/tech/html/html_figure/test_4.json
+++ b/data/tests/tech/html/html_figure/test_4.json
@@ -25,9 +25,9 @@
       "browsers": {
         "ie": {
           "at_version": "2019",
-          "browser_version": "44",
+          "browser_version": "11",
           "os_version": "1809",
-          "date": "2019-01-14",
+          "date": "2019-01-21",
           "output": [
             {
               "command": "next_item",
@@ -40,7 +40,7 @@
           "at_version": "2019",
           "browser_version": "64.0.2",
           "os_version": "1809",
-          "date": "2019-01-14",
+          "date": "2019-01-21",
           "output": [
             {
               "command": "next_item",
@@ -57,7 +57,7 @@
           "at_version": "1804",
           "browser_version": "42",
           "os_version": "1804",
-          "date": "2019-01-14",
+          "date": "2019-01-21",
           "output": [
             {
               "command": "next_item",
@@ -75,7 +75,7 @@
           "at_version": "2018.4.1",
           "browser_version": "64.0.2",
           "os_version": "1809",
-          "date": "2019-01-14",
+          "date": "2019-01-21",
           "output": [
             {
               "command": "next_item",
@@ -89,10 +89,10 @@
     "vo_macos": {
       "browsers": {
         "safari": {
-          "at_version": "10.14",
+          "at_version": "10.14.2",
           "browser_version": "12.0.2",
-          "os_version": "10.14",
-          "date": "2019-01-14",
+          "os_version": "10.14.2",
+          "date": "2019-01-21",
           "output": [
             {
               "command": "next_item",
@@ -109,7 +109,7 @@
           "at_version": "12.1",
           "browser_version": "12.1.2",
           "os_version": "12.1",
-          "date": "2019-01-14",
+          "date": "2019-01-21",
           "output": [
             {
               "command": "next_item",
@@ -123,10 +123,10 @@
     "talkback": {
       "browsers": {
         "and_chr": {
-          "at_version": "7.2",
+          "at_version": "8.1",
           "browser_version": "70",
-          "os_version": "7.2",
-          "date": "2019-01-14",
+          "os_version": "8.1",
+          "date": "2019-01-21",
           "output": [
             {
               "command": "next_item",

--- a/data/tests/tech/html/html_figure/test_4.json
+++ b/data/tests/tech/html/html_figure/test_4.json
@@ -123,7 +123,7 @@
     "talkback": {
       "browsers": {
         "and_chr": {
-          "at_version": "8.1",
+          "at_version": "7.2",
           "browser_version": "70",
           "os_version": "8.1",
           "date": "2019-01-21",

--- a/data/tests/tech/html/html_figure/test_4.json
+++ b/data/tests/tech/html/html_figure/test_4.json
@@ -1,0 +1,141 @@
+{
+  "type": "assertion",
+  "title": "Figure test 4",
+  "description": "This test was originally imported from the article titled '[how do you figure?'](https://www.scottohara.me/blog/2019/01/21/how-do-you-figure.html)' by Scott O'Hara.",
+  "features": [
+    "html/figure_element",
+    "html/figcaption_element"
+  ],
+  "supports_sr": true,
+  "supports_vc": false,
+  "css_target": "#target_4",
+  "html_file": "html_figure_tests.html",
+  "assertion": {
+    "aspect": "role",
+    "value": "figure"
+  },
+  "history": [
+    {
+      "date": "2019-01-21",
+      "message": "Test created. Thank you @scottaohara."
+    }
+  ],
+  "at": {
+    "jaws": {
+      "browsers": {
+        "ie": {
+          "at_version": "2019",
+          "browser_version": "44",
+          "os_version": "1809",
+          "date": "2019-01-14",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "(unknown)",
+              "result": "fail"
+            }
+          ]
+        },
+        "firefox": {
+          "at_version": "2019",
+          "browser_version": "64.0.2",
+          "os_version": "1809",
+          "date": "2019-01-14",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "figure role with \"ARIA label\" as the accessible name.",
+              "result": "pass"
+            }
+          ]
+        }
+      }
+    },
+    "narrator": {
+      "browsers": {
+        "edge": {
+          "at_version": "1804",
+          "browser_version": "42",
+          "os_version": "1804",
+          "date": "2019-01-14",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "(unknown)",
+              "result": "partial"
+            }
+          ],
+          "notes": "no announced role, but relationship made"
+        }
+      }
+    },
+    "nvda": {
+      "browsers": {
+        "firefox": {
+          "at_version": "2018.4.1",
+          "browser_version": "64.0.2",
+          "os_version": "1809",
+          "date": "2019-01-14",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "(unknown)",
+              "result": "fail"
+            }
+          ]
+        }
+      }
+    },
+    "vo_macos": {
+      "browsers": {
+        "safari": {
+          "at_version": "10.14",
+          "browser_version": "12.0.2",
+          "os_version": "10.14",
+          "date": "2019-01-14",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "figure role with \"ARIA label\" as the accessible name.",
+              "result": "pass"
+            }
+          ]
+        }
+      }
+    },
+    "vo_ios": {
+      "browsers": {
+        "ios_saf": {
+          "at_version": "12.1",
+          "browser_version": "12.1.2",
+          "os_version": "12.1",
+          "date": "2019-01-14",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "(unknown)",
+              "result": "fail"
+            }
+          ]
+        }
+      }
+    },
+    "talkback": {
+      "browsers": {
+        "and_chr": {
+          "at_version": "7.2",
+          "browser_version": "70",
+          "os_version": "7.2",
+          "date": "2019-01-14",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "(unknown)",
+              "result": "fail"
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/data/tests/tech/html/html_figure/test_5.json
+++ b/data/tests/tech/html/html_figure/test_5.json
@@ -122,7 +122,7 @@
     "talkback": {
       "browsers": {
         "and_chr": {
-          "at_version": "8.1",
+          "at_version": "7.2",
           "browser_version": "70",
           "os_version": "8.1",
           "date": "2019-01-21",

--- a/data/tests/tech/html/html_figure/test_5.json
+++ b/data/tests/tech/html/html_figure/test_5.json
@@ -25,9 +25,9 @@
       "browsers": {
         "ie": {
           "at_version": "2019",
-          "browser_version": "44",
+          "browser_version": "11",
           "os_version": "1809",
-          "date": "2019-01-14",
+          "date": "2019-01-21",
           "output": [
             {
               "command": "next_item",
@@ -40,7 +40,7 @@
           "at_version": "2019",
           "browser_version": "64.0.2",
           "os_version": "1809",
-          "date": "2019-01-14",
+          "date": "2019-01-21",
           "output": [
             {
               "command": "next_item",
@@ -57,7 +57,7 @@
           "at_version": "1804",
           "browser_version": "42",
           "os_version": "1804",
-          "date": "2019-01-14",
+          "date": "2019-01-21",
           "output": [
             {
               "command": "next_item",
@@ -74,7 +74,7 @@
           "at_version": "2018.4.1",
           "browser_version": "64.0.2",
           "os_version": "1809",
-          "date": "2019-01-14",
+          "date": "2019-01-21",
           "output": [
             {
               "command": "next_item",
@@ -88,10 +88,10 @@
     "vo_macos": {
       "browsers": {
         "safari": {
-          "at_version": "10.14",
+          "at_version": "10.14.2",
           "browser_version": "12.0.2",
-          "os_version": "10.14",
-          "date": "2019-01-14",
+          "os_version": "10.14.2",
+          "date": "2019-01-21",
           "output": [
             {
               "command": "next_item",
@@ -108,7 +108,7 @@
           "at_version": "12.1",
           "browser_version": "12.1.2",
           "os_version": "12.1",
-          "date": "2019-01-14",
+          "date": "2019-01-21",
           "output": [
             {
               "command": "next_item",
@@ -122,10 +122,10 @@
     "talkback": {
       "browsers": {
         "and_chr": {
-          "at_version": "7.2",
+          "at_version": "8.1",
           "browser_version": "70",
-          "os_version": "7.2",
-          "date": "2019-01-14",
+          "os_version": "8.1",
+          "date": "2019-01-21",
           "output": [
             {
               "command": "next_item",

--- a/data/tests/tech/html/html_figure/test_5.json
+++ b/data/tests/tech/html/html_figure/test_5.json
@@ -1,0 +1,140 @@
+{
+  "type": "assertion",
+  "title": "Figure test 5",
+  "description": "This test was originally imported from the article titled '[how do you figure?'](https://www.scottohara.me/blog/2019/01/21/how-do-you-figure.html)' by Scott O'Hara.",
+  "features": [
+    "html/figure_element",
+    "html/figcaption_element"
+  ],
+  "supports_sr": true,
+  "supports_vc": false,
+  "css_target": "#target_5",
+  "html_file": "html_figure_tests.html",
+  "assertion": {
+    "aspect": "role",
+    "value": "figure"
+  },
+  "history": [
+    {
+      "date": "2019-01-21",
+      "message": "Test created. Thank you @scottaohara."
+    }
+  ],
+  "at": {
+    "jaws": {
+      "browsers": {
+        "ie": {
+          "at_version": "2019",
+          "browser_version": "44",
+          "os_version": "1809",
+          "date": "2019-01-14",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "(unknown)",
+              "result": "fail"
+            }
+          ]
+        },
+        "firefox": {
+          "at_version": "2019",
+          "browser_version": "64.0.2",
+          "os_version": "1809",
+          "date": "2019-01-14",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "figure role with no accessible name.",
+              "result": "pass"
+            }
+          ]
+        }
+      }
+    },
+    "narrator": {
+      "browsers": {
+        "edge": {
+          "at_version": "1804",
+          "browser_version": "42",
+          "os_version": "1804",
+          "date": "2019-01-14",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "(unknown)",
+              "result": "fail"
+            }
+          ]
+        }
+      }
+    },
+    "nvda": {
+      "browsers": {
+        "firefox": {
+          "at_version": "2018.4.1",
+          "browser_version": "64.0.2",
+          "os_version": "1809",
+          "date": "2019-01-14",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "(unknown)",
+              "result": "fail"
+            }
+          ]
+        }
+      }
+    },
+    "vo_macos": {
+      "browsers": {
+        "safari": {
+          "at_version": "10.14",
+          "browser_version": "12.0.2",
+          "os_version": "10.14",
+          "date": "2019-01-14",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "(unknown)",
+              "result": "fail"
+            }
+          ]
+        }
+      }
+    },
+    "vo_ios": {
+      "browsers": {
+        "ios_saf": {
+          "at_version": "12.1",
+          "browser_version": "12.1.2",
+          "os_version": "12.1",
+          "date": "2019-01-14",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "(unknown)",
+              "result": "fail"
+            }
+          ]
+        }
+      }
+    },
+    "talkback": {
+      "browsers": {
+        "and_chr": {
+          "at_version": "7.2",
+          "browser_version": "70",
+          "os_version": "7.2",
+          "date": "2019-01-14",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "(unknown)",
+              "result": "fail"
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/data/tests/tech/html/html_figure/test_6.json
+++ b/data/tests/tech/html/html_figure/test_6.json
@@ -25,9 +25,9 @@
       "browsers": {
         "ie": {
           "at_version": "2019",
-          "browser_version": "44",
+          "browser_version": "11",
           "os_version": "1809",
-          "date": "2019-01-14",
+          "date": "2019-01-21",
           "output": [
             {
               "command": "next_item",
@@ -40,7 +40,7 @@
           "at_version": "2019",
           "browser_version": "64.0.2",
           "os_version": "1809",
-          "date": "2019-01-14",
+          "date": "2019-01-21",
           "output": [
             {
               "command": "next_item",
@@ -57,7 +57,7 @@
           "at_version": "1804",
           "browser_version": "42",
           "os_version": "1804",
-          "date": "2019-01-14",
+          "date": "2019-01-21",
           "output": [
             {
               "command": "next_item",
@@ -75,7 +75,7 @@
           "at_version": "2018.4.1",
           "browser_version": "64.0.2",
           "os_version": "1809",
-          "date": "2019-01-14",
+          "date": "2019-01-21",
           "output": [
             {
               "command": "next_item",
@@ -89,10 +89,10 @@
     "vo_macos": {
       "browsers": {
         "safari": {
-          "at_version": "10.14",
+          "at_version": "10.14.2",
           "browser_version": "12.0.2",
-          "os_version": "10.14",
-          "date": "2019-01-14",
+          "os_version": "10.14.2",
+          "date": "2019-01-21",
           "output": [
             {
               "command": "next_item",
@@ -109,7 +109,7 @@
           "at_version": "12.1",
           "browser_version": "12.1.2",
           "os_version": "12.1",
-          "date": "2019-01-14",
+          "date": "2019-01-21",
           "output": [
             {
               "command": "next_item",
@@ -123,10 +123,10 @@
     "talkback": {
       "browsers": {
         "and_chr": {
-          "at_version": "7.2",
+          "at_version": "8.1",
           "browser_version": "70",
-          "os_version": "7.2",
-          "date": "2019-01-14",
+          "os_version": "8.1",
+          "date": "2019-01-21",
           "output": [
             {
               "command": "next_item",

--- a/data/tests/tech/html/html_figure/test_6.json
+++ b/data/tests/tech/html/html_figure/test_6.json
@@ -123,7 +123,7 @@
     "talkback": {
       "browsers": {
         "and_chr": {
-          "at_version": "8.1",
+          "at_version": "7.2",
           "browser_version": "70",
           "os_version": "8.1",
           "date": "2019-01-21",

--- a/data/tests/tech/html/html_figure/test_6.json
+++ b/data/tests/tech/html/html_figure/test_6.json
@@ -1,0 +1,141 @@
+{
+  "type": "assertion",
+  "title": "Figure test 6",
+  "description": "This test was originally imported from the article titled '[how do you figure?'](https://www.scottohara.me/blog/2019/01/21/how-do-you-figure.html)' by Scott O'Hara.",
+  "features": [
+    "html/figure_element",
+    "html/figcaption_element"
+  ],
+  "supports_sr": true,
+  "supports_vc": false,
+  "css_target": "#target_6",
+  "html_file": "html_figure_tests.html",
+  "assertion": {
+    "aspect": "role",
+    "value": "figure"
+  },
+  "history": [
+    {
+      "date": "2019-01-21",
+      "message": "Test created. Thank you @scottaohara."
+    }
+  ],
+  "at": {
+    "jaws": {
+      "browsers": {
+        "ie": {
+          "at_version": "2019",
+          "browser_version": "44",
+          "os_version": "1809",
+          "date": "2019-01-14",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "(unknown)",
+              "result": "fail"
+            }
+          ]
+        },
+        "firefox": {
+          "at_version": "2019",
+          "browser_version": "64.0.2",
+          "os_version": "1809",
+          "date": "2019-01-14",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "figure role with \"Content caption\" as the accessible name.",
+              "result": "pass"
+            }
+          ]
+        }
+      }
+    },
+    "narrator": {
+      "browsers": {
+        "edge": {
+          "at_version": "1804",
+          "browser_version": "42",
+          "os_version": "1804",
+          "date": "2019-01-14",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "(unknown)",
+              "result": "partial"
+            }
+          ],
+          "notes": "no announced role, but relationship made"
+        }
+      }
+    },
+    "nvda": {
+      "browsers": {
+        "firefox": {
+          "at_version": "2018.4.1",
+          "browser_version": "64.0.2",
+          "os_version": "1809",
+          "date": "2019-01-14",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "(unknown)",
+              "result": "fail"
+            }
+          ]
+        }
+      }
+    },
+    "vo_macos": {
+      "browsers": {
+        "safari": {
+          "at_version": "10.14",
+          "browser_version": "12.0.2",
+          "os_version": "10.14",
+          "date": "2019-01-14",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "figure role with \"Content caption\" as the accessible name.",
+              "result": "pass"
+            }
+          ]
+        }
+      }
+    },
+    "vo_ios": {
+      "browsers": {
+        "ios_saf": {
+          "at_version": "12.1",
+          "browser_version": "12.1.2",
+          "os_version": "12.1",
+          "date": "2019-01-14",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "(unknown)",
+              "result": "fail"
+            }
+          ]
+        }
+      }
+    },
+    "talkback": {
+      "browsers": {
+        "and_chr": {
+          "at_version": "7.2",
+          "browser_version": "70",
+          "os_version": "7.2",
+          "date": "2019-01-14",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "(unknown)",
+              "result": "fail"
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/data/tests/tech/html/html_figure/test_7.json
+++ b/data/tests/tech/html/html_figure/test_7.json
@@ -25,9 +25,9 @@
       "browsers": {
         "ie": {
           "at_version": "2019",
-          "browser_version": "44",
+          "browser_version": "11",
           "os_version": "1809",
-          "date": "2019-01-14",
+          "date": "2019-01-21",
           "output": [
             {
               "command": "next_item",
@@ -41,7 +41,7 @@
           "at_version": "2019",
           "browser_version": "64.0.2",
           "os_version": "1809",
-          "date": "2019-01-14",
+          "date": "2019-01-21",
           "output": [
             {
               "command": "next_item",
@@ -58,7 +58,7 @@
           "at_version": "1804",
           "browser_version": "42",
           "os_version": "1804",
-          "date": "2019-01-14",
+          "date": "2019-01-21",
           "output": [
             {
               "command": "next_item",
@@ -76,7 +76,7 @@
           "at_version": "2018.4.1",
           "browser_version": "64.0.2",
           "os_version": "1809",
-          "date": "2019-01-14",
+          "date": "2019-01-21",
           "output": [
             {
               "command": "next_item",
@@ -90,10 +90,10 @@
     "vo_macos": {
       "browsers": {
         "safari": {
-          "at_version": "10.14",
+          "at_version": "10.14.2",
           "browser_version": "12.0.2",
-          "os_version": "10.14",
-          "date": "2019-01-14",
+          "os_version": "10.14.2",
+          "date": "2019-01-21",
           "output": [
             {
               "command": "next_item",
@@ -110,7 +110,7 @@
           "at_version": "12.1",
           "browser_version": "12.1.2",
           "os_version": "12.1",
-          "date": "2019-01-14",
+          "date": "2019-01-21",
           "output": [
             {
               "command": "next_item",
@@ -124,10 +124,10 @@
     "talkback": {
       "browsers": {
         "and_chr": {
-          "at_version": "7.2",
+          "at_version": "8.1",
           "browser_version": "70",
-          "os_version": "7.2",
-          "date": "2019-01-14",
+          "os_version": "8.1",
+          "date": "2019-01-21",
           "output": [
             {
               "command": "next_item",

--- a/data/tests/tech/html/html_figure/test_7.json
+++ b/data/tests/tech/html/html_figure/test_7.json
@@ -1,0 +1,142 @@
+{
+  "type": "assertion",
+  "title": "Figure test 7",
+  "description": "This test was originally imported from the article titled '[how do you figure?'](https://www.scottohara.me/blog/2019/01/21/how-do-you-figure.html)' by Scott O'Hara.",
+  "features": [
+    "html/figure_element",
+    "html/figcaption_element"
+  ],
+  "supports_sr": true,
+  "supports_vc": false,
+  "css_target": "#target_7",
+  "html_file": "html_figure_tests.html",
+  "assertion": {
+    "aspect": "role",
+    "value": "figure"
+  },
+  "history": [
+    {
+      "date": "2019-01-21",
+      "message": "Test created. Thank you @scottaohara."
+    }
+  ],
+  "at": {
+    "jaws": {
+      "browsers": {
+        "ie": {
+          "at_version": "2019",
+          "browser_version": "44",
+          "os_version": "1809",
+          "date": "2019-01-14",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "(unknown)",
+              "result": "fail"
+            }
+          ],
+          "notes": "fail (figure exposed but no accessible name)"
+        },
+        "firefox": {
+          "at_version": "2019",
+          "browser_version": "64.0.2",
+          "os_version": "1809",
+          "date": "2019-01-14",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "figure role with \"Content caption\" as the accessible name.",
+              "result": "pass"
+            }
+          ]
+        }
+      }
+    },
+    "narrator": {
+      "browsers": {
+        "edge": {
+          "at_version": "1804",
+          "browser_version": "42",
+          "os_version": "1804",
+          "date": "2019-01-14",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "(unknown)",
+              "result": "partial"
+            }
+          ],
+          "notes": "no announced role, but relationship made"
+        }
+      }
+    },
+    "nvda": {
+      "browsers": {
+        "firefox": {
+          "at_version": "2018.4.1",
+          "browser_version": "64.0.2",
+          "os_version": "1809",
+          "date": "2019-01-14",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "(unknown)",
+              "result": "fail"
+            }
+          ]
+        }
+      }
+    },
+    "vo_macos": {
+      "browsers": {
+        "safari": {
+          "at_version": "10.14",
+          "browser_version": "12.0.2",
+          "os_version": "10.14",
+          "date": "2019-01-14",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "figure role with \"Content caption\" as the accessible name.",
+              "result": "pass"
+            }
+          ]
+        }
+      }
+    },
+    "vo_ios": {
+      "browsers": {
+        "ios_saf": {
+          "at_version": "12.1",
+          "browser_version": "12.1.2",
+          "os_version": "12.1",
+          "date": "2019-01-14",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "(unknown)",
+              "result": "fail"
+            }
+          ]
+        }
+      }
+    },
+    "talkback": {
+      "browsers": {
+        "and_chr": {
+          "at_version": "7.2",
+          "browser_version": "70",
+          "os_version": "7.2",
+          "date": "2019-01-14",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "(unknown)",
+              "result": "fail"
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/data/tests/tech/html/html_figure/test_7.json
+++ b/data/tests/tech/html/html_figure/test_7.json
@@ -124,7 +124,7 @@
     "talkback": {
       "browsers": {
         "and_chr": {
-          "at_version": "8.1",
+          "at_version": "7.2",
           "browser_version": "70",
           "os_version": "8.1",
           "date": "2019-01-21",

--- a/data/tests/tech/html/html_figure/test_8.json
+++ b/data/tests/tech/html/html_figure/test_8.json
@@ -25,9 +25,9 @@
       "browsers": {
         "ie": {
           "at_version": "2019",
-          "browser_version": "44",
+          "browser_version": "11",
           "os_version": "1809",
-          "date": "2019-01-14",
+          "date": "2019-01-21",
           "output": [
             {
               "command": "next_item",
@@ -40,7 +40,7 @@
           "at_version": "2019",
           "browser_version": "64.0.2",
           "os_version": "1809",
-          "date": "2019-01-14",
+          "date": "2019-01-21",
           "output": [
             {
               "command": "next_item",
@@ -57,7 +57,7 @@
           "at_version": "1804",
           "browser_version": "42",
           "os_version": "1804",
-          "date": "2019-01-14",
+          "date": "2019-01-21",
           "output": [
             {
               "command": "next_item",
@@ -75,7 +75,7 @@
           "at_version": "2018.4.1",
           "browser_version": "64.0.2",
           "os_version": "1809",
-          "date": "2019-01-14",
+          "date": "2019-01-21",
           "output": [
             {
               "command": "next_item",
@@ -89,10 +89,10 @@
     "vo_macos": {
       "browsers": {
         "safari": {
-          "at_version": "10.14",
+          "at_version": "10.14.2",
           "browser_version": "12.0.2",
-          "os_version": "10.14",
-          "date": "2019-01-14",
+          "os_version": "10.14.2",
+          "date": "2019-01-21",
           "output": [
             {
               "command": "next_item",
@@ -109,7 +109,7 @@
           "at_version": "12.1",
           "browser_version": "12.1.2",
           "os_version": "12.1",
-          "date": "2019-01-14",
+          "date": "2019-01-21",
           "output": [
             {
               "command": "next_item",
@@ -123,10 +123,10 @@
     "talkback": {
       "browsers": {
         "and_chr": {
-          "at_version": "7.2",
+          "at_version": "8.1",
           "browser_version": "70",
-          "os_version": "7.2",
-          "date": "2019-01-14",
+          "os_version": "8.1",
+          "date": "2019-01-21",
           "output": [
             {
               "command": "next_item",

--- a/data/tests/tech/html/html_figure/test_8.json
+++ b/data/tests/tech/html/html_figure/test_8.json
@@ -123,7 +123,7 @@
     "talkback": {
       "browsers": {
         "and_chr": {
-          "at_version": "8.1",
+          "at_version": "7.2",
           "browser_version": "70",
           "os_version": "8.1",
           "date": "2019-01-21",

--- a/data/tests/tech/html/html_figure/test_8.json
+++ b/data/tests/tech/html/html_figure/test_8.json
@@ -1,0 +1,141 @@
+{
+  "type": "assertion",
+  "title": "Figure test 8",
+  "description": "This test was originally imported from the article titled '[how do you figure?'](https://www.scottohara.me/blog/2019/01/21/how-do-you-figure.html)' by Scott O'Hara.",
+  "features": [
+    "html/figure_element",
+    "html/figcaption_element"
+  ],
+  "supports_sr": true,
+  "supports_vc": false,
+  "css_target": "#target_8",
+  "html_file": "html_figure_tests.html",
+  "assertion": {
+    "aspect": "role",
+    "value": "figure"
+  },
+  "history": [
+    {
+      "date": "2019-01-21",
+      "message": "Test created. Thank you @scottaohara."
+    }
+  ],
+  "at": {
+    "jaws": {
+      "browsers": {
+        "ie": {
+          "at_version": "2019",
+          "browser_version": "44",
+          "os_version": "1809",
+          "date": "2019-01-14",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "figure role with \"Content caption\" as the accessible name.",
+              "result": "pass"
+            }
+          ]
+        },
+        "firefox": {
+          "at_version": "2019",
+          "browser_version": "64.0.2",
+          "os_version": "1809",
+          "date": "2019-01-14",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "figure role with \"Content caption\" as the accessible name.",
+              "result": "pass"
+            }
+          ]
+        }
+      }
+    },
+    "narrator": {
+      "browsers": {
+        "edge": {
+          "at_version": "1804",
+          "browser_version": "42",
+          "os_version": "1804",
+          "date": "2019-01-14",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "(unknown)",
+              "result": "partial"
+            }
+          ],
+          "notes": "no announced role, but relationship made"
+        }
+      }
+    },
+    "nvda": {
+      "browsers": {
+        "firefox": {
+          "at_version": "2018.4.1",
+          "browser_version": "64.0.2",
+          "os_version": "1809",
+          "date": "2019-01-14",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "(unknown)",
+              "result": "fail"
+            }
+          ]
+        }
+      }
+    },
+    "vo_macos": {
+      "browsers": {
+        "safari": {
+          "at_version": "10.14",
+          "browser_version": "12.0.2",
+          "os_version": "10.14",
+          "date": "2019-01-14",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "figure role with \"Content caption\" as the accessible name.",
+              "result": "pass"
+            }
+          ]
+        }
+      }
+    },
+    "vo_ios": {
+      "browsers": {
+        "ios_saf": {
+          "at_version": "12.1",
+          "browser_version": "12.1.2",
+          "os_version": "12.1",
+          "date": "2019-01-14",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "(unknown)",
+              "result": "fail"
+            }
+          ]
+        }
+      }
+    },
+    "talkback": {
+      "browsers": {
+        "and_chr": {
+          "at_version": "7.2",
+          "browser_version": "70",
+          "os_version": "7.2",
+          "date": "2019-01-14",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "(unknown)",
+              "result": "fail"
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/data/tests/tech/html/html_figure/test_9.json
+++ b/data/tests/tech/html/html_figure/test_9.json
@@ -25,9 +25,9 @@
       "browsers": {
         "ie": {
           "at_version": "2019",
-          "browser_version": "44",
+          "browser_version": "11",
           "os_version": "1809",
-          "date": "2019-01-14",
+          "date": "2019-01-21",
           "output": [
             {
               "command": "next_item",
@@ -40,7 +40,7 @@
           "at_version": "2019",
           "browser_version": "64.0.2",
           "os_version": "1809",
-          "date": "2019-01-14",
+          "date": "2019-01-21",
           "output": [
             {
               "command": "next_item",
@@ -57,7 +57,7 @@
           "at_version": "1804",
           "browser_version": "42",
           "os_version": "1804",
-          "date": "2019-01-14",
+          "date": "2019-01-21",
           "output": [
             {
               "command": "next_item",
@@ -75,7 +75,7 @@
           "at_version": "2018.4.1",
           "browser_version": "64.0.2",
           "os_version": "1809",
-          "date": "2019-01-14",
+          "date": "2019-01-21",
           "output": [
             {
               "command": "next_item",
@@ -89,10 +89,10 @@
     "vo_macos": {
       "browsers": {
         "safari": {
-          "at_version": "10.14",
+          "at_version": "10.14.2",
           "browser_version": "12.0.2",
-          "os_version": "10.14",
-          "date": "2019-01-14",
+          "os_version": "10.14.2",
+          "date": "2019-01-21",
           "output": [
             {
               "command": "next_item",
@@ -109,7 +109,7 @@
           "at_version": "12.1",
           "browser_version": "12.1.2",
           "os_version": "12.1",
-          "date": "2019-01-14",
+          "date": "2019-01-21",
           "output": [
             {
               "command": "next_item",
@@ -123,10 +123,10 @@
     "talkback": {
       "browsers": {
         "and_chr": {
-          "at_version": "7.2",
+          "at_version": "8.1",
           "browser_version": "70",
-          "os_version": "7.2",
-          "date": "2019-01-14",
+          "os_version": "8.1",
+          "date": "2019-01-21",
           "output": [
             {
               "command": "next_item",

--- a/data/tests/tech/html/html_figure/test_9.json
+++ b/data/tests/tech/html/html_figure/test_9.json
@@ -123,7 +123,7 @@
     "talkback": {
       "browsers": {
         "and_chr": {
-          "at_version": "8.1",
+          "at_version": "7.2",
           "browser_version": "70",
           "os_version": "8.1",
           "date": "2019-01-21",

--- a/data/tests/tech/html/html_figure/test_9.json
+++ b/data/tests/tech/html/html_figure/test_9.json
@@ -1,0 +1,141 @@
+{
+  "type": "assertion",
+  "title": "Figure test 9",
+  "description": "This test was originally imported from the article titled '[how do you figure?'](https://www.scottohara.me/blog/2019/01/21/how-do-you-figure.html)' by Scott O'Hara.",
+  "features": [
+    "html/figure_element",
+    "html/figcaption_element"
+  ],
+  "supports_sr": true,
+  "supports_vc": false,
+  "css_target": "#target_9",
+  "html_file": "html_figure_tests.html",
+  "assertion": {
+    "aspect": "role",
+    "value": "figure"
+  },
+  "history": [
+    {
+      "date": "2019-01-21",
+      "message": "Test created. Thank you @scottaohara."
+    }
+  ],
+  "at": {
+    "jaws": {
+      "browsers": {
+        "ie": {
+          "at_version": "2019",
+          "browser_version": "44",
+          "os_version": "1809",
+          "date": "2019-01-14",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "figure role with \"ARIA label\" as the accessible name.",
+              "result": "pass"
+            }
+          ]
+        },
+        "firefox": {
+          "at_version": "2019",
+          "browser_version": "64.0.2",
+          "os_version": "1809",
+          "date": "2019-01-14",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "figure role with \"ARIA label\" as the accessible name.",
+              "result": "pass"
+            }
+          ]
+        }
+      }
+    },
+    "narrator": {
+      "browsers": {
+        "edge": {
+          "at_version": "1804",
+          "browser_version": "42",
+          "os_version": "1804",
+          "date": "2019-01-14",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "(unknown)",
+              "result": "partial"
+            }
+          ],
+          "notes": "no announced role, but relationship made"
+        }
+      }
+    },
+    "nvda": {
+      "browsers": {
+        "firefox": {
+          "at_version": "2018.4.1",
+          "browser_version": "64.0.2",
+          "os_version": "1809",
+          "date": "2019-01-14",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "(unknown)",
+              "result": "fail"
+            }
+          ]
+        }
+      }
+    },
+    "vo_macos": {
+      "browsers": {
+        "safari": {
+          "at_version": "10.14",
+          "browser_version": "12.0.2",
+          "os_version": "10.14",
+          "date": "2019-01-14",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "figure role with \"ARIA label\" as the accessible name.",
+              "result": "pass"
+            }
+          ]
+        }
+      }
+    },
+    "vo_ios": {
+      "browsers": {
+        "ios_saf": {
+          "at_version": "12.1",
+          "browser_version": "12.1.2",
+          "os_version": "12.1",
+          "date": "2019-01-14",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "(unknown)",
+              "result": "fail"
+            }
+          ]
+        }
+      }
+    },
+    "talkback": {
+      "browsers": {
+        "and_chr": {
+          "at_version": "7.2",
+          "browser_version": "70",
+          "os_version": "7.2",
+          "date": "2019-01-14",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "(unknown)",
+              "result": "fail"
+            }
+          ]
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This imports tests from Scott O'Hara: https://scottaohara.github.io/testing/figure/

Note: sample script used to import the tests: https://gist.github.com/mfairchild365/7cf5425b1950182e25198605fe7c9f00

In order for this to work, the script must be in the `/scripts` directory and the original test page must be saved to `/tests/html/html_figure_results.html`