### PR TITLE
Search label clarification

### DIFF
--- a/views/index.pug
+++ b/views/index.pug
@@ -9,7 +9,7 @@ block content
       div.search-controls
         form
           div.input
-            label(for="feature-search") Find support for a feature
+            label(for="feature-search") Find support for a feature (search by element or attribute, for example &quot;aria&quot;)
             input(id="feature-search" type="text").search
           div.submit
             button Search


### PR DESCRIPTION
I was initially a bit confused as to how the search worked, i.e. what it searched and what my options were. Have have added some clarification in this fork. Might end up making the label verbose, but potentially a useful UI fix initially?