### PR TITLE
Add aria-current support information

### DIFF
--- a/data/tests/html/aria/aria-current.html
+++ b/data/tests/html/aria/aria-current.html
@@ -1,0 +1,361 @@
+
+<!doctype html>
+
+<html lang="en">
+
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width">
+    <title>aria-current design patterns</title>
+
+    <style>
+        html, body {
+            font: normal 95% Helvetica, Verdana, Arial, sans-serif;
+            color: #000;
+            padding: 0;
+            margin: 0;
+        }
+
+        body {
+            padding: 0.5em 0.7em;
+            margin: 0 4em 0 1em;
+            max-width: 55em;
+            background: #fff;
+        }
+
+        h1, h2, h3 {
+            margin-bottom: 0;
+            background: transparent;
+        }
+
+        h1 {
+            padding: 0.2em;
+        }
+
+        a {
+            color: #009;
+            background: transparent;
+        }
+
+        a:visited {
+            color:#360;
+            background:transparent;
+        }
+
+        a:hover, a:focus, a:active {
+            color:#000;
+            background-color: #fc0;
+        }
+
+        img {
+            border: none;
+        }
+
+        code {
+            font: bold "Courier new", Courier, Monospace;
+        }
+
+        mark {
+            color: #fff;
+            background-color: #820bbb;
+        }
+
+        .example {
+            margin-top: 1em;
+            margin-bottom: 2em;
+        }
+    </style>
+    <style>
+        [aria-current] {
+            font-weight: bold;
+            background-color: #cc33ff;
+        }
+
+        .time {
+            width: 200px;
+        }
+
+        .support, .support th, .support td {
+            border-collapse: collapse;
+            border:1px solid #bbb;
+        }
+        .support th, .support td {
+            text-align:center;
+            padding: .2em;
+        }
+        .support th:nth-child(1) {
+            text-align: right;
+        }
+
+    </style>
+</head>
+
+<body>
+<h1><code>aria-current</code> design patterns</h1>
+<p>Credit: this document was originally created by Léonie Watson and sourced from <a href="http://design-patterns.tink.uk/aria-current/">http://design-patterns.tink.uk/aria-current/</a>.</p>
+
+<p>The <a href="https://www.w3.org/TR/wai-aria-1.1/#aria-current"><code>aria-current</code></a> attribute indicates the element that represents the current item within  a container or set of related elements. It is an enumerated type attribute that takes one of a number of predefined tokens ("page", "step", "location", "date" or "time"), or which may be set to "true".</p>
+
+<h2><code>aria-current="date"</code></h2>
+
+<p>Screen readers should announce "Current date" to indicate that Saturday 16th is the current date in the month.</p>
+
+<h3>Code</h3>
+<pre><code>
+&lt;table&gt;
+&lt;caption&gt;July 2016&lt;/caption&gt;
+&lt;tr&gt;
+&lt;th&gt;Mon&lt;/th&gt;&lt;th&gt;Tue&lt;/th&gt;&lt;th&gt;Wed&lt;/th&gt;&lt;th&gt;Thu&lt;/th&gt;&lt;th&gt;Fri&lt;/th&gt;&lt;th&gt;Sat&lt;/th&gt;&lt;th&gt;Sun&lt;/th&gt;
+&lt;/tr&gt;
+&lt;tr&gt;
+&lt;td&gt;&lt;/td&gt;&lt;td&gt;&lt;/td&gt;&lt;td&gt;&lt;/td&gt;&lt;td&gt;&lt;/td&gt;&lt;td&gt;1&lt;/td&gt;&lt;td&gt;2&lt;/td&gt;&lt;td&gt;3&lt;/td&gt;
+&lt;/tr&gt;
+&lt;tr&gt;
+&lt;td&gt;4&lt;/td&gt;&lt;td&gt;5&lt;/td&gt;&lt;td&gt;6&lt;/td&gt;&lt;td&gt;7&lt;/td&gt;&lt;td&gt;8&lt;/td&gt;&lt;td&gt;9&lt;/td&gt;&lt;td&gt;10&lt;/td&gt;
+&lt;/tr&gt;
+&lt;tr&gt;
+&lt;td&gt;11&lt;/td&gt;&lt;td&gt;12&lt;/td&gt;&lt;td&gt;13&lt;/td&gt;&lt;td&gt;14&lt;/td&gt;&lt;td&gt;15&lt;/td&gt;&lt;td <mark>aria-current="date"</mark>&gt;16&lt;/td&gt;&lt;td&gt;17&lt;/td&gt;
+&lt;/tr&gt;
+&lt;tr&gt;
+&lt;td&gt;18&lt;/td&gt;&lt;td&gt;19&lt;/td&gt;&lt;td&gt;20&lt;/td&gt;&lt;td&gt;21&lt;/td&gt;&lt;td&gt;21&lt;/td&gt;&lt;td&gt;22&lt;/td&gt;&lt;td&gt;23&lt;/td&gt;
+&lt;/tr&gt;
+&lt;tr&gt;
+&lt;td&gt;24&lt;/td&gt;&lt;td&gt;25&lt;/td&gt;&lt;td&gt;26&lt;/td&gt;&lt;td&gt;27&lt;/td&gt;&lt;td&gt;28&lt;/td&gt;&lt;td&gt;29&lt;/td&gt;&lt;td&gt;30&lt;/td&gt;
+&lt;/tr&gt;
+&lt;tr&gt;
+&lt;td&gt;31&lt;/td&gt;&lt;td&gt;&lt;/td&gt;&lt;td&gt;&lt;/td&gt;&lt;td&gt;&lt;/td&gt;&lt;td&gt;&lt;/td&gt;&lt;td&gt;&lt;/td&gt;&lt;td&gt;&lt;/td&gt;
+&lt;/tr&gt;
+&lt;/table&gt;
+</code></pre>
+
+<h3>Example</h3>
+<div class="example">
+    <table>
+        <caption>July 2016</caption>
+        <tr>
+            <th>Mon</th><th>Tue</th><th>Wed</th><th>Thu</th><th>Fri</th><th>Sat</th><th>Sun</th>
+        </tr>
+        <tr>
+            <td></td><td></td><td></td><td></td><td>1</td><td>2</td><td>3</td>
+        </tr>
+        <tr>
+            <td>4</td><td>5</td><td>6</td><td>7</td><td>8</td><td>9</td><td>10</td>
+        </tr>
+        <tr>
+            <td>11</td><td>12</td><td>13</td><td>14</td><td>15</td><td aria-current="date">16</td><td>17</td>
+        </tr>
+        <tr>
+            <td>18</td><td>19</td><td>20</td><td>21</td><td>21</td><td>22</td><td>23</td>
+        </tr>
+        <tr>
+            <td>24</td><td>25</td><td>26</td><td>27</td><td>28</td><td>29</td><td>30</td>
+        </tr>
+        <tr>
+            <td>31</td><td></td><td></td><td></td><td></td><td></td><td></td>
+        </tr>
+    </table>
+</div>
+
+<h2>aria-current="location"</h2>
+
+<p>Screen readers should announce "Current location" to indicate the last link is the current location in the breadcrumb navigation.</p>
+
+<h3>Code</h3>
+<pre><code>
+&lt;nav aria-label="Breadcrumb"&gt;
+&lt;ul&gt;
+&lt;li&gt;&lt;a href="/"&gt;Home&lt;/a&gt;&lt;/li&gt;
+&lt;li&gt;&lt;a href="/"&gt; Contact us&lt;/a&gt;&lt;/li&gt;
+&lt;li&gt;&lt;a href="/" <mark>aria-current="location"</mark>&gt; Phone numbers&lt;/a&gt;&lt;/li&gt;
+&lt;/ul&gt;
+&lt;/nav&gt;
+</code></pre>
+</div>
+
+<h3>Example</h3>
+<div class="example">
+    <nav aria-label="Breadcrumb">
+        <ul>
+            <li><a href="/">Home</a></li>
+            <li><a href="/"> Contact us</a></li>
+            <li><a href="/" aria-current="location"> Phone numbers</a></li>
+        </ul>
+    </nav>
+</div>
+
+<h2><code>aria-current="page"</code></h2>
+
+<p>Screen readers should announce "Current page" to indicate the first link is the current page in the navigation.</p>
+
+<h3>Code</h3>
+<pre><code>
+&lt;nav&gt;
+&lt;ul&gt;
+&lt;li&gt;&lt;a href="/" <mark>aria-current="page"</mark>&gt;Home&lt;/a&gt;&lt;/li&gt;
+&lt;li&gt;&lt;a href="/"&gt;About&lt;/a&gt;&lt;/li&gt;
+&lt;li&gt;&lt;a href="/"&gt;Contact&lt;/a&gt;&lt;/li&gt;
+&lt;/ul&gt;
+&lt;/nav&gt;
+</code></pre>
+
+<h3>Example</h3>
+<div class="example">
+    <nav>
+        <ul>
+            <li><a href="/" aria-current="page">Home</a></li>
+            <li><a href="/">About</a></li>
+            <li><a href="/">Contact</a></li>
+        </ul>
+    </nav>
+</div>
+
+<h2><code>aria-current="step"</code></h2>
+
+<p>Screen readers should announce "Current step" to indicate the first link is the current step in the process.</p>
+
+<h3>Code</h3>
+<pre><code>
+&lt;ol&gt;
+&lt;li&gt;&lt;a href="/" <mark>aria-current="step"</mark>&gt;Do this&lt;/a&gt;&lt;/li&gt;
+&lt;li&gt;&lt;a href="/"&gt;Do that&lt;/a&gt;&lt;/li&gt;
+&lt;li&gt;&lt;a href="/"&gt;Do the other&lt;/a&gt;&lt;/li&gt;
+&lt;/ol&gt;
+</code></pre>
+
+<h3>Example</h3>
+<div class="example">
+    <ol>
+        <li><a href="/" aria-current="step">Do this</a></li>
+        <li><a href="/">Do that</a></li>
+        <li><a href="/">Do the other</a></li>
+    </ol>
+</div>
+
+<h2><code>aria-current="time"</code></h2>
+
+<p>Screen readers should announce "Current time" to indicate the keynote is happening at the current time in the schedule.</p>
+
+<h3>Code</h3>
+<pre><code>
+&lt;ul&gt;
+&lt;li&gt;9am to 10am: Welcome&lt;/li&gt;
+&lt;li <mark>aria-current="time"</mark>&gt;10am to 11am: Keynote&lt;/li&gt;
+&lt;li&gt;11am to 11.30pm: Break&lt;/li&gt;
+&lt;li&gt;11.30am to 1pm: Workshop&lt;/li&gt;
+&lt;li&gt;1pm to 2pm: Lunch&lt;/li&gt;
+&lt;li&gt;2pm to 3pm: Lecture&lt;/li&gt;
+&lt;li&gt;3pm to 3.30pm: Break&lt;/li&gt;
+&lt;li&gt;3.30pm to 5pm: Workshop&lt;/li&gt;
+&lt;/ul&gt;
+</code></pre>
+
+<h3>Example</h3>
+<div class="example">
+    <ul class="time">
+        <li>9am to 10am: Welcome</li>
+        <li aria-current="time">10am to 11am: Keynote</li>
+        <li>11am to 11.30pm: Break</li>
+        <li>11.30am to 1pm: Workshop</li>
+        <li>1pm to 2pm: Lunch</li>
+        <li>2pm to 3pm: Lecture</li>
+        <li>3pm to 3.30pm: Break</li>
+        <li>3.30pm to 5pm: Workshop</li>
+    </ul>
+</div>
+
+<h2><code>aria-current="true"</code></h2>
+
+<p>Screen readers should announce "Current" to indicate the first link is the current link in the set.</p>
+
+<h3>Code</h3>
+<pre><code>
+&lt;ul&gt;
+&lt;li&gt;&lt;a href="/" <mark>aria-current="true"</mark>&gt;Apples&lt;/a&gt;&lt;/li&gt;
+&lt;li&gt;&lt;a href="/"&gt;Bananas&lt;/a&gt;&lt;/li&gt;
+&lt;li&gt;&lt;a href="/"&gt;Cherries&lt;/a&gt;&lt;/li&gt;
+&lt;/ul&gt;
+</code></pre>
+
+<h3>Example</h3>
+<div class="example">
+    <ul>
+        <li><a href="/" aria-current="true">Apples</a></li>
+        <li><a href="/">Bananas</a></li>
+        <li><a href="/">Cherries</a></li>
+    </ul>
+</div>
+
+
+<h2>Screen reader support</h2>
+<p>Unless otherwise stated, tests were carried out on the latest OS, browser, and screen reader version. Last updated on 3rd February 2018.</p>
+
+<table class="support">
+    <caption>Screen reader support for aria-current</caption>
+    <tr>
+        <th></th><th><code>=date"</code></th><th><code>="location"</code></th><th><code>="page"</code></th><th><code>="step"</code></th><th><code>="time"</code></th><th><code>="true"</code></th><th>Notes</th>
+    </tr>
+
+    <tr>
+        <th>Jaws 18/Chrome</th><td>Yes</td><td>Yes</td><td>Yes</td><td>Yes</td><td>Yes</td><td>Yes</td><td></td>
+    </tr>
+
+    <tr>
+        <th>Jaws 2018/Edge</th><td>No</td><td>No</td><td>No</td><td>No</td><td>No</td><td>No</td><td><a href="https://github.com/FreedomScientific/VFO-standards-support/issues/48">Issue #48</a></td>
+    </tr>
+
+    <tr>
+        <th>Jaws 18/Firefox</th><td>Yes</td><td>Yes</td><td>Yes</td><td>Yes</td><td>Yes</td><td>Yes</td><td></td>
+    </tr>
+
+    <tr>
+        <th>Jaws 18/IE</th><td>Yes</td><td>Yes</td><td>Yes</td><td>Yes</td><td>Yes</td><td>Yes</td><td></td>
+    </tr>
+
+    <tr>
+        <th>Narrator/Edge</th><td>No</td><td>No</td><td>No</td><td>No</td><td>No</td><td>No</td><td></td>
+    </tr>
+
+    <tr>
+        <th>NVDA/Chrome</th><td>Yes</td><td>Yes</td><td>Yes</td><td>Yes</td><td>Yes</td><td>Yes</td><td></td>
+    </tr>
+
+    <tr>
+        <th>NVDA/Edge</th><td>Yes</td><td>Yes</td><td>Yes</td><td>Yes</td><td>Yes</td><td>Yes</td><td></td>
+    </tr>
+
+    <tr>
+        <th>NVDA/Firefox</th><td>Yes</td><td>Yes</td><td>Yes</td><td>Yes</td><td>Yes</td><td>Yes</td><td></td>
+    </tr>
+
+    <tr>
+        <th>NVDA/IE</th><td>Yes</td><td>Yes</td><td>Yes</td><td>Yes</td><td>Yes</td><td>Yes</td><td></td>
+    </tr>
+
+    <tr>
+        <th>TalkBack/Chrome</th><td>?</td><td>?</td><td>?</td><td>?</td><td>?</td><td>?</td><td></td>
+    </tr>
+
+    <tr>
+        <th>TalkBack/Firefox</th><td>No</td><td>No</td><td>No</td><td>No</td><td>No</td><td>No</td><td></td>
+    </tr>
+
+    <tr>
+        <th>VoiceOver (iOS)/Safari</th><td>Yes</td><td>Yes</td><td>Yes</td><td>Yes</td><td>Yes</td><td>Yes</td><td></td>
+    </tr>
+
+    <tr>
+        <th>VoiceOver (MacOS/Safari</th><td>Yes</td><td>Yes</td><td>Yes</td><td>Yes</td><td>Yes</td><td>Yes</td><td></td>
+    </tr>
+</table>
+
+<h2>Screen reader demos</h2>
+<ul>
+    <li><a href="https://youtu.be/nr1RuyIiHi0">Screen reader demo: aria-current="date"</a></li>
+    <li><a href="	https://youtu.be/o1FyUaaK8hk">Screen reader demo: aria-current="location"</a></li>
+    <li><a href="https://www.youtube.com/watch?v=as2CZKc4Kx4">Screen reader demo: aria-current="page"</a></li>
+    <li><a href="https://youtu.be/BxSzMuHXrPg">Screen reader demo: aria-current="step"</a></li>
+    <li><a href="https://youtu.be/PH6qIazMNgY">Screen reader demo: aria-current="time"</a></li>
+    <li><a href="https://youtu.be/f3tNnqSW3VM">Screen reader demo: aria-current="true"</a></li>
+</ul>
+</body>
+</html>

--- a/data/tests/tech/aria/aria_current_date.json
+++ b/data/tests/tech/aria/aria_current_date.json
@@ -1,0 +1,203 @@
+{
+  "type": "assertion",
+  "title": "aria-current=\"date\" attribute",
+  "description": "Tests the aria-current=\"date\" attribute. Originally sourced from [Léonie Watson's aria-current tests](http://design-patterns.tink.uk/aria-current/).",
+  "supports_sr": true,
+  "supports_vc": false,
+  "html_file": "aria/aria-current.html",
+  "css_target": "td[aria-current=\"date\"",
+  "assertion": {
+    "aspect": "property",
+    "title": "aria-current",
+    "value": "date"
+  },
+  "features": ["aria/aria-current_attribute"],
+  "history": [
+    {
+      "date": "2019-03-29",
+      "message": "Test created"
+    }
+  ],
+  "at": {
+    "jaws": {
+      "browsers": {
+        "firefox": {
+          "at_version": "2018.1811.2",
+          "browser_version": "66",
+          "os_version": "1809",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "current date",
+              "result": "pass"
+            }
+          ],
+          "date": "2019-03-29"
+        },
+        "chrome": {
+          "at_version": "2018.1811.2",
+          "browser_version": "73",
+          "os_version": "1809",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "current date",
+              "result": "pass"
+            }
+          ],
+          "date": "2019-03-29"
+        },
+        "ie": {
+          "at_version": "2018.1811.2",
+          "browser_version": "11",
+          "os_version": "1809",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "current date",
+              "result": "pass"
+            }
+          ],
+          "date": "2019-03-29"
+        },
+        "edge": {
+          "at_version": "2018.1811.2",
+          "browser_version": "44",
+          "os_version": "1809",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "(not announced)",
+              "result": "fail"
+            }
+          ],
+          "date": "2019-03-29"
+        }
+      }
+    },
+    "narrator": {
+      "browsers": {
+        "edge": {
+          "at_version": "1809",
+          "browser_version": "44.17763",
+          "os_version": "1809",
+          "date": "2019-03-29",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "(not announced)",
+              "result": "fail"
+            }
+          ]
+        }
+      }
+    },
+    "nvda": {
+      "browsers": {
+        "firefox": {
+          "at_version": "2019.0.1",
+          "browser_version": "66",
+          "os_version": "1809",
+          "date": "2019-03-29",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "current date",
+              "result": "pass"
+            }
+          ]
+        },
+        "chrome": {
+          "at_version": "2019.0.1",
+          "browser_version": "73",
+          "os_version": "1809",
+          "date": "2019-03-29",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "current date",
+              "result": "pass"
+            }
+          ]
+        },
+        "edge": {
+          "at_version": "2019.0.1",
+          "browser_version": "44.17763",
+          "os_version": "1809",
+          "date": "2019-03-29",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "current date",
+              "result": "pass"
+            }
+          ]
+        },
+        "ie": {
+          "at_version": "2019.0.1",
+          "browser_version": "11",
+          "os_version": "1809",
+          "date": "2019-03-29",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "current date",
+              "result": "pass"
+            }
+          ]
+        }
+      }
+    },
+    "talkback": {
+      "browsers": {
+        "firefox": {
+          "at_version": "unknown",
+          "browser_version": "unknown",
+          "os_version": "unknown",
+          "date": "2018-02-03",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "(unknown)",
+              "result": "pass"
+            }
+          ]
+        }
+      }
+    },
+    "vo_ios": {
+      "browsers": {
+        "ios_saf": {
+          "at_version": "12.2",
+          "browser_version": "12.2",
+          "os_version": "12.2",
+          "date": "2019-03-29",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "current date",
+              "result": "pass"
+            }
+          ]
+        }
+      }
+    },
+    "vo_macos": {
+      "browsers": {
+        "safari": {
+          "at_version": "10.14.4",
+          "browser_version": "12.1",
+          "os_version": "10.14.4",
+          "date": "2019-03-29",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "current date",
+              "result": "pass"
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/data/tests/tech/aria/aria_current_location.json
+++ b/data/tests/tech/aria/aria_current_location.json
@@ -1,0 +1,203 @@
+{
+  "type": "assertion",
+  "title": "aria-current=\"location\" attribute",
+  "description": "Tests the aria-current=\"location\" attribute. Originally sourced from [Léonie Watson's aria-current tests](http://design-patterns.tink.uk/aria-current/).",
+  "supports_sr": true,
+  "supports_vc": false,
+  "html_file": "aria/aria-current.html",
+  "css_target": "td[aria-current=\"location\"",
+  "assertion": {
+    "aspect": "property",
+    "title": "aria-current",
+    "value": "location"
+  },
+  "features": ["aria/aria-current_attribute"],
+  "history": [
+    {
+      "date": "2019-03-29",
+      "message": "Test created"
+    }
+  ],
+  "at": {
+    "jaws": {
+      "browsers": {
+        "firefox": {
+          "at_version": "2018.1811.2",
+          "browser_version": "66",
+          "os_version": "1809",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "current location",
+              "result": "pass"
+            }
+          ],
+          "date": "2019-03-29"
+        },
+        "chrome": {
+          "at_version": "2018.1811.2",
+          "browser_version": "73",
+          "os_version": "1809",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "current location",
+              "result": "pass"
+            }
+          ],
+          "date": "2019-03-29"
+        },
+        "ie": {
+          "at_version": "2018.1811.2",
+          "browser_version": "11",
+          "os_version": "1809",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "current location",
+              "result": "pass"
+            }
+          ],
+          "date": "2019-03-29"
+        },
+        "edge": {
+          "at_version": "2018.1811.2",
+          "browser_version": "44",
+          "os_version": "1809",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "(not announced)",
+              "result": "fail"
+            }
+          ],
+          "date": "2019-03-29"
+        }
+      }
+    },
+    "narrator": {
+      "browsers": {
+        "edge": {
+          "at_version": "1809",
+          "browser_version": "44.17763",
+          "os_version": "1809",
+          "date": "2019-03-29",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "(not announced)",
+              "result": "fail"
+            }
+          ]
+        }
+      }
+    },
+    "nvda": {
+      "browsers": {
+        "firefox": {
+          "at_version": "2019.0.1",
+          "browser_version": "66",
+          "os_version": "1809",
+          "date": "2019-03-29",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "current location",
+              "result": "pass"
+            }
+          ]
+        },
+        "chrome": {
+          "at_version": "2019.0.1",
+          "browser_version": "73",
+          "os_version": "1809",
+          "date": "2019-03-29",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "current location",
+              "result": "pass"
+            }
+          ]
+        },
+        "edge": {
+          "at_version": "2019.0.1",
+          "browser_version": "44.17763",
+          "os_version": "1809",
+          "date": "2019-03-29",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "current location",
+              "result": "pass"
+            }
+          ]
+        },
+        "ie": {
+          "at_version": "2019.0.1",
+          "browser_version": "11",
+          "os_version": "1809",
+          "date": "2019-03-29",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "current location",
+              "result": "pass"
+            }
+          ]
+        }
+      }
+    },
+    "talkback": {
+      "browsers": {
+        "firefox": {
+          "at_version": "unknown",
+          "browser_version": "unknown",
+          "os_version": "unknown",
+          "date": "2018-02-03",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "(unknown)",
+              "result": "pass"
+            }
+          ]
+        }
+      }
+    },
+    "vo_ios": {
+      "browsers": {
+        "ios_saf": {
+          "at_version": "12.2",
+          "browser_version": "12.2",
+          "os_version": "12.2",
+          "date": "2019-03-29",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "current location",
+              "result": "pass"
+            }
+          ]
+        }
+      }
+    },
+    "vo_macos": {
+      "browsers": {
+        "safari": {
+          "at_version": "10.14.4",
+          "browser_version": "12.1",
+          "os_version": "10.14.4",
+          "date": "2019-03-29",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "current location",
+              "result": "pass"
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/data/tests/tech/aria/aria_current_page.json
+++ b/data/tests/tech/aria/aria_current_page.json
@@ -1,0 +1,203 @@
+{
+  "type": "assertion",
+  "title": "aria-current=\"page\" attribute",
+  "description": "Tests the aria-current=\"page\" attribute. Originally sourced from [Léonie Watson's aria-current tests](http://design-patterns.tink.uk/aria-current/).",
+  "supports_sr": true,
+  "supports_vc": false,
+  "html_file": "aria/aria-current.html",
+  "css_target": "td[aria-current=\"page\"",
+  "assertion": {
+    "aspect": "property",
+    "title": "aria-current",
+    "value": "page"
+  },
+  "features": ["aria/aria-current_attribute"],
+  "history": [
+    {
+      "date": "2019-03-29",
+      "message": "Test created"
+    }
+  ],
+  "at": {
+    "jaws": {
+      "browsers": {
+        "firefox": {
+          "at_version": "2018.1811.2",
+          "browser_version": "66",
+          "os_version": "1809",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "current page",
+              "result": "pass"
+            }
+          ],
+          "date": "2019-03-29"
+        },
+        "chrome": {
+          "at_version": "2018.1811.2",
+          "browser_version": "73",
+          "os_version": "1809",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "current page",
+              "result": "pass"
+            }
+          ],
+          "date": "2019-03-29"
+        },
+        "ie": {
+          "at_version": "2018.1811.2",
+          "browser_version": "11",
+          "os_version": "1809",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "current page",
+              "result": "pass"
+            }
+          ],
+          "date": "2019-03-29"
+        },
+        "edge": {
+          "at_version": "2018.1811.2",
+          "browser_version": "44",
+          "os_version": "1809",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "(not announced)",
+              "result": "fail"
+            }
+          ],
+          "date": "2019-03-29"
+        }
+      }
+    },
+    "narrator": {
+      "browsers": {
+        "edge": {
+          "at_version": "1809",
+          "browser_version": "44.17763",
+          "os_version": "1809",
+          "date": "2019-03-29",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "(not announced)",
+              "result": "fail"
+            }
+          ]
+        }
+      }
+    },
+    "nvda": {
+      "browsers": {
+        "firefox": {
+          "at_version": "2019.0.1",
+          "browser_version": "66",
+          "os_version": "1809",
+          "date": "2019-03-29",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "current page",
+              "result": "pass"
+            }
+          ]
+        },
+        "chrome": {
+          "at_version": "2019.0.1",
+          "browser_version": "73",
+          "os_version": "1809",
+          "date": "2019-03-29",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "current page",
+              "result": "pass"
+            }
+          ]
+        },
+        "edge": {
+          "at_version": "2019.0.1",
+          "browser_version": "44.17763",
+          "os_version": "1809",
+          "date": "2019-03-29",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "current page",
+              "result": "pass"
+            }
+          ]
+        },
+        "ie": {
+          "at_version": "2019.0.1",
+          "browser_version": "11",
+          "os_version": "1809",
+          "date": "2019-03-29",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "current page",
+              "result": "pass"
+            }
+          ]
+        }
+      }
+    },
+    "talkback": {
+      "browsers": {
+        "firefox": {
+          "at_version": "unknown",
+          "browser_version": "unknown",
+          "os_version": "unknown",
+          "date": "2018-02-03",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "(unknown)",
+              "result": "pass"
+            }
+          ]
+        }
+      }
+    },
+    "vo_ios": {
+      "browsers": {
+        "ios_saf": {
+          "at_version": "12.2",
+          "browser_version": "12.2",
+          "os_version": "12.2",
+          "date": "2019-03-29",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "current page",
+              "result": "pass"
+            }
+          ]
+        }
+      }
+    },
+    "vo_macos": {
+      "browsers": {
+        "safari": {
+          "at_version": "10.14.4",
+          "browser_version": "12.1",
+          "os_version": "10.14.4",
+          "date": "2019-03-29",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "current page",
+              "result": "pass"
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/data/tests/tech/aria/aria_current_step.json
+++ b/data/tests/tech/aria/aria_current_step.json
@@ -1,0 +1,203 @@
+{
+  "type": "assertion",
+  "title": "aria-current=\"step\" attribute",
+  "description": "Tests the aria-current=\"step\" attribute. Originally sourced from [Léonie Watson's aria-current tests](http://design-patterns.tink.uk/aria-current/).",
+  "supports_sr": true,
+  "supports_vc": false,
+  "html_file": "aria/aria-current.html",
+  "css_target": "*[aria-current=\"step\"",
+  "assertion": {
+    "aspect": "property",
+    "title": "aria-current",
+    "value": "step"
+  },
+  "features": ["aria/aria-current_attribute"],
+  "history": [
+    {
+      "date": "2019-03-29",
+      "message": "Test created"
+    }
+  ],
+  "at": {
+    "jaws": {
+      "browsers": {
+        "firefox": {
+          "at_version": "2018.1811.2",
+          "browser_version": "66",
+          "os_version": "1809",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "current step",
+              "result": "pass"
+            }
+          ],
+          "date": "2019-03-29"
+        },
+        "chrome": {
+          "at_version": "2018.1811.2",
+          "browser_version": "73",
+          "os_version": "1809",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "current step",
+              "result": "pass"
+            }
+          ],
+          "date": "2019-03-29"
+        },
+        "ie": {
+          "at_version": "2018.1811.2",
+          "browser_version": "11",
+          "os_version": "1809",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "current step",
+              "result": "pass"
+            }
+          ],
+          "date": "2019-03-29"
+        },
+        "edge": {
+          "at_version": "2018.1811.2",
+          "browser_version": "44",
+          "os_version": "1809",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "(not announced)",
+              "result": "fail"
+            }
+          ],
+          "date": "2019-03-29"
+        }
+      }
+    },
+    "narrator": {
+      "browsers": {
+        "edge": {
+          "at_version": "1809",
+          "browser_version": "44.17763",
+          "os_version": "1809",
+          "date": "2019-03-29",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "(not announced)",
+              "result": "fail"
+            }
+          ]
+        }
+      }
+    },
+    "nvda": {
+      "browsers": {
+        "firefox": {
+          "at_version": "2019.0.1",
+          "browser_version": "66",
+          "os_version": "1809",
+          "date": "2019-03-29",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "current step",
+              "result": "pass"
+            }
+          ]
+        },
+        "chrome": {
+          "at_version": "2019.0.1",
+          "browser_version": "73",
+          "os_version": "1809",
+          "date": "2019-03-29",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "current step",
+              "result": "pass"
+            }
+          ]
+        },
+        "edge": {
+          "at_version": "2019.0.1",
+          "browser_version": "44.17763",
+          "os_version": "1809",
+          "date": "2019-03-29",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "current step",
+              "result": "pass"
+            }
+          ]
+        },
+        "ie": {
+          "at_version": "2019.0.1",
+          "browser_version": "11",
+          "os_version": "1809",
+          "date": "2019-03-29",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "current step",
+              "result": "pass"
+            }
+          ]
+        }
+      }
+    },
+    "talkback": {
+      "browsers": {
+        "firefox": {
+          "at_version": "unknown",
+          "browser_version": "unknown",
+          "os_version": "unknown",
+          "date": "2018-02-03",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "(unknown)",
+              "result": "pass"
+            }
+          ]
+        }
+      }
+    },
+    "vo_ios": {
+      "browsers": {
+        "ios_saf": {
+          "at_version": "12.2",
+          "browser_version": "12.2",
+          "os_version": "12.2",
+          "date": "2019-03-29",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "current step",
+              "result": "pass"
+            }
+          ]
+        }
+      }
+    },
+    "vo_macos": {
+      "browsers": {
+        "safari": {
+          "at_version": "10.14.4",
+          "browser_version": "12.1",
+          "os_version": "10.14.4",
+          "date": "2019-03-29",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "current step",
+              "result": "pass"
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/data/tests/tech/aria/aria_current_time.json
+++ b/data/tests/tech/aria/aria_current_time.json
@@ -1,0 +1,203 @@
+{
+  "type": "assertion",
+  "title": "aria-current=\"time\" attribute",
+  "description": "Tests the aria-current=\"time\" attribute. Originally sourced from [Léonie Watson's aria-current tests](http://design-patterns.tink.uk/aria-current/).",
+  "supports_sr": true,
+  "supports_vc": false,
+  "html_file": "aria/aria-current.html",
+  "css_target": "*[aria-current=\"time\"",
+  "assertion": {
+    "aspect": "property",
+    "title": "aria-current",
+    "value": "time"
+  },
+  "features": ["aria/aria-current_attribute"],
+  "history": [
+    {
+      "date": "2019-03-29",
+      "message": "Test created"
+    }
+  ],
+  "at": {
+    "jaws": {
+      "browsers": {
+        "firefox": {
+          "at_version": "2018.1811.2",
+          "browser_version": "66",
+          "os_version": "1809",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "current time",
+              "result": "pass"
+            }
+          ],
+          "date": "2019-03-29"
+        },
+        "chrome": {
+          "at_version": "2018.1811.2",
+          "browser_version": "73",
+          "os_version": "1809",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "current time",
+              "result": "pass"
+            }
+          ],
+          "date": "2019-03-29"
+        },
+        "ie": {
+          "at_version": "2018.1811.2",
+          "browser_version": "11",
+          "os_version": "1809",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "current time",
+              "result": "pass"
+            }
+          ],
+          "date": "2019-03-29"
+        },
+        "edge": {
+          "at_version": "2018.1811.2",
+          "browser_version": "44",
+          "os_version": "1809",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "(not announced)",
+              "result": "fail"
+            }
+          ],
+          "date": "2019-03-29"
+        }
+      }
+    },
+    "narrator": {
+      "browsers": {
+        "edge": {
+          "at_version": "1809",
+          "browser_version": "44.17763",
+          "os_version": "1809",
+          "date": "2019-03-29",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "(not announced)",
+              "result": "fail"
+            }
+          ]
+        }
+      }
+    },
+    "nvda": {
+      "browsers": {
+        "firefox": {
+          "at_version": "2019.0.1",
+          "browser_version": "66",
+          "os_version": "1809",
+          "date": "2019-03-29",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "current time",
+              "result": "pass"
+            }
+          ]
+        },
+        "chrome": {
+          "at_version": "2019.0.1",
+          "browser_version": "73",
+          "os_version": "1809",
+          "date": "2019-03-29",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "current time",
+              "result": "pass"
+            }
+          ]
+        },
+        "edge": {
+          "at_version": "2019.0.1",
+          "browser_version": "44.17763",
+          "os_version": "1809",
+          "date": "2019-03-29",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "current time",
+              "result": "pass"
+            }
+          ]
+        },
+        "ie": {
+          "at_version": "2019.0.1",
+          "browser_version": "11",
+          "os_version": "1809",
+          "date": "2019-03-29",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "current time",
+              "result": "pass"
+            }
+          ]
+        }
+      }
+    },
+    "talkback": {
+      "browsers": {
+        "firefox": {
+          "at_version": "unknown",
+          "browser_version": "unknown",
+          "os_version": "unknown",
+          "date": "2018-02-03",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "(unknown)",
+              "result": "pass"
+            }
+          ]
+        }
+      }
+    },
+    "vo_ios": {
+      "browsers": {
+        "ios_saf": {
+          "at_version": "12.2",
+          "browser_version": "12.2",
+          "os_version": "12.2",
+          "date": "2019-03-29",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "current time",
+              "result": "pass"
+            }
+          ]
+        }
+      }
+    },
+    "vo_macos": {
+      "browsers": {
+        "safari": {
+          "at_version": "10.14.4",
+          "browser_version": "12.1",
+          "os_version": "10.14.4",
+          "date": "2019-03-29",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "current time",
+              "result": "pass"
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/data/tests/tech/aria/aria_current_true.json
+++ b/data/tests/tech/aria/aria_current_true.json
@@ -1,0 +1,203 @@
+{
+  "type": "assertion",
+  "title": "aria-current=\"true\" attribute",
+  "description": "Tests the aria-current=\"true\" attribute. Originally sourced from [Léonie Watson's aria-current tests](http://design-patterns.tink.uk/aria-current/).",
+  "supports_sr": true,
+  "supports_vc": false,
+  "html_file": "aria/aria-current.html",
+  "css_target": "*[aria-current=\"true\"",
+  "assertion": {
+    "aspect": "property",
+    "title": "aria-current",
+    "value": "true"
+  },
+  "features": ["aria/aria-current_attribute"],
+  "history": [
+    {
+      "date": "2019-03-29",
+      "message": "Test created"
+    }
+  ],
+  "at": {
+    "jaws": {
+      "browsers": {
+        "firefox": {
+          "at_version": "2018.1811.2",
+          "browser_version": "66",
+          "os_version": "1809",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "current",
+              "result": "pass"
+            }
+          ],
+          "date": "2019-03-29"
+        },
+        "chrome": {
+          "at_version": "2018.1811.2",
+          "browser_version": "73",
+          "os_version": "1809",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "current",
+              "result": "pass"
+            }
+          ],
+          "date": "2019-03-29"
+        },
+        "ie": {
+          "at_version": "2018.1811.2",
+          "browser_version": "11",
+          "os_version": "1809",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "current",
+              "result": "pass"
+            }
+          ],
+          "date": "2019-03-29"
+        },
+        "edge": {
+          "at_version": "2018.1811.2",
+          "browser_version": "44",
+          "os_version": "1809",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "(not announced)",
+              "result": "fail"
+            }
+          ],
+          "date": "2019-03-29"
+        }
+      }
+    },
+    "narrator": {
+      "browsers": {
+        "edge": {
+          "at_version": "1809",
+          "browser_version": "44.17763",
+          "os_version": "1809",
+          "date": "2019-03-29",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "(not announced)",
+              "result": "fail"
+            }
+          ]
+        }
+      }
+    },
+    "nvda": {
+      "browsers": {
+        "firefox": {
+          "at_version": "2019.0.1",
+          "browser_version": "66",
+          "os_version": "1809",
+          "date": "2019-03-29",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "current",
+              "result": "pass"
+            }
+          ]
+        },
+        "chrome": {
+          "at_version": "2019.0.1",
+          "browser_version": "73",
+          "os_version": "1809",
+          "date": "2019-03-29",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "current",
+              "result": "pass"
+            }
+          ]
+        },
+        "edge": {
+          "at_version": "2019.0.1",
+          "browser_version": "44.17763",
+          "os_version": "1809",
+          "date": "2019-03-29",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "current",
+              "result": "pass"
+            }
+          ]
+        },
+        "ie": {
+          "at_version": "2019.0.1",
+          "browser_version": "11",
+          "os_version": "1809",
+          "date": "2019-03-29",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "current",
+              "result": "pass"
+            }
+          ]
+        }
+      }
+    },
+    "talkback": {
+      "browsers": {
+        "firefox": {
+          "at_version": "unknown",
+          "browser_version": "unknown",
+          "os_version": "unknown",
+          "date": "2018-02-03",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "(unknown)",
+              "result": "pass"
+            }
+          ]
+        }
+      }
+    },
+    "vo_ios": {
+      "browsers": {
+        "ios_saf": {
+          "at_version": "12.2",
+          "browser_version": "12.2",
+          "os_version": "12.2",
+          "date": "2019-03-29",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "current",
+              "result": "pass"
+            }
+          ]
+        }
+      }
+    },
+    "vo_macos": {
+      "browsers": {
+        "safari": {
+          "at_version": "10.14.4",
+          "browser_version": "12.1",
+          "os_version": "10.14.4",
+          "date": "2019-03-29",
+          "output": [
+            {
+              "command": "next_item",
+              "output": "current",
+              "result": "pass"
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/views/feature.pug
+++ b/views/feature.pug
@@ -17,11 +17,10 @@ block content
         each test, index in data.tests
           a(href='/tests/' + testIdHelper.makeSafe(test.id))
             h3(id='support-table-'+test.id)= 'Support for ' + test.title
-          p Assertion:
-            if (test.assertion)
-              | #[+assertion(test.assertion)]
-            else
-              | custom test
+          if (test.assertion)
+            p Assertion: #[+assertion(test.assertion)]
+          else
+            p Assertion:custom test
           table(aria-labelledby='support-table-'+test.id)
             tr
               th AT

--- a/views/test-case-run.pug
+++ b/views/test-case-run.pug
@@ -148,8 +148,11 @@ block content
                 if (test.type === "assertion" || test.type === "custom")
                     h2 For reference: Test HTML
                     p This is just for reference. You likely won't need to use this.
-                    pre.test-html
-                        code= testHTML
+                    if (testHTML.split(/\r\n|\r|\n/).length < 30)
+                        pre.test-html
+                            code= testHTML
+                    else
+                        p HTML source is too long to display here.
 
         div.sidebar
             h2 Related Features

--- a/views/test-case.pug
+++ b/views/test-case.pug
@@ -27,8 +27,11 @@ block content
 
             if (test.type === "assertion" || test.type === "custom")
                 h2(id="test-html") Test HTML
-                pre.test-html
-                    code= testHTML
+                if (testHTML.split(/\r\n|\r|\n/).length < 30)
+                    pre.test-html
+                        code= testHTML
+                else
+                    p HTML source is too long to display here.
 
             h2(id="support-tables") Support tables
 


### PR DESCRIPTION
This information was imported from http://design-patterns.tink.uk/aria-current/ and double checked with the latest AT/browser versions wherever possible. Not differences in support were found.
