### PR TITLE
Streamline version tracking

### DIFF
--- a/data/ATBrowsers.json
+++ b/data/ATBrowsers.json
@@ -359,6 +359,15 @@
             "sr/interaction"
           ]
         },
+        "activate_form_control": {
+          "command": "Space",
+          "name": "Activate Form Control",
+          "tags": [
+            "forms",
+            "sr/reading",
+            "sr/interaction"
+          ]
+        },
         "activate_link": {
           "command": "Shift + enter or Shift + Spacebar",
           "name": "Activate Item (secondary action)",
@@ -1030,7 +1039,7 @@
       "short_title": "TalkBack",
       "os": "Android",
       "core_browsers": ["and_chr"],
-      "extended_browsers": ["firefox"],
+      "extended_browsers": ["and_ff"],
       "url": "https://support.google.com/accessibility/android/answer/6283677?hl=en",
       "description": "",
       "bugs": "https://www.google.com/accessibility/get-in-touch.html",

--- a/data/schema/dev-feature.json
+++ b/data/schema/dev-feature.json
@@ -65,7 +65,6 @@
     "related_issues": {
       "type": "array",
       "items": {
-        "type": "object",
         "$ref": "#/definitions/url"
       }
     },
@@ -82,14 +81,12 @@
     "references": {
       "type": "array",
       "items": {
-        "type": "object",
         "$ref": "#/definitions/url"
       }
     },
     "assertions": {
       "type": "array",
       "items": {
-        "type": "object",
         "$ref": "#/definitions/assertion"
       }
     },

--- a/data/schema/dev-test.json
+++ b/data/schema/dev-test.json
@@ -260,11 +260,8 @@
   },
   "required": [
     "title",
-    "features",
-    "type",
     "description",
     "history",
-    "html_file",
     "versions",
     "assertions"
   ]

--- a/data/schema/dev-test.json
+++ b/data/schema/dev-test.json
@@ -3,6 +3,62 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "definitions": {
+    "at_version": {
+      "type": "object",
+      "properties": {
+        "browsers": {
+          "type": "object",
+          "properties": {
+            "chrome": {
+              "$ref": "#/definitions/browser_version"
+            },
+            "and_chr": {
+              "$ref": "#/definitions/browser_version"
+            },
+            "edge": {
+              "$ref": "#/definitions/browser_version"
+            },
+            "firefox": {
+              "$ref": "#/definitions/browser_version"
+            },
+            "and_ff": {
+              "$ref": "#/definitions/browser_version"
+            },
+            "ie": {
+              "$ref": "#/definitions/browser_version"
+            },
+            "ios_saf": {
+              "$ref": "#/definitions/browser_version"
+            },
+            "safari": {
+              "$ref": "#/definitions/browser_version"
+            }
+          }
+        }
+      },
+      "required": ["browsers"]
+    },
+    "browser_version": {
+      "type": "object",
+      "properties": {
+        "at_version": {
+          "type": "string"
+        },
+        "browser_version": {
+          "type": "string"
+        },
+        "os_version": {
+          "type": "string",
+          "description": "The OS version indicates what accessibility APIs are in use"
+        },
+        "date": {
+          "description": "The date is required to help us determine which support points have priority for testing.",
+          "type": "string",
+          "format": "date"
+        }
+      },
+      "required": ["at_version", "browser_version", "os_version", "date"]
+    },
     "at": {
       "type": "object",
       "properties": {
@@ -41,25 +97,10 @@
     "browser": {
       "type": "object",
       "properties": {
-        "at_version": {
-          "type": "string"
-        },
-        "browser_version": {
-          "type": "string"
-        },
-        "os_version": {
-          "type": "string",
-          "description": "The OS version indicates what accessibility APIs are in use"
-        },
         "support": {
           "description": "Is the combination supported? y=yes, p=partial, n=no, na=not-applicable. If partial, please provide extra documentation as to why.",
           "type": "string",
           "enum": ["y", "p", "n", "na", "u"]
-        },
-        "date": {
-          "description": "The date is required to help us determine which support points have priority for testing.",
-          "type": "string",
-          "format": "date"
         },
         "output": {
           "type": "array",
@@ -77,7 +118,7 @@
               },
               "to": {
                 "type": "string",
-                "enum": ["target", "start of target", "end of target", "past target", "na"],
+                "enum": ["target", "start of target", "end of target", "past target", "before target", "within target", "after target", "na"],
                 "description": "Describes the focus/cursor destination after the command."
               },
               "output": {
@@ -96,7 +137,7 @@
           "type": "string"
         }
       },
-      "required": ["at_version", "browser_version", "os_version", "date"]
+      "required": ["output"]
     },
     "assertion": {
       "type": "object",
@@ -105,7 +146,7 @@
           "type": "string"
         },
         "feature_assertion_id": {
-          "type": "number"
+          "type": "string"
         },
         "css_target": {
           "type": "string",
@@ -130,9 +171,6 @@
             "vo_macos": {
               "$ref": "#/definitions/at"
             },
-            "windoweyes": {
-              "$ref": "#/definitions/at"
-            },
             "narrator": {
               "$ref": "#/definitions/at"
             },
@@ -141,21 +179,11 @@
             },
             "dragon_win": {
               "$ref": "#/definitions/at"
-            },
-            "dragon_mac": {
-              "$ref": "#/definitions/at"
             }
           }
         }
       },
       "required": ["feature_id", "feature_assertion_id", "results"]
-    },
-    "assertions": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "$ref": "#/definitions/assertion"
-      }
     },
     "history": {
       "type": "object",
@@ -189,6 +217,39 @@
       "type": "string",
       "description": "path relative to the /data/tests/html directory. References the file that contains the test html."
     },
+    "versions": {
+      "type": "object",
+      "properties": {
+        "jaws": {
+          "$ref": "#/definitions/at_version"
+        },
+        "nvda": {
+          "$ref": "#/definitions/at_version"
+        },
+        "vo_ios": {
+          "$ref": "#/definitions/at_version"
+        },
+        "vo_macos": {
+          "$ref": "#/definitions/at_version"
+        },
+        "narrator": {
+          "$ref": "#/definitions/at_version"
+        },
+        "android": {
+          "$ref": "#/definitions/at_version"
+        },
+        "dragon_win": {
+          "$ref": "#/definitions/at_version"
+        }
+      }
+    },
+    "assertions": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "$ref": "#/definitions/assertion"
+      }
+    },
     "history": {
       "type": "array",
       "items": {
@@ -204,6 +265,7 @@
     "description",
     "history",
     "html_file",
+    "versions",
     "assertions"
   ]
 }

--- a/data/schema/dev-test.json
+++ b/data/schema/dev-test.json
@@ -246,14 +246,12 @@
     "assertions": {
       "type": "array",
       "items": {
-        "type": "object",
         "$ref": "#/definitions/assertion"
       }
     },
     "history": {
       "type": "array",
       "items": {
-        "type": "object",
         "$ref": "#/definitions/history"
       }
     }

--- a/data/schema/feature.json
+++ b/data/schema/feature.json
@@ -71,7 +71,6 @@
     "related_issues": {
       "type": "array",
       "items": {
-        "type": "object",
         "$ref": "#/definitions/url"
       }
     },
@@ -91,14 +90,12 @@
     "references": {
       "type": "array",
       "items": {
-        "type": "object",
         "$ref": "#/definitions/url"
       }
     },
     "assertions": {
       "type": "array",
       "items": {
-        "type": "object",
         "$ref": "#/definitions/assertion"
       }
     },

--- a/data/schema/test.json
+++ b/data/schema/test.json
@@ -293,6 +293,7 @@
     "id",
     "title",
     "description",
+    "html_file",
     "history",
     "core_support",
     "extended_support",

--- a/data/schema/test.json
+++ b/data/schema/test.json
@@ -259,14 +259,12 @@
     "assertions": {
       "type": "array",
       "items": {
-        "type": "object",
         "$ref": "#/definitions/assertion"
       }
     },
     "history": {
       "type": "array",
       "items": {
-        "type": "object",
         "$ref": "#/definitions/history"
       }
     },

--- a/data/schema/test.json
+++ b/data/schema/test.json
@@ -3,6 +3,62 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "definitions": {
+    "at_version": {
+      "type": "object",
+      "properties": {
+        "browsers": {
+          "type": "object",
+          "properties": {
+            "chrome": {
+              "$ref": "#/definitions/browser_version"
+            },
+            "and_chr": {
+              "$ref": "#/definitions/browser_version"
+            },
+            "edge": {
+              "$ref": "#/definitions/browser_version"
+            },
+            "firefox": {
+              "$ref": "#/definitions/browser_version"
+            },
+            "and_ff": {
+              "$ref": "#/definitions/browser_version"
+            },
+            "ie": {
+              "$ref": "#/definitions/browser_version"
+            },
+            "ios_saf": {
+              "$ref": "#/definitions/browser_version"
+            },
+            "safari": {
+              "$ref": "#/definitions/browser_version"
+            }
+          }
+        }
+      },
+      "required": ["browsers"]
+    },
+    "browser_version": {
+      "type": "object",
+      "properties": {
+        "at_version": {
+          "type": "string"
+        },
+        "browser_version": {
+          "type": "string"
+        },
+        "os_version": {
+          "type": "string",
+          "description": "The OS version indicates what accessibility APIs are in use"
+        },
+        "date": {
+          "description": "The date is required to help us determine which support points have priority for testing.",
+          "type": "string",
+          "format": "date"
+        }
+      },
+      "required": ["at_version", "browser_version", "os_version", "date"]
+    },
     "at": {
       "type": "object",
       "properties": {
@@ -41,25 +97,10 @@
     "browser": {
       "type": "object",
       "properties": {
-        "at_version": {
-          "type": "string"
-        },
-        "browser_version": {
-          "type": "string"
-        },
-        "os_version": {
-          "type": "string",
-          "description": "The OS version indicates what accessibility APIs are in use"
-        },
         "support": {
           "description": "Is the combination of support values for the output array y=yes, p=partial, n=no, na=not-applicable. If partial, please provide extra documentation as to why.",
           "type": "string",
           "enum": ["y", "p", "n", "na", "u"]
-        },
-        "date": {
-          "description": "The date is required to help us determine which support points have priority for testing.",
-          "type": "string",
-          "format": "date"
         },
         "output": {
           "type": "array",
@@ -76,7 +117,7 @@
               },
               "to": {
                 "type": "string",
-                "enum": ["target", "start of target", "end of target", "past target", "na"],
+                "enum": ["target", "start of target", "end of target", "past target", "before target", "within target", "after target", "na"],
                 "description": "Describes the focus/cursor destination after the command."
               },
               "output": {
@@ -112,7 +153,7 @@
           "type": "string"
         },
         "feature_assertion_id": {
-          "type": "number"
+          "type": "string"
         },
         "css_target": {
           "type": "string",
@@ -137,9 +178,6 @@
             "vo_macos": {
               "$ref": "#/definitions/at"
             },
-            "windoweyes": {
-              "$ref": "#/definitions/at"
-            },
             "narrator": {
               "$ref": "#/definitions/at"
             },
@@ -156,13 +194,6 @@
         }
       },
       "required": ["feature_id", "feature_assertion_id", "css_target", "results"]
-    },
-    "assertions": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "$ref": "#/definitions/assertion"
-      }
     },
     "history": {
       "type": "object",
@@ -199,6 +230,39 @@
       "type": "string",
       "description": "path relative to the /data/tests/html directory. References the file that contains the test html."
     },
+    "versions": {
+      "type": "object",
+      "properties": {
+        "jaws": {
+          "$ref": "#/definitions/at_version"
+        },
+        "nvda": {
+          "$ref": "#/definitions/at_version"
+        },
+        "vo_ios": {
+          "$ref": "#/definitions/at_version"
+        },
+        "vo_macos": {
+          "$ref": "#/definitions/at_version"
+        },
+        "narrator": {
+          "$ref": "#/definitions/at_version"
+        },
+        "android": {
+          "$ref": "#/definitions/at_version"
+        },
+        "dragon_win": {
+          "$ref": "#/definitions/at_version"
+        }
+      }
+    },
+    "assertions": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "$ref": "#/definitions/assertion"
+      }
+    },
     "history": {
       "type": "array",
       "items": {
@@ -234,6 +298,7 @@
     "extended_support",
     "core_support_string",
     "extended_support_string",
+    "versions",
     "assertions"
   ]
 }

--- a/data/tests/aria_alertdialog_document_mode.json
+++ b/data/tests/aria_alertdialog_document_mode.json
@@ -9,10 +9,6 @@
         "nvda": {
           "browsers": {
             "chrome": {
-              "at_version": "2018.1808.10",
-              "browser_version": "74",
-              "os_version": "1809",
-              "date": "2019-05-19",
               "output": [
                 {
                   "command": "next_item",
@@ -22,10 +18,6 @@
               ]
             },
             "firefox": {
-              "at_version": "2018.4.1",
-              "browser_version": "64.0.2",
-              "os_version": "1809",
-              "date": "2019-01-19",
               "output": [
                 {
                   "command": "next_item",
@@ -40,10 +32,6 @@
         "jaws": {
           "browsers": {
             "ie": {
-              "at_version": "2018.1811.2",
-              "browser_version": "11.253",
-              "os_version": "1809",
-              "date": "2019-01-19",
               "output": [
                 {
                   "command": "next_item",
@@ -53,10 +41,6 @@
               ]
             },
             "chrome": {
-              "at_version": "2018.1808.10",
-              "browser_version": "74",
-              "os_version": "1809",
-              "date": "2019-05-19",
               "output": [
                 {
                   "command": "next_item",
@@ -66,10 +50,6 @@
               ]
             },
             "firefox": {
-              "at_version": "2018.1811.2",
-              "browser_version": "66",
-              "os_version": "1809",
-              "date": "2019-05-19",
               "output": [
                 {
                   "command": "next_item",
@@ -83,10 +63,6 @@
         "vo_macos": {
           "browsers": {
             "safari": {
-              "at_version": "10.14.2",
-              "browser_version": "12.0.2",
-              "os_version": "10.14.2",
-              "date": "2018-10-26",
               "output": [
                 {
                   "command": "next_item",
@@ -100,10 +76,6 @@
         "narrator": {
           "browsers": {
             "edge": {
-              "at_version": "1809",
-              "browser_version": "44.17763",
-              "os_version": "1809",
-              "date": "2018-01-18",
               "output": [
                 {
                   "command": "next_item",
@@ -117,10 +89,6 @@
         "vo_ios": {
           "browsers": {
             "ios_saf": {
-              "at_version": "12.1.2",
-              "browser_version": "12.1.2",
-              "os_version": "12.1.2",
-              "date": "2018-01-18",
               "output": [
                 {
                   "command": "next_item",
@@ -134,10 +102,6 @@
         "talkback": {
           "browsers": {
             "and_chr": {
-              "at_version": "7.2",
-              "browser_version": "67",
-              "os_version": "8.1",
-              "date": "2018-07-21",
               "output": [
                 {
                   "command": "next_item",
@@ -156,5 +120,85 @@
       "date": "2019-01-18",
       "message": "Test created"
     }
-  ]
+  ],
+  "versions": {
+    "jaws": {
+      "browsers": {
+        "chrome": {
+          "at_version": "2018.1808.10",
+          "browser_version": "74",
+          "os_version": "1809",
+          "date": "2019-05-19"
+        },
+        "ie": {
+          "at_version": "2018.1811.2",
+          "browser_version": "11.253",
+          "os_version": "1809",
+          "date": "2019-01-19"
+        },
+        "firefox": {
+          "at_version": "2018.1811.2",
+          "browser_version": "66",
+          "os_version": "1809",
+          "date": "2019-05-19"
+        }
+      }
+    },
+    "narrator": {
+      "browsers": {
+        "edge": {
+          "at_version": "1809",
+          "browser_version": "44.17763",
+          "os_version": "1809",
+          "date": "2018-01-18"
+        }
+      }
+    },
+    "nvda": {
+      "browsers": {
+        "chrome": {
+          "at_version": "2018.1808.10",
+          "browser_version": "74",
+          "os_version": "1809",
+          "date": "2019-05-19"
+        },
+        "firefox": {
+          "at_version": "2018.4.1",
+          "browser_version": "64.0.2",
+          "os_version": "1809",
+          "date": "2019-01-19"
+        }
+      }
+    },
+    "talkback": {
+      "browsers": {
+        "and_chr": {
+          "at_version": "7.2",
+          "browser_version": "67",
+          "os_version": "8.1",
+          "date": "2018-07-21"
+        }
+      }
+    },
+    "vo_ios": {
+      "browsers": {
+        "ios_saf": {
+          "at_version": "12.1.2",
+          "browser_version": "12.1.2",
+          "os_version": "12.1.2",
+          "date": "2018-01-18"
+        }
+      }
+    },
+    "vo_macos": {
+      "browsers": {
+        "safari": {
+          "at_version": "10.14.2",
+          "browser_version": "12.0.2",
+          "os_version": "10.14.2",
+          "date": "2018-10-26"
+        }
+      }
+    }
+  }
 }

--- a/data/tests/aria_dialog_document_mode.json
+++ b/data/tests/aria_dialog_document_mode.json
@@ -9,10 +9,6 @@
         "nvda": {
           "browsers": {
             "chrome": {
-              "at_version": "2018.1808.10",
-              "browser_version": "74",
-              "os_version": "1809",
-              "date": "2019-05-19",
               "output": [
                 {
                   "command": "next_item",
@@ -22,10 +18,6 @@
               ]
             },
             "firefox": {
-              "at_version": "2018.4.1",
-              "browser_version": "64.0.2",
-              "os_version": "1809",
-              "date": "2019-01-19",
               "output": [
                 {
                   "command": "next_item",
@@ -40,10 +32,6 @@
         "jaws": {
           "browsers": {
             "ie": {
-              "at_version": "2018.1811.2",
-              "browser_version": "11.253",
-              "os_version": "1809",
-              "date": "2019-01-19",
               "output": [
                 {
                   "command": "next_item",
@@ -53,10 +41,6 @@
               ]
             },
             "chrome": {
-              "at_version": "2018.1808.10",
-              "browser_version": "74",
-              "os_version": "1809",
-              "date": "2019-05-19",
               "output": [
                 {
                   "command": "next_item",
@@ -66,10 +50,6 @@
               ]
             },
             "firefox": {
-              "at_version": "2018.1811.2",
-              "browser_version": "66",
-              "os_version": "1809",
-              "date": "2019-05-19",
               "output": [
                 {
                   "command": "next_item",
@@ -83,10 +63,6 @@
         "vo_macos": {
           "browsers": {
             "safari": {
-              "at_version": "10.14.2",
-              "browser_version": "12.0.2",
-              "os_version": "10.14.2",
-              "date": "2018-10-26",
               "output": [
                 {
                   "command": "next_item",
@@ -100,10 +76,6 @@
         "narrator": {
           "browsers": {
             "edge": {
-              "at_version": "1809",
-              "browser_version": "44.17763",
-              "os_version": "1809",
-              "date": "2018-01-18",
               "output": [
                 {
                   "command": "next_item",
@@ -117,10 +89,6 @@
         "vo_ios": {
           "browsers": {
             "ios_saf": {
-              "at_version": "12.1.2",
-              "browser_version": "12.1.2",
-              "os_version": "12.1.2",
-              "date": "2018-01-18",
               "output": [
                 {
                   "command": "next_item",
@@ -134,10 +102,6 @@
         "talkback": {
           "browsers": {
             "and_chr": {
-              "at_version": "7.2",
-              "browser_version": "67",
-              "os_version": "8.1",
-              "date": "2018-07-21",
               "output": [
                 {
                   "command": "next_item",
@@ -156,5 +120,85 @@
       "date": "2019-01-18",
       "message": "Test created"
     }
-  ]
+  ],
+  "versions": {
+    "jaws": {
+      "browsers": {
+        "chrome": {
+          "at_version": "2018.1808.10",
+          "browser_version": "74",
+          "os_version": "1809",
+          "date": "2019-05-19"
+        },
+        "ie": {
+          "at_version": "2018.1811.2",
+          "browser_version": "11.253",
+          "os_version": "1809",
+          "date": "2019-01-19"
+        },
+        "firefox": {
+          "at_version": "2018.1811.2",
+          "browser_version": "66",
+          "os_version": "1809",
+          "date": "2019-05-19"
+        }
+      }
+    },
+    "narrator": {
+      "browsers": {
+        "edge": {
+          "at_version": "1809",
+          "browser_version": "44.17763",
+          "os_version": "1809",
+          "date": "2018-01-18"
+        }
+      }
+    },
+    "nvda": {
+      "browsers": {
+        "chrome": {
+          "at_version": "2018.1808.10",
+          "browser_version": "74",
+          "os_version": "1809",
+          "date": "2019-05-19"
+        },
+        "firefox": {
+          "at_version": "2018.4.1",
+          "browser_version": "64.0.2",
+          "os_version": "1809",
+          "date": "2019-01-19"
+        }
+      }
+    },
+    "talkback": {
+      "browsers": {
+        "and_chr": {
+          "at_version": "7.2",
+          "browser_version": "67",
+          "os_version": "8.1",
+          "date": "2018-07-21"
+        }
+      }
+    },
+    "vo_ios": {
+      "browsers": {
+        "ios_saf": {
+          "at_version": "12.1.2",
+          "browser_version": "12.1.2",
+          "os_version": "12.1.2",
+          "date": "2018-01-18"
+        }
+      }
+    },
+    "vo_macos": {
+      "browsers": {
+        "safari": {
+          "at_version": "10.14.2",
+          "browser_version": "12.0.2",
+          "os_version": "10.14.2",
+          "date": "2018-10-26"
+        }
+      }
+    }
+  }
 }

--- a/data/tests/aria_gridcell(aria-selected-false).json
+++ b/data/tests/aria_gridcell(aria-selected-false).json
@@ -15,10 +15,6 @@
         "nvda": {
           "browsers": {
             "firefox": {
-              "at_version": "2018.3.2",
-              "browser_version": "63",
-              "os_version": "17763",
-              "date": "2018-10-26",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -33,10 +29,6 @@
         "vo_macos": {
           "browsers": {
             "safari": {
-              "at_version": "10.14",
-              "browser_version": "12",
-              "os_version": "10.14",
-              "date": "2018-10-26",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -56,5 +48,27 @@
       "date": "2018-10-26",
       "message": "Test created"
     }
-  ]
+  ],
+  "versions": {
+    "nvda": {
+      "browsers": {
+        "firefox": {
+          "at_version": "2018.3.2",
+          "browser_version": "63",
+          "os_version": "17763",
+          "date": "2018-10-26"
+        }
+      }
+    },
+    "vo_macos": {
+      "browsers": {
+        "safari": {
+          "at_version": "10.14",
+          "browser_version": "12",
+          "os_version": "10.14",
+          "date": "2018-10-26"
+        }
+      }
+    }
+  }
 }

--- a/data/tests/aria_gridcell.json
+++ b/data/tests/aria_gridcell.json
@@ -10,10 +10,6 @@
         "nvda": {
           "browsers": {
             "firefox": {
-              "at_version": "2018.3.2",
-              "browser_version": "63",
-              "os_version": "17763",
-              "date": "2018-10-26",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -28,10 +24,6 @@
         "vo_macos": {
           "browsers": {
             "safari": {
-              "at_version": "10.14",
-              "browser_version": "12",
-              "os_version": "10.14",
-              "date": "2018-10-26",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -51,5 +43,27 @@
       "date": "2018-10-26",
       "message": "Test created"
     }
-  ]
+  ],
+  "versions": {
+    "nvda": {
+      "browsers": {
+        "firefox": {
+          "at_version": "2018.3.2",
+          "browser_version": "63",
+          "os_version": "17763",
+          "date": "2018-10-26"
+        }
+      }
+    },
+    "vo_macos": {
+      "browsers": {
+        "safari": {
+          "at_version": "10.14",
+          "browser_version": "12",
+          "os_version": "10.14",
+          "date": "2018-10-26"
+        }
+      }
+    }
+  }
 }

--- a/data/tests/aria_hidden_text_input.json
+++ b/data/tests/aria_hidden_text_input.json
@@ -10,9 +10,6 @@
         "nvda": {
           "browsers": {
             "firefox": {
-              "at_version": "2018.2.1",
-              "browser_version": "61.0.1",
-              "os_version": "17134.165",
               "output": [
                 {
                   "command": "next_item",
@@ -25,7 +22,6 @@
                   "result": "pass"
                 }
               ],
-              "date": "2018-08-02",
               "notes": "When using focus mode (tab key) the control is still read. This is because the `aria-hidden=\"true\"` does not make elements in the sub tree inert. It is the author's responsibility to make controls inert. See [nvaccess/nvda #5014](https://github.com/nvaccess/nvda/issues/5014) for more information."
             }
           }
@@ -33,10 +29,6 @@
         "vo_macos": {
           "browsers": {
             "safari": {
-              "at_version": "10.13.6",
-              "browser_version": "11.1.2",
-              "os_version": "10.13.6",
-              "date": "2018-08-19",
               "output": [
                 {
                   "command": "next_item",
@@ -77,5 +69,27 @@
       "date": "2018-08-19",
       "message": "vo_macos/safari support updated"
     }
-  ]
+  ],
+  "versions": {
+    "nvda": {
+      "browsers": {
+        "firefox": {
+          "at_version": "2018.2.1",
+          "browser_version": "61.0.1",
+          "os_version": "17134.165",
+          "date": "2018-08-02"
+        }
+      }
+    },
+    "vo_macos": {
+      "browsers": {
+        "safari": {
+          "at_version": "10.13.6",
+          "browser_version": "11.1.2",
+          "os_version": "10.13.6",
+          "date": "2018-08-19"
+        }
+      }
+    }
+  }
 }

--- a/data/tests/aria_roledescription_with_html_button.json
+++ b/data/tests/aria_roledescription_with_html_button.json
@@ -10,10 +10,6 @@
         "jaws": {
           "browsers": {
             "edge": {
-              "at_version": "2018.1808.10",
-              "browser_version": "44.17763.1.0",
-              "os_version": "17763",
-              "date": "2018-11-12",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -23,10 +19,6 @@
               ]
             },
             "ie": {
-              "at_version": "17763",
-              "browser_version": "44.17763.1.0",
-              "os_version": "17763",
-              "date": "2018-11-12",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -40,10 +32,6 @@
         "narrator": {
           "browsers": {
             "edge": {
-              "at_version": "17763",
-              "browser_version": "44.17763.1.0",
-              "os_version": "17763",
-              "date": "2018-11-12",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -57,10 +45,6 @@
         "nvda": {
           "browsers": {
             "firefox": {
-              "at_version": "2018.3.2",
-              "browser_version": "63.0.1",
-              "os_version": "17763",
-              "date": "2018-11-12",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -74,10 +58,6 @@
         "vo_macos": {
           "browsers": {
             "safari": {
-              "at_version": "10.14.1",
-              "browser_version": "12.0.1",
-              "os_version": "10.14.1",
-              "date": "2018-11-12",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -91,10 +71,6 @@
         "vo_ios": {
           "browsers": {
             "ios_saf": {
-              "at_version": "12.1",
-              "browser_version": "12.1",
-              "os_version": "12.1",
-              "date": "2018-11-12",
               "output": [
                 {
                   "command": "next_item",
@@ -114,5 +90,63 @@
       "date": "2018-11-12",
       "message": "Test created"
     }
-  ]
+  ],
+  "versions": {
+    "jaws": {
+      "browsers": {
+        "ie": {
+          "at_version": "17763",
+          "browser_version": "44.17763.1.0",
+          "os_version": "17763",
+          "date": "2018-11-12"
+        },
+        "edge": {
+          "at_version": "2018.1808.10",
+          "browser_version": "44.17763.1.0",
+          "os_version": "17763",
+          "date": "2018-11-12"
+        }
+      }
+    },
+    "narrator": {
+      "browsers": {
+        "edge": {
+          "at_version": "17763",
+          "browser_version": "44.17763.1.0",
+          "os_version": "17763",
+          "date": "2018-11-12"
+        }
+      }
+    },
+    "nvda": {
+      "browsers": {
+        "firefox": {
+          "at_version": "2018.3.2",
+          "browser_version": "63.0.1",
+          "os_version": "17763",
+          "date": "2018-11-12"
+        }
+      }
+    },
+    "vo_ios": {
+      "browsers": {
+        "ios_saf": {
+          "at_version": "12.1",
+          "browser_version": "12.1",
+          "os_version": "12.1",
+          "date": "2018-11-12"
+        }
+      }
+    },
+    "vo_macos": {
+      "browsers": {
+        "safari": {
+          "at_version": "10.14.1",
+          "browser_version": "12.0.1",
+          "os_version": "10.14.1",
+          "date": "2018-11-12"
+        }
+      }
+    }
+  }
 }

--- a/data/tests/aria_roledescription_with_html_section.json
+++ b/data/tests/aria_roledescription_with_html_section.json
@@ -10,10 +10,6 @@
         "jaws": {
           "browsers": {
             "edge": {
-              "at_version": "2018.1808.10",
-              "browser_version": "44.17763.1.0",
-              "os_version": "17763",
-              "date": "2018-11-12",
               "output": [
                 {
                   "command": "next_item",
@@ -23,10 +19,6 @@
               ]
             },
             "ie": {
-              "at_version": "2018.1808.10",
-              "browser_version": "11.55",
-              "os_version": "17763",
-              "date": "2018-11-12",
               "output": [
                 {
                   "command": "next_item",
@@ -40,10 +32,6 @@
         "narrator": {
           "browsers": {
             "edge": {
-              "at_version": "17763",
-              "browser_version": "44.17763.1.0",
-              "os_version": "17763",
-              "date": "2018-11-12",
               "output": [
                 {
                   "command": "next_item",
@@ -57,10 +45,6 @@
         "nvda": {
           "browsers": {
             "firefox": {
-              "at_version": "2018.3.2",
-              "browser_version": "63.0.1",
-              "os_version": "17763",
-              "date": "2018-11-12",
               "output": [
                 {
                   "command": "next_item",
@@ -74,10 +58,6 @@
         "vo_macos": {
           "browsers": {
             "safari": {
-              "at_version": "10.14.1",
-              "browser_version": "12.0.1",
-              "os_version": "10.14.1",
-              "date": "2018-10-19",
               "output": [
                 {
                   "command": "next_item",
@@ -91,10 +71,6 @@
         "vo_ios": {
           "browsers": {
             "ios_saf": {
-              "at_version": "12.1",
-              "browser_version": "12.1",
-              "os_version": "12.1",
-              "date": "2018-11-12",
               "output": [
                 {
                   "command": "next_item",
@@ -114,5 +90,63 @@
       "date": "2018-11-12",
       "message": "Test created"
     }
-  ]
+  ],
+  "versions": {
+    "jaws": {
+      "browsers": {
+        "ie": {
+          "at_version": "2018.1808.10",
+          "browser_version": "11.55",
+          "os_version": "17763",
+          "date": "2018-11-12"
+        },
+        "edge": {
+          "at_version": "2018.1808.10",
+          "browser_version": "44.17763.1.0",
+          "os_version": "17763",
+          "date": "2018-11-12"
+        }
+      }
+    },
+    "narrator": {
+      "browsers": {
+        "edge": {
+          "at_version": "17763",
+          "browser_version": "44.17763.1.0",
+          "os_version": "17763",
+          "date": "2018-11-12"
+        }
+      }
+    },
+    "nvda": {
+      "browsers": {
+        "firefox": {
+          "at_version": "2018.3.2",
+          "browser_version": "63.0.1",
+          "os_version": "17763",
+          "date": "2018-11-12"
+        }
+      }
+    },
+    "vo_ios": {
+      "browsers": {
+        "ios_saf": {
+          "at_version": "12.1",
+          "browser_version": "12.1",
+          "os_version": "12.1",
+          "date": "2018-11-12"
+        }
+      }
+    },
+    "vo_macos": {
+      "browsers": {
+        "safari": {
+          "at_version": "10.14.1",
+          "browser_version": "12.0.1",
+          "os_version": "10.14.1",
+          "date": "2018-10-19"
+        }
+      }
+    }
+  }
 }

--- a/data/tests/css_generated_content.json
+++ b/data/tests/css_generated_content.json
@@ -10,70 +10,50 @@
         "jaws": {
           "browsers": {
             "firefox": {
-              "at_version": "18",
-              "browser_version": "60",
-              "os_version": "17134",
               "output": [
                 {
                   "command": "next_item",
                   "output": "This is generated content.",
                   "result": "pass"
                 }
-              ],
-              "date": "2018-07-21"
+              ]
             },
             "ie": {
-              "at_version": "2019.1903",
-              "browser_version": "11",
-              "os_version": "1809",
               "output": [
                 {
                   "command": "next_item",
                   "output": "is generated",
                   "result": "fail"
                 }
-              ],
-              "date": "2019-03-21"
+              ]
             },
             "edge": {
-              "at_version": "18",
-              "browser_version": "17",
-              "os_version": "17134",
               "output": [
                 {
                   "command": "next_item",
                   "output": "This is generated content.",
                   "result": "pass"
                 }
-              ],
-              "date": "2018-07-21"
+              ]
             }
           }
         },
         "nvda": {
           "browsers": {
             "firefox": {
-              "at_version": "2018.1.1",
-              "browser_version": "60",
-              "os_version": "17134",
               "output": [
                 {
                   "command": "next_item",
                   "output": "This is generated content.",
                   "result": "pass"
                 }
-              ],
-              "date": "2018-07-21"
+              ]
             }
           }
         },
         "vo_ios": {
           "browsers": {
             "ios_saf": {
-              "at_version": "11.4.1",
-              "browser_version": "11.4.1",
-              "os_version": "11.4.1",
-              "date": "2018-08-12",
               "output": [
                 {
                   "command": "next_item",
@@ -93,10 +73,6 @@
         "vo_macos": {
           "browsers": {
             "safari": {
-              "at_version": "10.13.6",
-              "browser_version": "11.1.2",
-              "os_version": "10.13.6",
-              "date": "2018-08-19",
               "output": [
                 {
                   "command": "next_item",
@@ -116,10 +92,6 @@
         "narrator": {
           "browsers": {
             "edge": {
-              "at_version": "1809",
-              "browser_version": "44",
-              "os_version": "1809",
-              "date": "2018-12-17",
               "output": [
                 {
                   "command": "next_item",
@@ -155,5 +127,69 @@
       "date": "2019-03-21",
       "message": "jaws/ie updated with latest versions"
     }
-  ]
+  ],
+  "versions": {
+    "jaws": {
+      "browsers": {
+        "ie": {
+          "at_version": "2019.1903",
+          "browser_version": "11",
+          "os_version": "1809",
+          "date": "2019-03-21"
+        },
+        "firefox": {
+          "at_version": "18",
+          "browser_version": "60",
+          "os_version": "17134",
+          "date": "2018-07-21"
+        },
+        "edge": {
+          "at_version": "18",
+          "browser_version": "17",
+          "os_version": "17134",
+          "date": "2018-07-21"
+        }
+      }
+    },
+    "narrator": {
+      "browsers": {
+        "edge": {
+          "at_version": "1809",
+          "browser_version": "44",
+          "os_version": "1809",
+          "date": "2018-12-17"
+        }
+      }
+    },
+    "nvda": {
+      "browsers": {
+        "firefox": {
+          "at_version": "2018.1.1",
+          "browser_version": "60",
+          "os_version": "17134",
+          "date": "2018-07-21"
+        }
+      }
+    },
+    "vo_ios": {
+      "browsers": {
+        "ios_saf": {
+          "at_version": "11.4.1",
+          "browser_version": "11.4.1",
+          "os_version": "11.4.1",
+          "date": "2018-08-12"
+        }
+      }
+    },
+    "vo_macos": {
+      "browsers": {
+        "safari": {
+          "at_version": "10.13.6",
+          "browser_version": "11.1.2",
+          "os_version": "10.13.6",
+          "date": "2018-08-19"
+        }
+      }
+    }
+  }
 }

--- a/data/tests/html/html_label_element_css_content.html
+++ b/data/tests/html/html_label_element_css_content.html
@@ -8,7 +8,7 @@
         }
 
         #label::after {
-            content: ' content.'
+            content: ' content'
         }
     </style>
 </head>

--- a/data/tests/html_button(type-button--aria-disabled-true).json
+++ b/data/tests/html_button(type-button--aria-disabled-true).json
@@ -10,10 +10,6 @@
         "vo_ios": {
           "browsers": {
             "ios_saf": {
-              "at_version": "12.1",
-              "browser_version": "12.1",
-              "os_version": "12.1",
-              "date": "2018-11-30",
               "output": [
                 {
                   "command": "next_rotor_item",
@@ -33,10 +29,6 @@
         "vo_macos": {
           "browsers": {
             "safari": {
-              "at_version": "10.14.1",
-              "browser_version": "12.0.1",
-              "os_version": "10.14.1",
-              "date": "2018-11-30",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -56,10 +48,6 @@
         "narrator": {
           "browsers": {
             "edge": {
-              "at_version": "1809",
-              "browser_version": "44.17763",
-              "os_version": "1809",
-              "date": "2018-11-30",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -79,10 +67,6 @@
         "jaws": {
           "browsers": {
             "ie": {
-              "at_version": "2018.1808.10",
-              "browser_version": "11.134",
-              "os_version": "1809",
-              "date": "2018-11-30",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -98,10 +82,6 @@
               "notes": ""
             },
             "firefox": {
-              "at_version": "2018.1808.10",
-              "browser_version": "63.0.1",
-              "os_version": "1809",
-              "date": "2018-11-30",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -121,10 +101,6 @@
         "nvda": {
           "browsers": {
             "firefox": {
-              "at_version": "2018.3.2",
-              "browser_version": "63",
-              "os_version": "1809",
-              "date": "2018-11-30",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -153,5 +129,63 @@
       "date": "2018-11-30",
       "message": "support updated"
     }
-  ]
+  ],
+  "versions": {
+    "jaws": {
+      "browsers": {
+        "ie": {
+          "at_version": "2018.1808.10",
+          "browser_version": "11.134",
+          "os_version": "1809",
+          "date": "2018-11-30"
+        },
+        "firefox": {
+          "at_version": "2018.1808.10",
+          "browser_version": "63.0.1",
+          "os_version": "1809",
+          "date": "2018-11-30"
+        }
+      }
+    },
+    "narrator": {
+      "browsers": {
+        "edge": {
+          "at_version": "1809",
+          "browser_version": "44.17763",
+          "os_version": "1809",
+          "date": "2018-11-30"
+        }
+      }
+    },
+    "nvda": {
+      "browsers": {
+        "firefox": {
+          "at_version": "2018.3.2",
+          "browser_version": "63",
+          "os_version": "1809",
+          "date": "2018-11-30"
+        }
+      }
+    },
+    "vo_ios": {
+      "browsers": {
+        "ios_saf": {
+          "at_version": "12.1",
+          "browser_version": "12.1",
+          "os_version": "12.1",
+          "date": "2018-11-30"
+        }
+      }
+    },
+    "vo_macos": {
+      "browsers": {
+        "safari": {
+          "at_version": "10.14.1",
+          "browser_version": "12.0.1",
+          "os_version": "10.14.1",
+          "date": "2018-11-30"
+        }
+      }
+    }
+  }
 }

--- a/data/tests/html_button(type-button--aria-disabled-true--aria-haspopup-true).json
+++ b/data/tests/html_button(type-button--aria-disabled-true--aria-haspopup-true).json
@@ -10,10 +10,6 @@
         "vo_ios": {
           "browsers": {
             "ios_saf": {
-              "at_version": "12.1",
-              "browser_version": "12.1",
-              "os_version": "12.1",
-              "date": "2018-12-03",
               "output": [
                 {
                   "command": "next_rotor_item",
@@ -33,10 +29,6 @@
         "vo_macos": {
           "browsers": {
             "safari": {
-              "at_version": "10.14.1",
-              "browser_version": "12.0.1",
-              "os_version": "10.14.1",
-              "date": "2018-12-03",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -56,10 +48,6 @@
         "jaws": {
           "browsers": {
             "firefox": {
-              "at_version": "2018.1808.10",
-              "browser_version": "63",
-              "os_version": "1809",
-              "date": "2018-12-03",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -75,10 +63,6 @@
               "notes": ""
             },
             "ie": {
-              "at_version": "2018.1808.10",
-              "browser_version": "11.134",
-              "os_version": "1809",
-              "date": "2018-12-03",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -98,10 +82,6 @@
         "narrator": {
           "browsers": {
             "edge": {
-              "at_version": "1809",
-              "browser_version": "44.17763",
-              "os_version": "1809",
-              "date": "2018-12-03",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -121,10 +101,6 @@
         "nvda": {
           "browsers": {
             "firefox": {
-              "at_version": "2018.3.2",
-              "browser_version": "63.0.1",
-              "os_version": "1809",
-              "date": "2018-12-03",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -153,5 +129,63 @@
       "date": "2018-12-03",
       "message": "support updated"
     }
-  ]
+  ],
+  "versions": {
+    "jaws": {
+      "browsers": {
+        "ie": {
+          "at_version": "2018.1808.10",
+          "browser_version": "11.134",
+          "os_version": "1809",
+          "date": "2018-12-03"
+        },
+        "firefox": {
+          "at_version": "2018.1808.10",
+          "browser_version": "63",
+          "os_version": "1809",
+          "date": "2018-12-03"
+        }
+      }
+    },
+    "narrator": {
+      "browsers": {
+        "edge": {
+          "at_version": "1809",
+          "browser_version": "44.17763",
+          "os_version": "1809",
+          "date": "2018-12-03"
+        }
+      }
+    },
+    "nvda": {
+      "browsers": {
+        "firefox": {
+          "at_version": "2018.3.2",
+          "browser_version": "63.0.1",
+          "os_version": "1809",
+          "date": "2018-12-03"
+        }
+      }
+    },
+    "vo_ios": {
+      "browsers": {
+        "ios_saf": {
+          "at_version": "12.1",
+          "browser_version": "12.1",
+          "os_version": "12.1",
+          "date": "2018-12-03"
+        }
+      }
+    },
+    "vo_macos": {
+      "browsers": {
+        "safari": {
+          "at_version": "10.14.1",
+          "browser_version": "12.0.1",
+          "os_version": "10.14.1",
+          "date": "2018-12-03"
+        }
+      }
+    }
+  }
 }

--- a/data/tests/html_button(type-button--disabled).json
+++ b/data/tests/html_button(type-button--disabled).json
@@ -10,10 +10,6 @@
         "vo_ios": {
           "browsers": {
             "ios_saf": {
-              "at_version": "12.1",
-              "browser_version": "12.1",
-              "os_version": "12.1",
-              "date": "2018-11-30",
               "output": [
                 {
                   "command": "next_rotor_item",
@@ -33,10 +29,6 @@
         "vo_macos": {
           "browsers": {
             "safari": {
-              "at_version": "10.14.1",
-              "browser_version": "12.0.1",
-              "os_version": "10.14.1",
-              "date": "2018-11-30",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -56,10 +48,6 @@
         "narrator": {
           "browsers": {
             "edge": {
-              "at_version": "1809",
-              "browser_version": "44.17763",
-              "os_version": "1809",
-              "date": "2018-11-30",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -79,10 +67,6 @@
         "jaws": {
           "browsers": {
             "ie": {
-              "at_version": "2018.1808.10",
-              "browser_version": "11.134",
-              "os_version": "1809",
-              "date": "2018-11-30",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -98,10 +82,6 @@
               "notes": ""
             },
             "firefox": {
-              "at_version": "2018.1808.10",
-              "browser_version": "63",
-              "os_version": "1809",
-              "date": "2018-11-30",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -121,10 +101,6 @@
         "nvda": {
           "browsers": {
             "firefox": {
-              "at_version": "2018.3.2",
-              "browser_version": "63.0.1",
-              "os_version": "1809",
-              "date": "2018-11-30",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -149,5 +125,63 @@
       "date": "2018-11-08",
       "message": "Test created"
     }
-  ]
+  ],
+  "versions": {
+    "jaws": {
+      "browsers": {
+        "ie": {
+          "at_version": "2018.1808.10",
+          "browser_version": "11.134",
+          "os_version": "1809",
+          "date": "2018-11-30"
+        },
+        "firefox": {
+          "at_version": "2018.1808.10",
+          "browser_version": "63",
+          "os_version": "1809",
+          "date": "2018-11-30"
+        }
+      }
+    },
+    "narrator": {
+      "browsers": {
+        "edge": {
+          "at_version": "1809",
+          "browser_version": "44.17763",
+          "os_version": "1809",
+          "date": "2018-11-30"
+        }
+      }
+    },
+    "nvda": {
+      "browsers": {
+        "firefox": {
+          "at_version": "2018.3.2",
+          "browser_version": "63.0.1",
+          "os_version": "1809",
+          "date": "2018-11-30"
+        }
+      }
+    },
+    "vo_ios": {
+      "browsers": {
+        "ios_saf": {
+          "at_version": "12.1",
+          "browser_version": "12.1",
+          "os_version": "12.1",
+          "date": "2018-11-30"
+        }
+      }
+    },
+    "vo_macos": {
+      "browsers": {
+        "safari": {
+          "at_version": "10.14.1",
+          "browser_version": "12.0.1",
+          "os_version": "10.14.1",
+          "date": "2018-11-30"
+        }
+      }
+    }
+  }
 }

--- a/data/tests/html_button(type-button--disabled--aria-haspopup-true).json
+++ b/data/tests/html_button(type-button--disabled--aria-haspopup-true).json
@@ -10,10 +10,6 @@
         "vo_ios": {
           "browsers": {
             "ios_saf": {
-              "at_version": "12.1",
-              "browser_version": "12.1",
-              "os_version": "12.1",
-              "date": "2018-12-03",
               "output": [
                 {
                   "command": "next_rotor_item",
@@ -33,10 +29,6 @@
         "vo_macos": {
           "browsers": {
             "safari": {
-              "at_version": "10.14.1",
-              "browser_version": "12.0.1",
-              "os_version": "10.14.1",
-              "date": "2018-12-03",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -56,10 +48,6 @@
         "jaws": {
           "browsers": {
             "firefox": {
-              "at_version": "2018.1808.10",
-              "browser_version": "63",
-              "os_version": "1809",
-              "date": "2018-12-03",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -75,10 +63,6 @@
               "notes": ""
             },
             "ie": {
-              "at_version": "2018.1808.10",
-              "browser_version": "11.134",
-              "os_version": "1809",
-              "date": "2018-12-03",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -98,10 +82,6 @@
         "narrator": {
           "browsers": {
             "edge": {
-              "at_version": "1809",
-              "browser_version": "44.17763",
-              "os_version": "1809",
-              "date": "2018-12-03",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -121,10 +101,6 @@
         "nvda": {
           "browsers": {
             "firefox": {
-              "at_version": "2018.3.2",
-              "browser_version": "63.0.1",
-              "os_version": "1809",
-              "date": "2018-12-03",
               "output": [
                 {
                   "command": "next_item",
@@ -153,5 +129,63 @@
       "date": "2018-12-03",
       "message": "vo_ios/ios_saf support updated"
     }
-  ]
+  ],
+  "versions": {
+    "jaws": {
+      "browsers": {
+        "ie": {
+          "at_version": "2018.1808.10",
+          "browser_version": "11.134",
+          "os_version": "1809",
+          "date": "2018-12-03"
+        },
+        "firefox": {
+          "at_version": "2018.1808.10",
+          "browser_version": "63",
+          "os_version": "1809",
+          "date": "2018-12-03"
+        }
+      }
+    },
+    "narrator": {
+      "browsers": {
+        "edge": {
+          "at_version": "1809",
+          "browser_version": "44.17763",
+          "os_version": "1809",
+          "date": "2018-12-03"
+        }
+      }
+    },
+    "nvda": {
+      "browsers": {
+        "firefox": {
+          "at_version": "2018.3.2",
+          "browser_version": "63.0.1",
+          "os_version": "1809",
+          "date": "2018-12-03"
+        }
+      }
+    },
+    "vo_ios": {
+      "browsers": {
+        "ios_saf": {
+          "at_version": "12.1",
+          "browser_version": "12.1",
+          "os_version": "12.1",
+          "date": "2018-12-03"
+        }
+      }
+    },
+    "vo_macos": {
+      "browsers": {
+        "safari": {
+          "at_version": "10.14.1",
+          "browser_version": "12.0.1",
+          "os_version": "10.14.1",
+          "date": "2018-12-03"
+        }
+      }
+    }
+  }
 }

--- a/data/tests/html_label_element_css_content.json
+++ b/data/tests/html_label_element_css_content.json
@@ -10,10 +10,6 @@
         "jaws": {
           "browsers": {
             "ie": {
-              "at_version": "2019.1903",
-              "browser_version": "11",
-              "os_version": "1809",
-              "date": "2019-03-21",
               "output": [
                 {
                   "command": "next_item",
@@ -28,17 +24,9 @@
               ]
             },
             "edge": {
-              "at_version": "18",
-              "browser_version": "17",
-              "os_version": "17134",
-              "support": "y",
-              "date": "2018-07-21"
+              "support": "y"
             },
             "firefox": {
-              "at_version": "2019",
-              "browser_version": "65.0.1",
-              "os_version": "1809",
-              "date": "2019-02-24",
               "output": [
                 {
                   "command": "next_item",
@@ -58,65 +46,41 @@
         "nvda": {
           "browsers": {
             "firefox": {
-              "at_version": "2018.1.1",
-              "browser_version": "60",
-              "os_version": "17134",
-              "support": "y",
-              "date": "2018-07-21"
+              "support": "y"
             }
           }
         },
         "vo_ios": {
           "browsers": {
             "ios_saf": {
-              "at_version": "11.4",
-              "browser_version": "11.4",
-              "os_version": "11.4",
-              "support": "y",
-              "date": "2018-07-21"
+              "support": "y"
             }
           }
         },
         "vo_macos": {
           "browsers": {
             "safari": {
-              "at_version": "10.13.5",
-              "browser_version": "11.1.1",
-              "os_version": "10.13.5",
-              "support": "y",
-              "date": "2018-07-21"
+              "support": "y"
             }
           }
         },
         "narrator": {
           "browsers": {
             "edge": {
-              "at_version": "10",
-              "browser_version": "17",
-              "os_version": "17134",
-              "support": "y",
-              "date": "2018-07-21"
+              "support": "y"
             }
           }
         },
         "talkback": {
           "browsers": {
             "and_chr": {
-              "at_version": "6.2",
-              "browser_version": "67",
-              "os_version": "8.1",
-              "support": "y",
-              "date": "2018-07-21"
+              "support": "y"
             }
           }
         },
         "dragon_win": {
           "browsers": {
             "chrome": {
-              "at_version": "15.30",
-              "browser_version": "70.0",
-              "os_version": "1809",
-              "date": "2018-11-15",
               "output": [
                 {
                   "command": "activate_actionable_item",
@@ -127,10 +91,6 @@
               "notes": ""
             },
             "ie": {
-              "at_version": "15.30",
-              "browser_version": "11.134",
-              "os_version": "1809",
-              "date": "2018-11-15",
               "output": [
                 {
                   "command": "activate_actionable_item",
@@ -141,10 +101,6 @@
               "notes": "It worked if I said \"click generated\", which means that the CSS generated content is not taken into account."
             },
             "firefox": {
-              "at_version": "15.30",
-              "browser_version": "63.0.1",
-              "os_version": "1809",
-              "date": "2018-11-15",
               "output": [
                 {
                   "command": "activate_actionable_item",
@@ -188,5 +144,101 @@
       "date": "2019-03-21",
       "message": "jaws/ie updated with latest versions"
     }
-  ]
+  ],
+  "versions": {
+    "dragon_win": {
+      "browsers": {
+        "ie": {
+          "at_version": "15.30",
+          "browser_version": "11.134",
+          "os_version": "1809",
+          "date": "2018-11-15"
+        },
+        "firefox": {
+          "at_version": "15.30",
+          "browser_version": "63.0.1",
+          "os_version": "1809",
+          "date": "2018-11-15"
+        },
+        "chrome": {
+          "at_version": "15.30",
+          "browser_version": "70.0",
+          "os_version": "1809",
+          "date": "2018-11-15"
+        }
+      }
+    },
+    "jaws": {
+      "browsers": {
+        "ie": {
+          "at_version": "2019.1903",
+          "browser_version": "11",
+          "os_version": "1809",
+          "date": "2019-03-21"
+        },
+        "firefox": {
+          "at_version": "2019",
+          "browser_version": "65.0.1",
+          "os_version": "1809",
+          "date": "2019-02-24"
+        },
+        "edge": {
+          "at_version": "18",
+          "browser_version": "17",
+          "os_version": "17134",
+          "date": "2018-07-21"
+        }
+      }
+    },
+    "narrator": {
+      "browsers": {
+        "edge": {
+          "at_version": "10",
+          "browser_version": "17",
+          "os_version": "17134",
+          "date": "2018-07-21"
+        }
+      }
+    },
+    "nvda": {
+      "browsers": {
+        "firefox": {
+          "at_version": "2018.1.1",
+          "browser_version": "60",
+          "os_version": "17134",
+          "date": "2018-07-21"
+        }
+      }
+    },
+    "talkback": {
+      "browsers": {
+        "and_chr": {
+          "at_version": "6.2",
+          "browser_version": "67",
+          "os_version": "8.1",
+          "date": "2018-07-21"
+        }
+      }
+    },
+    "vo_ios": {
+      "browsers": {
+        "ios_saf": {
+          "at_version": "11.4",
+          "browser_version": "11.4",
+          "os_version": "11.4",
+          "date": "2018-07-21"
+        }
+      }
+    },
+    "vo_macos": {
+      "browsers": {
+        "safari": {
+          "at_version": "10.13.5",
+          "browser_version": "11.1.1",
+          "os_version": "10.13.5",
+          "date": "2018-07-21"
+        }
+      }
+    }
+  }
 }

--- a/data/tests/html_label_element_css_content.json
+++ b/data/tests/html_label_element_css_content.json
@@ -24,7 +24,18 @@
               ]
             },
             "edge": {
-              "support": "y"
+              "output": [
+                {
+                  "command": "next_item",
+                  "output": "\"This is generated content\"",
+                  "result": "fail"
+                },
+                {
+                  "command": "next_focusable_item",
+                  "output": "\"This is generated content, edit\"",
+                  "result": "fail"
+                }
+              ]
             },
             "firefox": {
               "output": [
@@ -38,43 +49,115 @@
                   "output": "\"This is generated content, edit\"",
                   "result": "pass"
                 }
-              ],
-              "notes": "all content from the label (whether generated or not) becomes part of the input's accessible name and is announced by JAWS 2019 with Firefox 65.0.1 in both browse and forms mode."
+              ]
+            },
+            "chrome": {
+              "output": [
+                {
+                  "command": "next_item",
+                  "output": "\"This is generated content\"",
+                  "result": "pass"
+                },
+                {
+                  "command": "next_focusable_item",
+                  "output": "\"This is generated content, edit, type in text\"",
+                  "result": "pass"
+                }
+              ]
             }
           }
         },
         "nvda": {
           "browsers": {
             "firefox": {
-              "support": "y"
+              "output": [
+                {
+                  "command": "next_item",
+                  "output": "\"This is generated content, clickable\"",
+                  "result": "pass"
+                },
+                {
+                  "command": "next_focusable_item",
+                  "output": "\"This is generated content, edit, blank\"",
+                  "result": "pass"
+                }
+              ]
+            },
+            "chrome": {
+              "output": [
+                {
+                  "command": "next_item",
+                  "output": "\"This is generated content, edit\"",
+                  "result": "pass"
+                },
+                {
+                  "command": "next_focusable_item",
+                  "output": "\"This is generated content, edit, blank\"",
+                  "result": "pass"
+                }
+              ]
             }
           }
         },
         "vo_ios": {
           "browsers": {
             "ios_saf": {
-              "support": "y"
+              "output": [
+                {
+                  "command": "next_item",
+                  "output": "\"This is generated content, text field\"",
+                  "result": "pass"
+                }
+              ]
             }
           }
         },
         "vo_macos": {
           "browsers": {
             "safari": {
-              "support": "y"
+              "output": [
+                {
+                  "command": "next_item",
+                  "output": "\"This is generated content, edit text\"",
+                  "result": "pass"
+                },
+                {
+                  "command": "next_focusable_item",
+                  "output": "\"This is generated content, edit text\"",
+                  "result": "pass"
+                }
+              ]
             }
           }
         },
         "narrator": {
           "browsers": {
             "edge": {
-              "support": "y"
+              "output": [
+                {
+                  "command": "next_item",
+                  "output": "\"This is generated content, edit\"",
+                  "result": "pass"
+                },
+                {
+                  "command": "next_focusable_item",
+                  "output": "\"This is generated content, edit\"",
+                  "result": "pass"
+                }
+              ]
             }
           }
         },
         "talkback": {
           "browsers": {
             "and_chr": {
-              "support": "y"
+              "output": [
+                {
+                  "command": "next_item",
+                  "output": "\"This is generated content, edit\"",
+                  "result": "pass"
+                }
+              ]
             }
           }
         },
@@ -87,8 +170,7 @@
                   "output": "(input was not focused)",
                   "result": "fail"
                 }
-              ],
-              "notes": ""
+              ]
             },
             "ie": {
               "output": [
@@ -171,32 +253,38 @@
     "jaws": {
       "browsers": {
         "ie": {
-          "at_version": "2019.1903",
+          "at_version": "2019.1906.10",
           "browser_version": "11",
-          "os_version": "1809",
-          "date": "2019-03-21"
+          "os_version": "1903",
+          "date": "2019-07-10"
         },
         "firefox": {
-          "at_version": "2019",
-          "browser_version": "65.0.1",
-          "os_version": "1809",
-          "date": "2019-02-24"
+          "at_version": "2019.1606.10",
+          "browser_version": "67",
+          "os_version": "1903",
+          "date": "2019-07-10"
         },
         "edge": {
-          "at_version": "18",
-          "browser_version": "17",
-          "os_version": "17134",
-          "date": "2018-07-21"
+          "at_version": "2019.1906.10",
+          "browser_version": "44",
+          "os_version": "1903",
+          "date": "2019-07-10"
+        },
+        "chrome": {
+          "at_version": "2019.1906.10",
+          "browser_version": "75",
+          "os_version": "1903",
+          "date": "2019-07-10"
         }
       }
     },
     "narrator": {
       "browsers": {
         "edge": {
-          "at_version": "10",
-          "browser_version": "17",
-          "os_version": "17134",
-          "date": "2018-07-21"
+          "at_version": "1903",
+          "browser_version": "44",
+          "os_version": "1903",
+          "date": "2019-07-10"
         }
       }
     },
@@ -205,8 +293,14 @@
         "firefox": {
           "at_version": "2018.1.1",
           "browser_version": "60",
-          "os_version": "17134",
-          "date": "2018-07-21"
+          "os_version": "1903",
+          "date": "2019-07-10"
+        },
+        "chrome": {
+          "at_version": "2019.1906.10",
+          "browser_version": "75",
+          "os_version": "1903",
+          "date": "2019-07-10"
         }
       }
     },
@@ -223,20 +317,20 @@
     "vo_ios": {
       "browsers": {
         "ios_saf": {
-          "at_version": "11.4",
-          "browser_version": "11.4",
-          "os_version": "11.4",
-          "date": "2018-07-21"
+          "at_version": "12.3.1",
+          "browser_version": "12.3.1",
+          "os_version": "12.3.1",
+          "date": "2019-07-10"
         }
       }
     },
     "vo_macos": {
       "browsers": {
         "safari": {
-          "at_version": "10.13.5",
-          "browser_version": "11.1.1",
+          "at_version": "10.14.5",
+          "browser_version": "12.1.1",
           "os_version": "10.13.5",
-          "date": "2018-07-21"
+          "date": "2019-07-10"
         }
       }
     }

--- a/data/tests/html_label_element_explicit.json
+++ b/data/tests/html_label_element_explicit.json
@@ -11,49 +11,30 @@
         "jaws": {
           "browsers": {
             "ie": {
-              "at_version": "18",
-              "browser_version": "11",
-              "os_version": "17134",
-              "support": "y",
-              "date": "2018-07-21"
+              "support": "y"
             },
             "edge": {
-              "at_version": "18",
-              "browser_version": "17",
-              "os_version": "17134",
-              "support": "y",
-              "date": "2018-07-21"
+              "support": "y"
             }
           }
         },
         "nvda": {
           "browsers": {
             "firefox": {
-              "at_version": "2018.1.1",
-              "browser_version": "60",
-              "os_version": "17134",
-              "support": "y",
-              "date": "2018-07-21"
+              "support": "y"
             }
           }
         },
         "vo_ios": {
           "browsers": {
             "ios_saf": {
-              "at_version": "11.4",
-              "browser_version": "11.4",
-              "os_version": "11.4",
-              "support": "y",
-              "date": "2018-07-21"
+              "support": "y"
             }
           }
         },
         "vo_macos": {
           "browsers": {
             "safari": {
-              "at_version": "10.13.5",
-              "browser_version": "11.1.1",
-              "os_version": "10.13.5",
               "support": "y",
               "output": [
                 {
@@ -61,13 +42,9 @@
                   "output": "your name, edit text",
                   "result": "pass"
                 }
-              ],
-              "date": "2018-07-21"
+              ]
             },
             "chrome": {
-              "at_version": "10.13.6",
-              "browser_version": "68.0.3440.84",
-              "os_version": "10.13.6",
               "support": "y",
               "output": [
                 {
@@ -80,40 +57,27 @@
                   "output": "your name, edit text",
                   "result": "pass"
                 }
-              ],
-              "date": "2018-08-02"
+              ]
             }
           }
         },
         "narrator": {
           "browsers": {
             "edge": {
-              "at_version": "10",
-              "browser_version": "17",
-              "os_version": "17134",
-              "support": "y",
-              "date": "2018-07-21"
+              "support": "y"
             }
           }
         },
         "talkback": {
           "browsers": {
             "and_chr": {
-              "at_version": "6.2",
-              "browser_version": "67",
-              "os_version": "8.1",
-              "support": "y",
-              "date": "2018-07-21"
+              "support": "y"
             }
           }
         },
         "dragon_win": {
           "browsers": {
             "chrome": {
-              "at_version": "15.30",
-              "browser_version": "70.0",
-              "os_version": "1809",
-              "date": "2018-11-15",
               "output": [
                 {
                   "command": "activate_actionable_item",
@@ -129,10 +93,6 @@
               "notes": ""
             },
             "ie": {
-              "at_version": "15.30",
-              "browser_version": "11.134",
-              "os_version": "1809",
-              "date": "2018-11-15",
               "output": [
                 {
                   "command": "activate_actionable_item",
@@ -148,10 +108,6 @@
               "notes": ""
             },
             "firefox": {
-              "at_version": "15.30",
-              "browser_version": "63.0.1",
-              "os_version": "1809",
-              "date": "2018-11-15",
               "output": [
                 {
                   "command": "activate_actionable_item",
@@ -192,5 +148,101 @@
       "date": "2018-11-15",
       "message": "dragon_win/chrome support updated"
     }
-  ]
+  ],
+  "versions": {
+    "dragon_win": {
+      "browsers": {
+        "ie": {
+          "at_version": "15.30",
+          "browser_version": "11.134",
+          "os_version": "1809",
+          "date": "2018-11-15"
+        },
+        "firefox": {
+          "at_version": "15.30",
+          "browser_version": "63.0.1",
+          "os_version": "1809",
+          "date": "2018-11-15"
+        },
+        "chrome": {
+          "at_version": "15.30",
+          "browser_version": "70.0",
+          "os_version": "1809",
+          "date": "2018-11-15"
+        }
+      }
+    },
+    "jaws": {
+      "browsers": {
+        "ie": {
+          "at_version": "18",
+          "browser_version": "11",
+          "os_version": "17134",
+          "date": "2018-07-21"
+        },
+        "edge": {
+          "at_version": "18",
+          "browser_version": "17",
+          "os_version": "17134",
+          "date": "2018-07-21"
+        }
+      }
+    },
+    "narrator": {
+      "browsers": {
+        "edge": {
+          "at_version": "10",
+          "browser_version": "17",
+          "os_version": "17134",
+          "date": "2018-07-21"
+        }
+      }
+    },
+    "nvda": {
+      "browsers": {
+        "firefox": {
+          "at_version": "2018.1.1",
+          "browser_version": "60",
+          "os_version": "17134",
+          "date": "2018-07-21"
+        }
+      }
+    },
+    "talkback": {
+      "browsers": {
+        "and_chr": {
+          "at_version": "6.2",
+          "browser_version": "67",
+          "os_version": "8.1",
+          "date": "2018-07-21"
+        }
+      }
+    },
+    "vo_ios": {
+      "browsers": {
+        "ios_saf": {
+          "at_version": "11.4",
+          "browser_version": "11.4",
+          "os_version": "11.4",
+          "date": "2018-07-21"
+        }
+      }
+    },
+    "vo_macos": {
+      "browsers": {
+        "safari": {
+          "at_version": "10.13.5",
+          "browser_version": "11.1.1",
+          "os_version": "10.13.5",
+          "date": "2018-07-21"
+        },
+        "chrome": {
+          "at_version": "10.13.6",
+          "browser_version": "68.0.3440.84",
+          "os_version": "10.13.6",
+          "date": "2018-08-02"
+        }
+      }
+    }
+  }
 }

--- a/data/tests/html_label_element_explicit.json
+++ b/data/tests/html_label_element_explicit.json
@@ -11,32 +11,97 @@
         "jaws": {
           "browsers": {
             "ie": {
-              "support": "y"
+              "output": [
+                {
+                  "command": "next_focusable_item",
+                  "output": "\"Your name, edit, type in text\"",
+                  "result": "pass"
+                }
+              ]
             },
             "edge": {
-              "support": "y"
+              "output": [
+                {
+                  "command": "next_focusable_item",
+                  "output": "\"Your name, edit, type in text\"",
+                  "result": "pass"
+                }
+              ]
+            },
+            "firefox": {
+              "output": [
+                {
+                  "command": "next_focusable_item",
+                  "output": "\"Your name, edit, type in text\"",
+                  "result": "pass"
+                }
+              ]
+            },
+            "chrome": {
+              "output": [
+                {
+                  "command": "next_focusable_item",
+                  "output": "\"Your name, edit, type in text\"",
+                  "result": "pass"
+                }
+              ]
             }
           }
         },
         "nvda": {
           "browsers": {
             "firefox": {
-              "support": "y"
+              "output": [
+                {
+                  "command": "next_item",
+                  "output": "\"Clickable, Your name, edit, has auto complete\"",
+                  "result": "pass"
+                },
+                {
+                  "command": "next_focusable_item",
+                  "output": "\"Your name, edit, has auto complete, blank\"",
+                  "result": "pass"
+                }
+              ]
+            },
+            "chrome": {
+              "output": [
+                {
+                  "command": "next_item",
+                  "output": "\"Clickable, Your name, edit\"",
+                  "result": "pass"
+                },
+                {
+                  "command": "next_focusable_item",
+                  "output": "\"Your name, edit, blank\"",
+                  "result": "pass"
+                }
+              ]
             }
           }
         },
         "vo_ios": {
           "browsers": {
             "ios_saf": {
-              "support": "y"
+              "output": [
+                {
+                  "command": "next_item",
+                  "output": "\"Your name, text field\"",
+                  "result": "pass"
+                }
+              ]
             }
           }
         },
         "vo_macos": {
           "browsers": {
             "safari": {
-              "support": "y",
               "output": [
+                {
+                  "command": "next_item",
+                  "output": "your name, edit text",
+                  "result": "pass"
+                },
                 {
                   "command": "next_focusable_item",
                   "output": "your name, edit text",
@@ -45,7 +110,6 @@
               ]
             },
             "chrome": {
-              "support": "y",
               "output": [
                 {
                   "command": "next_item",
@@ -64,14 +128,31 @@
         "narrator": {
           "browsers": {
             "edge": {
-              "support": "y"
+              "output": [
+                {
+                  "command": "next_item",
+                  "output": "\"Your name\"",
+                  "result": "pass"
+                },
+                {
+                  "command": "next_focusable_item",
+                  "output": "\"Your name, edit\"",
+                  "result": "pass"
+                }
+              ]
             }
           }
         },
         "talkback": {
           "browsers": {
             "and_chr": {
-              "support": "y"
+              "output": [
+                {
+                  "command": "next_item",
+                  "output": "\"Your name, edit\"",
+                  "result": "pass"
+                }
+              ]
             }
           }
         },
@@ -175,26 +256,38 @@
     "jaws": {
       "browsers": {
         "ie": {
-          "at_version": "18",
+          "at_version": "2019.1906.10",
           "browser_version": "11",
-          "os_version": "17134",
-          "date": "2018-07-21"
+          "os_version": "1903",
+          "date": "2019-07-10"
+        },
+        "firefox": {
+          "at_version": "2019.1606.10",
+          "browser_version": "67",
+          "os_version": "1903",
+          "date": "2019-07-10"
         },
         "edge": {
-          "at_version": "18",
-          "browser_version": "17",
-          "os_version": "17134",
-          "date": "2018-07-21"
+          "at_version": "2019.1906.10",
+          "browser_version": "44",
+          "os_version": "1903",
+          "date": "2019-07-10"
+        },
+        "chrome": {
+          "at_version": "2019.1906.10",
+          "browser_version": "75",
+          "os_version": "1903",
+          "date": "2019-07-10"
         }
       }
     },
     "narrator": {
       "browsers": {
         "edge": {
-          "at_version": "10",
-          "browser_version": "17",
-          "os_version": "17134",
-          "date": "2018-07-21"
+          "at_version": "1903",
+          "browser_version": "44",
+          "os_version": "1903",
+          "date": "2019-07-10"
         }
       }
     },
@@ -203,8 +296,14 @@
         "firefox": {
           "at_version": "2018.1.1",
           "browser_version": "60",
-          "os_version": "17134",
-          "date": "2018-07-21"
+          "os_version": "1903",
+          "date": "2019-07-10"
+        },
+        "chrome": {
+          "at_version": "2019.1906.10",
+          "browser_version": "75",
+          "os_version": "1903",
+          "date": "2019-07-10"
         }
       }
     },
@@ -221,26 +320,26 @@
     "vo_ios": {
       "browsers": {
         "ios_saf": {
-          "at_version": "11.4",
-          "browser_version": "11.4",
-          "os_version": "11.4",
-          "date": "2018-07-21"
+          "at_version": "12.3.1",
+          "browser_version": "12.3.1",
+          "os_version": "12.3.1",
+          "date": "2019-07-10"
         }
       }
     },
     "vo_macos": {
       "browsers": {
         "safari": {
-          "at_version": "10.13.5",
-          "browser_version": "11.1.1",
+          "at_version": "10.14.5",
+          "browser_version": "12.1.1",
           "os_version": "10.13.5",
-          "date": "2018-07-21"
+          "date": "2019-07-10"
         },
         "chrome": {
-          "at_version": "10.13.6",
-          "browser_version": "68.0.3440.84",
-          "os_version": "10.13.6",
-          "date": "2018-08-02"
+          "at_version": "10.14.5",
+          "browser_version": "75",
+          "os_version": "10.13.5",
+          "date": "2019-07-10"
         }
       }
     }

--- a/data/tests/html_label_element_implicit.json
+++ b/data/tests/html_label_element_implicit.json
@@ -11,45 +11,148 @@
         "jaws": {
           "browsers": {
             "ie": {
-              "support": "y"
+              "output": [
+                {
+                  "command": "next_focusable_item",
+                  "output": "\"Your name, edit, type in text\"",
+                  "result": "pass"
+                }
+              ]
             },
             "edge": {
-              "support": "y"
+              "output": [
+                {
+                  "command": "next_focusable_item",
+                  "output": "\"Your name, edit, type in text\"",
+                  "result": "pass"
+                }
+              ]
+            },
+            "firefox": {
+              "output": [
+                {
+                  "command": "next_focusable_item",
+                  "output": "\"Your name, edit, type in text\"",
+                  "result": "pass"
+                }
+              ]
+            },
+            "chrome": {
+              "output": [
+                {
+                  "command": "next_focusable_item",
+                  "output": "\"Your name, edit, type in text\"",
+                  "result": "pass"
+                }
+              ]
             }
           }
         },
         "nvda": {
           "browsers": {
             "firefox": {
-              "support": "y"
+              "output": [
+                {
+                  "command": "next_item",
+                  "output": "\"Clickable, Your name, edit, has auto complete\"",
+                  "result": "pass"
+                },
+                {
+                  "command": "next_focusable_item",
+                  "output": "\"Your name, edit, has auto complete, blank\"",
+                  "result": "pass"
+                }
+              ]
+            },
+            "chrome": {
+              "output": [
+                {
+                  "command": "next_item",
+                  "output": "\"Clickable, Your name, edit\"",
+                  "result": "pass"
+                },
+                {
+                  "command": "next_focusable_item",
+                  "output": "\"Your name, edit, blank\"",
+                  "result": "pass"
+                }
+              ]
             }
           }
         },
         "vo_ios": {
           "browsers": {
             "ios_saf": {
-              "support": "y"
+              "output": [
+                {
+                  "command": "next_item",
+                  "output": "\"Your name, text field\"",
+                  "result": "pass"
+                }
+              ]
             }
           }
         },
         "vo_macos": {
           "browsers": {
             "safari": {
-              "support": "y"
+              "output": [
+                {
+                  "command": "next_item",
+                  "output": "your name, edit text",
+                  "result": "pass"
+                },
+                {
+                  "command": "next_focusable_item",
+                  "output": "your name, edit text",
+                  "result": "pass"
+                }
+              ]
+            },
+            "chrome": {
+              "output": [
+                {
+                  "command": "next_item",
+                  "output": "your name, edit text",
+                  "result": "pass"
+                },
+                {
+                  "command": "next_focusable_item",
+                  "output": "your name, edit text",
+                  "result": "pass"
+                }
+              ]
             }
           }
         },
         "narrator": {
           "browsers": {
             "edge": {
-              "support": "y"
+              "output": [
+                {
+                  "command": "next_item",
+                  "output": "\"Your name\"",
+                  "result": "pass"
+                },
+                {
+                  "command": "next_focusable_item",
+                  "output": "\"Your name, edit\"",
+                  "result": "pass"
+                }
+              ]
             }
           }
         },
         "talkback": {
           "browsers": {
             "and_chr": {
-              "support": "y"
+              "output": [
+                {
+                  "command": "next_item",
+                  "output": "\"Your name, edit\"",
+                  "result": "pass"
+                }
+              ]
             }
           }
         },
@@ -149,26 +252,38 @@
     "jaws": {
       "browsers": {
         "ie": {
-          "at_version": "18",
+          "at_version": "2019.1906.10",
           "browser_version": "11",
-          "os_version": "17134",
-          "date": "2018-07-21"
+          "os_version": "1903",
+          "date": "2019-07-10"
+        },
+        "firefox": {
+          "at_version": "2019.1606.10",
+          "browser_version": "67",
+          "os_version": "1903",
+          "date": "2019-07-10"
         },
         "edge": {
-          "at_version": "18",
-          "browser_version": "17",
-          "os_version": "17134",
-          "date": "2018-07-21"
+          "at_version": "2019.1906.10",
+          "browser_version": "44",
+          "os_version": "1903",
+          "date": "2019-07-10"
+        },
+        "chrome": {
+          "at_version": "2019.1906.10",
+          "browser_version": "75",
+          "os_version": "1903",
+          "date": "2019-07-10"
         }
       }
     },
     "narrator": {
       "browsers": {
         "edge": {
-          "at_version": "10",
-          "browser_version": "17",
-          "os_version": "17134",
-          "date": "2018-07-21"
+          "at_version": "1903",
+          "browser_version": "44",
+          "os_version": "1903",
+          "date": "2019-07-10"
         }
       }
     },
@@ -177,8 +292,14 @@
         "firefox": {
           "at_version": "2018.1.1",
           "browser_version": "60",
-          "os_version": "17134",
-          "date": "2018-07-21"
+          "os_version": "1903",
+          "date": "2019-07-10"
+        },
+        "chrome": {
+          "at_version": "2019.1906.10",
+          "browser_version": "75",
+          "os_version": "1903",
+          "date": "2019-07-10"
         }
       }
     },
@@ -195,20 +316,26 @@
     "vo_ios": {
       "browsers": {
         "ios_saf": {
-          "at_version": "11.4",
-          "browser_version": "11.4",
-          "os_version": "11.4",
-          "date": "2018-07-21"
+          "at_version": "12.3.1",
+          "browser_version": "12.3.1",
+          "os_version": "12.3.1",
+          "date": "2019-07-10"
         }
       }
     },
     "vo_macos": {
       "browsers": {
         "safari": {
-          "at_version": "10.13.5",
-          "browser_version": "11.1.1",
+          "at_version": "10.14.5",
+          "browser_version": "12.1.1",
           "os_version": "10.13.5",
-          "date": "2018-07-21"
+          "date": "2019-07-10"
+        },
+        "chrome": {
+          "at_version": "10.14.5",
+          "browser_version": "75",
+          "os_version": "10.13.5",
+          "date": "2019-07-10"
         }
       }
     }

--- a/data/tests/html_label_element_implicit.json
+++ b/data/tests/html_label_element_implicit.json
@@ -11,83 +11,51 @@
         "jaws": {
           "browsers": {
             "ie": {
-              "at_version": "18",
-              "browser_version": "11",
-              "os_version": "17134",
-              "support": "y",
-              "date": "2018-07-21"
+              "support": "y"
             },
             "edge": {
-              "at_version": "18",
-              "browser_version": "17",
-              "os_version": "17134",
-              "support": "y",
-              "date": "2018-07-21"
+              "support": "y"
             }
           }
         },
         "nvda": {
           "browsers": {
             "firefox": {
-              "at_version": "2018.1.1",
-              "browser_version": "60",
-              "os_version": "17134",
-              "support": "y",
-              "date": "2018-07-21"
+              "support": "y"
             }
           }
         },
         "vo_ios": {
           "browsers": {
             "ios_saf": {
-              "at_version": "11.4",
-              "browser_version": "11.4",
-              "os_version": "11.4",
-              "support": "y",
-              "date": "2018-07-21"
+              "support": "y"
             }
           }
         },
         "vo_macos": {
           "browsers": {
             "safari": {
-              "at_version": "10.13.5",
-              "browser_version": "11.1.1",
-              "os_version": "10.13.5",
-              "support": "y",
-              "date": "2018-07-21"
+              "support": "y"
             }
           }
         },
         "narrator": {
           "browsers": {
             "edge": {
-              "at_version": "10",
-              "browser_version": "17",
-              "os_version": "17134",
-              "support": "y",
-              "date": "2018-07-21"
+              "support": "y"
             }
           }
         },
         "talkback": {
           "browsers": {
             "and_chr": {
-              "at_version": "6.2",
-              "browser_version": "67",
-              "os_version": "8.1",
-              "support": "y",
-              "date": "2018-07-21"
+              "support": "y"
             }
           }
         },
         "dragon_win": {
           "browsers": {
             "chrome": {
-              "at_version": "15.30",
-              "browser_version": "70.0",
-              "os_version": "1809",
-              "date": "2018-11-15",
               "output": [
                 {
                   "command": "activate_actionable_item",
@@ -103,10 +71,6 @@
               "notes": ""
             },
             "ie": {
-              "at_version": "15.30",
-              "browser_version": "11.134",
-              "os_version": "1809",
-              "date": "2018-11-15",
               "output": [
                 {
                   "command": "activate_actionable_item",
@@ -122,10 +86,6 @@
               "notes": ""
             },
             "firefox": {
-              "at_version": "15.30",
-              "browser_version": "63.0.1",
-              "os_version": "1809",
-              "date": "2018-11-15",
               "output": [
                 {
                   "command": "activate_actionable_item",
@@ -162,5 +122,95 @@
       "date": "2018-11-15",
       "message": "dragon_win/chrome support updated"
     }
-  ]
+  ],
+  "versions": {
+    "dragon_win": {
+      "browsers": {
+        "ie": {
+          "at_version": "15.30",
+          "browser_version": "11.134",
+          "os_version": "1809",
+          "date": "2018-11-15"
+        },
+        "firefox": {
+          "at_version": "15.30",
+          "browser_version": "63.0.1",
+          "os_version": "1809",
+          "date": "2018-11-15"
+        },
+        "chrome": {
+          "at_version": "15.30",
+          "browser_version": "70.0",
+          "os_version": "1809",
+          "date": "2018-11-15"
+        }
+      }
+    },
+    "jaws": {
+      "browsers": {
+        "ie": {
+          "at_version": "18",
+          "browser_version": "11",
+          "os_version": "17134",
+          "date": "2018-07-21"
+        },
+        "edge": {
+          "at_version": "18",
+          "browser_version": "17",
+          "os_version": "17134",
+          "date": "2018-07-21"
+        }
+      }
+    },
+    "narrator": {
+      "browsers": {
+        "edge": {
+          "at_version": "10",
+          "browser_version": "17",
+          "os_version": "17134",
+          "date": "2018-07-21"
+        }
+      }
+    },
+    "nvda": {
+      "browsers": {
+        "firefox": {
+          "at_version": "2018.1.1",
+          "browser_version": "60",
+          "os_version": "17134",
+          "date": "2018-07-21"
+        }
+      }
+    },
+    "talkback": {
+      "browsers": {
+        "and_chr": {
+          "at_version": "6.2",
+          "browser_version": "67",
+          "os_version": "8.1",
+          "date": "2018-07-21"
+        }
+      }
+    },
+    "vo_ios": {
+      "browsers": {
+        "ios_saf": {
+          "at_version": "11.4",
+          "browser_version": "11.4",
+          "os_version": "11.4",
+          "date": "2018-07-21"
+        }
+      }
+    },
+    "vo_macos": {
+      "browsers": {
+        "safari": {
+          "at_version": "10.13.5",
+          "browser_version": "11.1.1",
+          "os_version": "10.13.5",
+          "date": "2018-07-21"
+        }
+      }
+    }
+  }
 }

--- a/data/tests/html_li_element_in_ol_with_sub_ol_posinset.json
+++ b/data/tests/html_li_element_in_ol_with_sub_ol_posinset.json
@@ -12,10 +12,6 @@
         "nvda": {
           "browsers": {
             "firefox": {
-              "at_version": "2018.3.2",
-              "browser_version": "62",
-              "os_version": "17763",
-              "date": "2018-10-19",
               "output": [
                 {
                   "command": "next_item",
@@ -29,10 +25,6 @@
         "vo_macos": {
           "browsers": {
             "safari": {
-              "at_version": "10.14",
-              "browser_version": "12",
-              "os_version": "10.14",
-              "date": "2018-10-19",
               "output": [
                 {
                   "command": "next_item",
@@ -51,5 +43,27 @@
       "date": "2018-10-19",
       "message": "Test created"
     }
-  ]
+  ],
+  "versions": {
+    "nvda": {
+      "browsers": {
+        "firefox": {
+          "at_version": "2018.3.2",
+          "browser_version": "62",
+          "os_version": "17763",
+          "date": "2018-10-19"
+        }
+      }
+    },
+    "vo_macos": {
+      "browsers": {
+        "safari": {
+          "at_version": "10.14",
+          "browser_version": "12",
+          "os_version": "10.14",
+          "date": "2018-10-19"
+        }
+      }
+    }
+  }
 }

--- a/data/tests/html_li_element_in_ol_with_sub_ol_setsize.json
+++ b/data/tests/html_li_element_in_ol_with_sub_ol_setsize.json
@@ -12,10 +12,6 @@
         "narrator": {
           "browsers": {
             "edge": {
-              "at_version": "1809",
-              "browser_version": "44.17763",
-              "os_version": "1809",
-              "date": "2019-05-20",
               "output": [
                 {
                   "command": "next_item",
@@ -30,10 +26,6 @@
         "nvda": {
           "browsers": {
             "firefox": {
-              "at_version": "2018.3.2",
-              "browser_version": "62",
-              "os_version": "17763",
-              "date": "2018-10-19",
               "output": [
                 {
                   "command": "next_item",
@@ -43,10 +35,6 @@
               ]
             },
             "chrome": {
-              "at_version": "2018.1808.10",
-              "browser_version": "74",
-              "os_version": "1809",
-              "date": "2019-05-20",
               "output": [
                 {
                   "command": "next_item",
@@ -60,10 +48,6 @@
         "jaws": {
           "browsers": {
             "ie": {
-              "at_version": "2018.1811.2",
-              "browser_version": "11.134",
-              "os_version": "1809",
-              "date": "2019-05-20",
               "output": [
                 {
                   "command": "next_item",
@@ -74,10 +58,6 @@
               "notes": ""
             },
             "firefox": {
-              "at_version": "2018.1811.2",
-              "browser_version": "66",
-              "os_version": "1809",
-              "date": "2019-05-20",
               "output": [
                 {
                   "command": "next_item",
@@ -88,10 +68,6 @@
               "notes": ""
             },
             "chrome": {
-              "at_version": "2018.1811.2",
-              "browser_version": "74",
-              "os_version": "1809",
-              "date": "2019-05-20",
               "output": [
                 {
                   "command": "next_item",
@@ -106,10 +82,6 @@
         "vo_macos": {
           "browsers": {
             "safari": {
-              "at_version": "10.14",
-              "browser_version": "12",
-              "os_version": "10.14",
-              "date": "2018-10-19",
               "output": [
                 {
                   "command": "next_item",
@@ -123,10 +95,6 @@
         "vo_ios": {
           "browsers": {
             "ios_saf": {
-              "at_version": "12.2",
-              "browser_version": "12.2",
-              "os_version": "12.2",
-              "date": "2019-05-20",
               "output": [
                 {
                   "command": "next_item",
@@ -146,5 +114,75 @@
       "date": "2018-10-19",
       "message": "Test created"
     }
-  ]
+  ],
+  "versions": {
+    "jaws": {
+      "browsers": {
+        "chrome": {
+          "at_version": "2018.1811.2",
+          "browser_version": "74",
+          "os_version": "1809",
+          "date": "2019-05-20"
+        },
+        "ie": {
+          "at_version": "2018.1811.2",
+          "browser_version": "11.134",
+          "os_version": "1809",
+          "date": "2019-05-20"
+        },
+        "firefox": {
+          "at_version": "2018.1811.2",
+          "browser_version": "66",
+          "os_version": "1809",
+          "date": "2019-05-20"
+        }
+      }
+    },
+    "narrator": {
+      "browsers": {
+        "edge": {
+          "at_version": "1809",
+          "browser_version": "44.17763",
+          "os_version": "1809",
+          "date": "2019-05-20"
+        }
+      }
+    },
+    "nvda": {
+      "browsers": {
+        "chrome": {
+          "at_version": "2018.1808.10",
+          "browser_version": "74",
+          "os_version": "1809",
+          "date": "2019-05-20"
+        },
+        "firefox": {
+          "at_version": "2018.3.2",
+          "browser_version": "62",
+          "os_version": "17763",
+          "date": "2018-10-19"
+        }
+      }
+    },
+    "vo_ios": {
+      "browsers": {
+        "ios_saf": {
+          "at_version": "12.2",
+          "browser_version": "12.2",
+          "os_version": "12.2",
+          "date": "2019-05-20"
+        }
+      }
+    },
+    "vo_macos": {
+      "browsers": {
+        "safari": {
+          "at_version": "10.14",
+          "browser_version": "12",
+          "os_version": "10.14",
+          "date": "2018-10-19"
+        }
+      }
+    }
+  }
 }

--- a/data/tests/html_li_element_in_ul_with_sub_ul_posinset.json
+++ b/data/tests/html_li_element_in_ul_with_sub_ul_posinset.json
@@ -12,10 +12,6 @@
         "nvda": {
           "browsers": {
             "firefox": {
-              "at_version": "2018.3.2",
-              "browser_version": "62",
-              "os_version": "17763",
-              "date": "2018-10-19",
               "output": [
                 {
                   "command": "next_item",
@@ -29,10 +25,6 @@
         "vo_macos": {
           "browsers": {
             "safari": {
-              "at_version": "10.14",
-              "browser_version": "12",
-              "os_version": "10.14",
-              "date": "2018-10-19",
               "output": [
                 {
                   "command": "next_item",
@@ -51,5 +43,27 @@
       "date": "2018-10-19",
       "message": "Test created"
     }
-  ]
+  ],
+  "versions": {
+    "nvda": {
+      "browsers": {
+        "firefox": {
+          "at_version": "2018.3.2",
+          "browser_version": "62",
+          "os_version": "17763",
+          "date": "2018-10-19"
+        }
+      }
+    },
+    "vo_macos": {
+      "browsers": {
+        "safari": {
+          "at_version": "10.14",
+          "browser_version": "12",
+          "os_version": "10.14",
+          "date": "2018-10-19"
+        }
+      }
+    }
+  }
 }

--- a/data/tests/html_li_element_in_ul_with_sub_ul_setsize.json
+++ b/data/tests/html_li_element_in_ul_with_sub_ul_setsize.json
@@ -12,10 +12,6 @@
         "narrator": {
           "browsers": {
             "edge": {
-              "at_version": "1809",
-              "browser_version": "44.17763",
-              "os_version": "1809",
-              "date": "2019-05-20",
               "output": [
                 {
                   "command": "next_item",
@@ -30,10 +26,6 @@
         "nvda": {
           "browsers": {
             "firefox": {
-              "at_version": "2018.3.2",
-              "browser_version": "62",
-              "os_version": "17763",
-              "date": "2018-10-20",
               "output": [
                 {
                   "command": "next_item",
@@ -43,10 +35,6 @@
               ]
             },
             "chrome": {
-              "at_version": "2018.1808.10",
-              "browser_version": "74",
-              "os_version": "1809",
-              "date": "2019-05-20",
               "output": [
                 {
                   "command": "next_item",
@@ -60,10 +48,6 @@
         "jaws": {
           "browsers": {
             "ie": {
-              "at_version": "2018.1811.2",
-              "browser_version": "11.134",
-              "os_version": "1809",
-              "date": "2019-05-20",
               "output": [
                 {
                   "command": "next_item",
@@ -74,10 +58,6 @@
               "notes": ""
             },
             "firefox": {
-              "at_version": "2018.1811.2",
-              "browser_version": "66",
-              "os_version": "1809",
-              "date": "2019-05-20",
               "output": [
                 {
                   "command": "next_item",
@@ -88,10 +68,6 @@
               "notes": ""
             },
             "chrome": {
-              "at_version": "2018.1811.2",
-              "browser_version": "74",
-              "os_version": "1809",
-              "date": "2019-05-20",
               "output": [
                 {
                   "command": "next_item",
@@ -106,10 +82,6 @@
         "vo_macos": {
           "browsers": {
             "safari": {
-              "at_version": "10.14",
-              "browser_version": "12",
-              "os_version": "10.14",
-              "date": "2018-10-19",
               "output": [
                 {
                   "command": "next_item",
@@ -123,10 +95,6 @@
         "vo_ios": {
           "browsers": {
             "ios_saf": {
-              "at_version": "12.2",
-              "browser_version": "12.2",
-              "os_version": "12.2",
-              "date": "2019-05-20",
               "output": [
                 {
                   "command": "next_item",
@@ -146,5 +114,75 @@
       "date": "2018-10-19",
       "message": "Test created"
     }
-  ]
+  ],
+  "versions": {
+    "jaws": {
+      "browsers": {
+        "chrome": {
+          "at_version": "2018.1811.2",
+          "browser_version": "74",
+          "os_version": "1809",
+          "date": "2019-05-20"
+        },
+        "ie": {
+          "at_version": "2018.1811.2",
+          "browser_version": "11.134",
+          "os_version": "1809",
+          "date": "2019-05-20"
+        },
+        "firefox": {
+          "at_version": "2018.1811.2",
+          "browser_version": "66",
+          "os_version": "1809",
+          "date": "2019-05-20"
+        }
+      }
+    },
+    "narrator": {
+      "browsers": {
+        "edge": {
+          "at_version": "1809",
+          "browser_version": "44.17763",
+          "os_version": "1809",
+          "date": "2019-05-20"
+        }
+      }
+    },
+    "nvda": {
+      "browsers": {
+        "chrome": {
+          "at_version": "2018.1808.10",
+          "browser_version": "74",
+          "os_version": "1809",
+          "date": "2019-05-20"
+        },
+        "firefox": {
+          "at_version": "2018.3.2",
+          "browser_version": "62",
+          "os_version": "17763",
+          "date": "2018-10-20"
+        }
+      }
+    },
+    "vo_ios": {
+      "browsers": {
+        "ios_saf": {
+          "at_version": "12.2",
+          "browser_version": "12.2",
+          "os_version": "12.2",
+          "date": "2019-05-20"
+        }
+      }
+    },
+    "vo_macos": {
+      "browsers": {
+        "safari": {
+          "at_version": "10.14",
+          "browser_version": "12",
+          "os_version": "10.14",
+          "date": "2018-10-19"
+        }
+      }
+    }
+  }
 }

--- a/data/tests/html_option_element_with_lang.json
+++ b/data/tests/html_option_element_with_lang.json
@@ -11,10 +11,6 @@
         "nvda": {
           "browsers": {
             "firefox": {
-              "at_version": "2018.3.2",
-              "browser_version": "62",
-              "os_version": "17763",
-              "date": "2018-10-19",
               "output": [
                 {
                   "command": "next_item",
@@ -29,10 +25,6 @@
         "vo_macos": {
           "browsers": {
             "safari": {
-              "at_version": "10.14",
-              "browser_version": "12",
-              "os_version": "10.14",
-              "date": "2018-10-19",
               "output": [
                 {
                   "command": "next_item",
@@ -55,5 +47,27 @@
       "date": "2018-10-19",
       "message": "Test created"
     }
-  ]
+  ],
+  "versions": {
+    "nvda": {
+      "browsers": {
+        "firefox": {
+          "at_version": "2018.3.2",
+          "browser_version": "62",
+          "os_version": "17763",
+          "date": "2018-10-19"
+        }
+      }
+    },
+    "vo_macos": {
+      "browsers": {
+        "safari": {
+          "at_version": "10.14",
+          "browser_version": "12",
+          "os_version": "10.14",
+          "date": "2018-10-19"
+        }
+      }
+    }
+  }
 }

--- a/data/tests/html_p_element_with_lang.json
+++ b/data/tests/html_p_element_with_lang.json
@@ -11,10 +11,6 @@
         "nvda": {
           "browsers": {
             "firefox": {
-              "at_version": "2018.3.2",
-              "browser_version": "62",
-              "os_version": "17763",
-              "date": "2018-10-19",
               "output": [
                 {
                   "command": "next_item",
@@ -29,10 +25,6 @@
         "vo_macos": {
           "browsers": {
             "safari": {
-              "at_version": "10.14",
-              "browser_version": "12",
-              "os_version": "10.14",
-              "date": "2018-10-19",
               "output": [
                 {
                   "command": "next_item",
@@ -55,5 +47,27 @@
       "date": "2018-10-19",
       "message": "Test created"
     }
-  ]
+  ],
+  "versions": {
+    "nvda": {
+      "browsers": {
+        "firefox": {
+          "at_version": "2018.3.2",
+          "browser_version": "62",
+          "os_version": "17763",
+          "date": "2018-10-19"
+        }
+      }
+    },
+    "vo_macos": {
+      "browsers": {
+        "safari": {
+          "at_version": "10.14",
+          "browser_version": "12",
+          "os_version": "10.14",
+          "date": "2018-10-19"
+        }
+      }
+    }
+  }
 }

--- a/data/tests/html_section(aria-label).json
+++ b/data/tests/html_section(aria-label).json
@@ -10,10 +10,6 @@
         "jaws": {
           "browsers": {
             "edge": {
-              "at_version": "2018.1808.10",
-              "browser_version": "44.17763.1.0",
-              "os_version": "17763",
-              "date": "2018-11-14",
               "output": [
                 {
                   "command": "next_item",
@@ -34,10 +30,6 @@
               "notes": "The next region command took the user to the text within the region, but did not announce the region name."
             },
             "ie": {
-              "at_version": "2018.1808.10",
-              "browser_version": "11.134",
-              "os_version": "17763",
-              "date": "2018-11-14",
               "output": [
                 {
                   "command": "next_item",
@@ -61,10 +53,6 @@
         "narrator": {
           "browsers": {
             "edge": {
-              "at_version": "17763",
-              "browser_version": "44.17763.1.0",
-              "os_version": "17763",
-              "date": "2018-11-14",
               "output": [
                 {
                   "command": "next_item",
@@ -83,10 +71,6 @@
         "nvda": {
           "browsers": {
             "firefox": {
-              "at_version": "2018.3.2",
-              "browser_version": "63.0.1",
-              "os_version": "17763",
-              "date": "2018-11-14",
               "output": [
                 {
                   "command": "next_item",
@@ -105,10 +89,6 @@
         "vo_macos": {
           "browsers": {
             "safari": {
-              "at_version": "10.14.1",
-              "browser_version": "12.0.1",
-              "os_version": "10.14.1",
-              "date": "2018-11-14",
               "output": [
                 {
                   "command": "next_item",
@@ -133,5 +113,53 @@
       "date": "2018-11-14",
       "message": "Test created"
     }
-  ]
+  ],
+  "versions": {
+    "jaws": {
+      "browsers": {
+        "ie": {
+          "at_version": "2018.1808.10",
+          "browser_version": "11.134",
+          "os_version": "17763",
+          "date": "2018-11-14"
+        },
+        "edge": {
+          "at_version": "2018.1808.10",
+          "browser_version": "44.17763.1.0",
+          "os_version": "17763",
+          "date": "2018-11-14"
+        }
+      }
+    },
+    "narrator": {
+      "browsers": {
+        "edge": {
+          "at_version": "17763",
+          "browser_version": "44.17763.1.0",
+          "os_version": "17763",
+          "date": "2018-11-14"
+        }
+      }
+    },
+    "nvda": {
+      "browsers": {
+        "firefox": {
+          "at_version": "2018.3.2",
+          "browser_version": "63.0.1",
+          "os_version": "17763",
+          "date": "2018-11-14"
+        }
+      }
+    },
+    "vo_macos": {
+      "browsers": {
+        "safari": {
+          "at_version": "10.14.1",
+          "browser_version": "12.0.1",
+          "os_version": "10.14.1",
+          "date": "2018-11-14"
+        }
+      }
+    }
+  }
 }

--- a/data/tests/html_section.json
+++ b/data/tests/html_section.json
@@ -10,10 +10,6 @@
         "jaws": {
           "browsers": {
             "edge": {
-              "at_version": "2018.1808.10",
-              "browser_version": "44.17763.1.0",
-              "os_version": "17763",
-              "date": "2018-11-12",
               "output": [
                 {
                   "command": "next_item",
@@ -33,10 +29,6 @@
               ]
             },
             "ie": {
-              "at_version": "2018.1808.10",
-              "browser_version": "11.134",
-              "os_version": "17763",
-              "date": "2018-11-12",
               "output": [
                 {
                   "command": "next_item",
@@ -60,10 +52,6 @@
         "narrator": {
           "browsers": {
             "edge": {
-              "at_version": "17763",
-              "browser_version": "44.17763.1.0",
-              "os_version": "17763",
-              "date": "2018-11-12",
               "output": [
                 {
                   "command": "next_item",
@@ -82,10 +70,6 @@
         "nvda": {
           "browsers": {
             "firefox": {
-              "at_version": "2018.3.2",
-              "browser_version": "63.0.1",
-              "os_version": "17763",
-              "date": "2018-11-14",
               "output": [
                 {
                   "command": "next_item",
@@ -104,10 +88,6 @@
         "vo_macos": {
           "browsers": {
             "safari": {
-              "at_version": "10.14.1",
-              "browser_version": "12.0.1",
-              "os_version": "10.14.1",
-              "date": "2018-11-14",
               "output": [
                 {
                   "command": "next_item",
@@ -126,10 +106,6 @@
         "vo_ios": {
           "browsers": {
             "ios_saf": {
-              "at_version": "12.1",
-              "browser_version": "12.1",
-              "os_version": "12.1",
-              "date": "2018-11-14",
               "output": [
                 {
                   "command": "next_item",
@@ -158,5 +134,63 @@
       "date": "2018-11-14",
       "message": "vo_ios/ios_saf support updated"
     }
-  ]
+  ],
+  "versions": {
+    "jaws": {
+      "browsers": {
+        "ie": {
+          "at_version": "2018.1808.10",
+          "browser_version": "11.134",
+          "os_version": "17763",
+          "date": "2018-11-12"
+        },
+        "edge": {
+          "at_version": "2018.1808.10",
+          "browser_version": "44.17763.1.0",
+          "os_version": "17763",
+          "date": "2018-11-12"
+        }
+      }
+    },
+    "narrator": {
+      "browsers": {
+        "edge": {
+          "at_version": "17763",
+          "browser_version": "44.17763.1.0",
+          "os_version": "17763",
+          "date": "2018-11-12"
+        }
+      }
+    },
+    "nvda": {
+      "browsers": {
+        "firefox": {
+          "at_version": "2018.3.2",
+          "browser_version": "63.0.1",
+          "os_version": "17763",
+          "date": "2018-11-14"
+        }
+      }
+    },
+    "vo_ios": {
+      "browsers": {
+        "ios_saf": {
+          "at_version": "12.1",
+          "browser_version": "12.1",
+          "os_version": "12.1",
+          "date": "2018-11-14"
+        }
+      }
+    },
+    "vo_macos": {
+      "browsers": {
+        "safari": {
+          "at_version": "10.14.1",
+          "browser_version": "12.0.1",
+          "os_version": "10.14.1",
+          "date": "2018-11-14"
+        }
+      }
+    }
+  }
 }

--- a/data/tests/html_svg_inline_with_title.json
+++ b/data/tests/html_svg_inline_with_title.json
@@ -11,10 +11,6 @@
         "jaws": {
           "browsers": {
             "ie": {
-              "at_version": "18",
-              "browser_version": "11",
-              "os_version": "17763",
-              "date": "2018-01-01",
               "output": [
                 {
                   "command": "next_item",
@@ -29,10 +25,6 @@
               ]
             },
             "chrome": {
-              "at_version": "18",
-              "browser_version": "65",
-              "os_version": "17763",
-              "date": "2018-01-01",
               "output": [
                 {
                   "command": "next_item",
@@ -47,10 +39,6 @@
               ]
             },
             "firefox": {
-              "at_version": "2018.1808.10",
-              "browser_version": "64",
-              "os_version": "1809",
-              "date": "2018-12-14",
               "output": [
                 {
                   "command": "next_item",
@@ -70,10 +58,6 @@
         "narrator": {
           "browsers": {
             "edge": {
-              "at_version": "1809",
-              "browser_version": "44",
-              "os_version": "1809",
-              "date": "2018-12-17",
               "output": [
                 {
                   "command": "next_item",
@@ -88,10 +72,6 @@
         "nvda": {
           "browsers": {
             "firefox": {
-              "at_version": "2018.3.2",
-              "browser_version": "64",
-              "os_version": "1809",
-              "date": "2018-12-14",
               "output": [
                 {
                   "command": "next_item",
@@ -111,10 +91,6 @@
         "vo_macos": {
           "browsers": {
             "safari": {
-              "at_version": "10.14.2",
-              "browser_version": "12.0.2",
-              "os_version": "10.14.2",
-              "date": "2018-12-14",
               "output": [
                 {
                   "command": "next_item",
@@ -134,10 +110,6 @@
         "vo_ios": {
           "browsers": {
             "ios_saf": {
-              "at_version": "12.1",
-              "browser_version": "12.1",
-              "os_version": "12.1",
-              "date": "2018-12-14",
               "output": [
                 {
                   "command": "next_item",
@@ -157,10 +129,6 @@
         "talkback": {
           "browsers": {
             "and_chr": {
-              "at_version": "7.0",
-              "browser_version": "65",
-              "os_version": "7.0",
-              "date": "2018-01-01",
               "output": [
                 {
                   "command": "next_item",
@@ -188,5 +156,79 @@
       "date": "2018-12-17",
       "message": "narrator/edge support updated"
     }
-  ]
+  ],
+  "versions": {
+    "jaws": {
+      "browsers": {
+        "chrome": {
+          "at_version": "18",
+          "browser_version": "65",
+          "os_version": "17763",
+          "date": "2018-01-01"
+        },
+        "ie": {
+          "at_version": "18",
+          "browser_version": "11",
+          "os_version": "17763",
+          "date": "2018-01-01"
+        },
+        "firefox": {
+          "at_version": "2018.1808.10",
+          "browser_version": "64",
+          "os_version": "1809",
+          "date": "2018-12-14"
+        }
+      }
+    },
+    "narrator": {
+      "browsers": {
+        "edge": {
+          "at_version": "1809",
+          "browser_version": "44",
+          "os_version": "1809",
+          "date": "2018-12-17"
+        }
+      }
+    },
+    "nvda": {
+      "browsers": {
+        "firefox": {
+          "at_version": "2018.3.2",
+          "browser_version": "64",
+          "os_version": "1809",
+          "date": "2018-12-14"
+        }
+      }
+    },
+    "talkback": {
+      "browsers": {
+        "and_chr": {
+          "at_version": "7.0",
+          "browser_version": "65",
+          "os_version": "7.0",
+          "date": "2018-01-01"
+        }
+      }
+    },
+    "vo_ios": {
+      "browsers": {
+        "ios_saf": {
+          "at_version": "12.1",
+          "browser_version": "12.1",
+          "os_version": "12.1",
+          "date": "2018-12-14"
+        }
+      }
+    },
+    "vo_macos": {
+      "browsers": {
+        "safari": {
+          "at_version": "10.14.2",
+          "browser_version": "12.0.2",
+          "os_version": "10.14.2",
+          "date": "2018-12-14"
+        }
+      }
+    }
+  }
 }

--- a/data/tests/html_td_element_with_th(scope-row).json
+++ b/data/tests/html_td_element_with_th(scope-row).json
@@ -1,7 +1,9 @@
 {
   "title": "HTML td element with a row header (th[scope=\"row\"])",
   "description": "This test verifies that the row header is announced for associated td elements when the scope=\"row\" attribute is used.",
-  "keywords": ["scope=\"row\""],
+  "keywords": [
+    "scope=\"row\""
+  ],
   "assertions": [
     {
       "feature_id": "html/table_element",
@@ -10,10 +12,6 @@
         "narrator": {
           "browsers": {
             "edge": {
-              "at_version": "1809",
-              "browser_version": "44.17763",
-              "os_version": "1809",
-              "date": "2019-05-03",
               "output": [
                 {
                   "command": "table_move_to_next_column",
@@ -37,10 +35,6 @@
         "nvda": {
           "browsers": {
             "firefox": {
-              "at_version": "2018.2.1",
-              "browser_version": "61.0.1",
-              "os_version": "1803",
-              "date": "2018-07-30",
               "output": [
                 {
                   "command": "next_item",
@@ -50,10 +44,6 @@
               ]
             },
             "chrome": {
-              "at_version": "2018.1808.10",
-              "browser_version": "74",
-              "os_version": "1809",
-              "date": "2019-05-03",
               "output": [
                 {
                   "command": "next_item",
@@ -67,10 +57,6 @@
         "jaws": {
           "browsers": {
             "ie": {
-              "at_version": "2018.1811.2",
-              "browser_version": "11.134",
-              "os_version": "1809",
-              "date": "2019-05-03",
               "output": [
                 {
                   "command": "next_item",
@@ -86,10 +72,6 @@
               "notes": ""
             },
             "firefox": {
-              "at_version": "2018.1811.2",
-              "browser_version": "66",
-              "os_version": "1809",
-              "date": "2019-05-03",
               "output": [
                 {
                   "command": "next_item",
@@ -105,10 +87,6 @@
               "notes": ""
             },
             "chrome": {
-              "at_version": "2018.1811.2",
-              "browser_version": "74",
-              "os_version": "1809",
-              "date": "2019-05-03",
               "output": [
                 {
                   "command": "next_item",
@@ -128,10 +106,6 @@
         "vo_macos": {
           "browsers": {
             "safari": {
-              "at_version": "10.14.4",
-              "browser_version": "12.1",
-              "os_version": "10.14.4",
-              "date": "2019-05-03",
               "output": [
                 {
                   "command": "next_item",
@@ -150,10 +124,6 @@
         "vo_ios": {
           "browsers": {
             "ios_saf": {
-              "at_version": "12.2",
-              "browser_version": "12.2",
-              "os_version": "12.2",
-              "date": "2019-05-01",
               "output": [
                 {
                   "command": "next_item",
@@ -179,10 +149,6 @@
         "narrator": {
           "browsers": {
             "edge": {
-              "at_version": "1809",
-              "browser_version": "44.17763",
-              "os_version": "1809",
-              "date": "2019-05-03",
               "output": [
                 {
                   "command": "next_item",
@@ -221,10 +187,6 @@
         "nvda": {
           "browsers": {
             "firefox": {
-              "at_version": "2018.2.1",
-              "browser_version": "61.0.1",
-              "os_version": "1803",
-              "date": "2018-07-30",
               "output": [
                 {
                   "command": "next_item",
@@ -259,10 +221,6 @@
               ]
             },
             "chrome": {
-              "at_version": "2018.1808.10",
-              "browser_version": "74",
-              "os_version": "1809",
-              "date": "2019-05-03",
               "output": [
                 {
                   "command": "next_item",
@@ -301,10 +259,6 @@
         "jaws": {
           "browsers": {
             "ie": {
-              "at_version": "2018.1811.2",
-              "browser_version": "11.134",
-              "os_version": "1809",
-              "date": "2019-05-03",
               "output": [
                 {
                   "command": "next_item",
@@ -320,10 +274,6 @@
               "notes": ""
             },
             "firefox": {
-              "at_version": "2018.1811.2",
-              "browser_version": "66",
-              "os_version": "1809",
-              "date": "2019-05-03",
               "output": [
                 {
                   "command": "next_item",
@@ -339,10 +289,6 @@
               "notes": ""
             },
             "chrome": {
-              "at_version": "2018.1811.2",
-              "browser_version": "74",
-              "os_version": "1809",
-              "date": "2019-05-03",
               "output": [
                 {
                   "command": "next_item",
@@ -362,10 +308,6 @@
         "vo_macos": {
           "browsers": {
             "safari": {
-              "at_version": "10.14.4",
-              "browser_version": "12.1",
-              "os_version": "10.14.4",
-              "date": "2019-05-03",
               "output": [
                 {
                   "command": "next_item",
@@ -384,10 +326,6 @@
         "vo_ios": {
           "browsers": {
             "ios_saf": {
-              "at_version": "12.2",
-              "browser_version": "12.2",
-              "os_version": "12.2",
-              "date": "2019-05-01",
               "output": [
                 {
                   "command": "next_item",
@@ -414,10 +352,6 @@
         "narrator": {
           "browsers": {
             "edge": {
-              "at_version": "1809",
-              "browser_version": "44.17763",
-              "os_version": "1809",
-              "date": "2019-05-03",
               "output": [
                 {
                   "command": "table_move_to_next_column",
@@ -441,10 +375,6 @@
         "nvda": {
           "browsers": {
             "firefox": {
-              "at_version": "2018.2.1",
-              "browser_version": "61.0.1",
-              "os_version": "1803",
-              "date": "2018-07-30",
               "output": [
                 {
                   "command": "table_move_to_previous_row",
@@ -459,10 +389,6 @@
               ]
             },
             "chrome": {
-              "at_version": "2018.1808.10",
-              "browser_version": "74",
-              "os_version": "1809",
-              "date": "2019-05-03",
               "output": [
                 {
                   "command": "table_move_to_previous_row",
@@ -481,10 +407,6 @@
         "jaws": {
           "browsers": {
             "ie": {
-              "at_version": "2018.1811.2",
-              "browser_version": "11.134",
-              "os_version": "1809",
-              "date": "2019-05-03",
               "output": [
                 {
                   "command": "table_move_to_previous_row",
@@ -500,10 +422,6 @@
               "notes": ""
             },
             "firefox": {
-              "at_version": "2018.1811.2",
-              "browser_version": "66",
-              "os_version": "1809",
-              "date": "2019-05-03",
               "output": [
                 {
                   "command": "table_move_to_previous_row",
@@ -519,10 +437,6 @@
               "notes": ""
             },
             "chrome": {
-              "at_version": "2018.1811.2",
-              "browser_version": "74",
-              "os_version": "1809",
-              "date": "2019-05-03",
               "output": [
                 {
                   "command": "table_move_to_previous_row",
@@ -542,10 +456,6 @@
         "vo_macos": {
           "browsers": {
             "safari": {
-              "at_version": "10.14.4",
-              "browser_version": "12.1",
-              "os_version": "10.14.4",
-              "date": "2019-05-03",
               "output": [
                 {
                   "command": "table_move_to_previous_row",
@@ -564,10 +474,6 @@
         "vo_ios": {
           "browsers": {
             "ios_saf": {
-              "at_version": "12.2",
-              "browser_version": "12.2",
-              "os_version": "12.2",
-              "date": "2019-05-01",
               "output": [
                 {
                   "command": "next_item",
@@ -603,10 +509,6 @@
         "narrator": {
           "browsers": {
             "edge": {
-              "at_version": "1809",
-              "browser_version": "44.17763",
-              "os_version": "1809",
-              "date": "2019-05-03",
               "output": [
                 {
                   "command": "table_move_to_next_row",
@@ -635,10 +537,6 @@
         "nvda": {
           "browsers": {
             "firefox": {
-              "at_version": "2018.2.1",
-              "browser_version": "61.0.1",
-              "os_version": "1803",
-              "date": "2018-07-30",
               "output": [
                 {
                   "command": "table_move_to_next_row",
@@ -663,10 +561,6 @@
               ]
             },
             "chrome": {
-              "at_version": "2018.1808.10",
-              "browser_version": "74",
-              "os_version": "1809",
-              "date": "2019-05-03",
               "output": [
                 {
                   "command": "table_move_to_next_row",
@@ -695,10 +589,6 @@
         "jaws": {
           "browsers": {
             "ie": {
-              "at_version": "2018.1811.2",
-              "browser_version": "11.134",
-              "os_version": "1809",
-              "date": "2019-05-03",
               "output": [
                 {
                   "command": "table_move_to_next_row",
@@ -724,10 +614,6 @@
               "notes": ""
             },
             "firefox": {
-              "at_version": "2018.1811.2",
-              "browser_version": "66",
-              "os_version": "1809",
-              "date": "2019-05-03",
               "output": [
                 {
                   "command": "table_move_to_next_row",
@@ -753,10 +639,6 @@
               "notes": ""
             },
             "chrome": {
-              "at_version": "2018.1811.2",
-              "browser_version": "74",
-              "os_version": "1809",
-              "date": "2019-05-03",
               "output": [
                 {
                   "command": "table_move_to_next_row",
@@ -786,10 +668,6 @@
         "vo_macos": {
           "browsers": {
             "safari": {
-              "at_version": "10.14.4",
-              "browser_version": "12.1",
-              "os_version": "10.14.4",
-              "date": "2019-05-03",
               "output": [
                 {
                   "command": "table_move_to_previous_row",
@@ -808,10 +686,6 @@
         "vo_ios": {
           "browsers": {
             "ios_saf": {
-              "at_version": "12.2",
-              "browser_version": "12.2",
-              "os_version": "12.2",
-              "date": "2019-05-01",
               "output": [
                 {
                   "command": "next_item",
@@ -847,10 +721,6 @@
         "narrator": {
           "browsers": {
             "edge": {
-              "at_version": "1809",
-              "browser_version": "44.17763",
-              "os_version": "1809",
-              "date": "2019-05-03",
               "output": [
                 {
                   "command": "table_move_to_next_column",
@@ -879,10 +749,6 @@
         "nvda": {
           "browsers": {
             "firefox": {
-              "at_version": "2018.2.1",
-              "browser_version": "61.0.1",
-              "os_version": "1803",
-              "date": "2018-07-30",
               "output": [
                 {
                   "command": "table_move_to_next_column",
@@ -907,10 +773,6 @@
               ]
             },
             "chrome": {
-              "at_version": "2018.1808.10",
-              "browser_version": "74",
-              "os_version": "1809",
-              "date": "2019-05-03",
               "output": [
                 {
                   "command": "table_move_to_next_column",
@@ -939,10 +801,6 @@
         "jaws": {
           "browsers": {
             "ie": {
-              "at_version": "2018.1811.2",
-              "browser_version": "11.134",
-              "os_version": "1809",
-              "date": "2019-05-03",
               "output": [
                 {
                   "command": "table_move_to_next_column",
@@ -968,10 +826,6 @@
               "notes": ""
             },
             "firefox": {
-              "at_version": "2018.1811.2",
-              "browser_version": "66",
-              "os_version": "1809",
-              "date": "2019-05-03",
               "output": [
                 {
                   "command": "table_move_to_next_column",
@@ -997,10 +851,6 @@
               "notes": ""
             },
             "chrome": {
-              "at_version": "2018.1811.2",
-              "browser_version": "74",
-              "os_version": "1809",
-              "date": "2019-05-03",
               "output": [
                 {
                   "command": "table_move_to_next_column",
@@ -1030,10 +880,6 @@
         "vo_macos": {
           "browsers": {
             "safari": {
-              "at_version": "10.14.4",
-              "browser_version": "12.1",
-              "os_version": "10.14.4",
-              "date": "2019-05-03",
               "output": [
                 {
                   "command": "table_move_to_next_column",
@@ -1062,10 +908,6 @@
         "vo_ios": {
           "browsers": {
             "ios_saf": {
-              "at_version": "12.2",
-              "browser_version": "12.2",
-              "os_version": "12.2",
-              "date": "2019-05-01",
               "output": [
                 {
                   "command": "table_move_to_next_column",
@@ -1101,10 +943,6 @@
         "narrator": {
           "browsers": {
             "edge": {
-              "at_version": "1809",
-              "browser_version": "44.17763",
-              "os_version": "1809",
-              "date": "2019-05-03",
               "output": [
                 {
                   "command": "previous_item",
@@ -1128,10 +966,6 @@
         "nvda": {
           "browsers": {
             "firefox": {
-              "at_version": "2018.2.1",
-              "browser_version": "61.0.1",
-              "os_version": "1803",
-              "date": "2018-07-30",
               "output": [
                 {
                   "command": "previous_item",
@@ -1151,10 +985,6 @@
               ]
             },
             "chrome": {
-              "at_version": "2018.1808.10",
-              "browser_version": "74",
-              "os_version": "1809",
-              "date": "2019-05-03",
               "output": [
                 {
                   "command": "previous_item",
@@ -1178,10 +1008,6 @@
         "jaws": {
           "browsers": {
             "ie": {
-              "at_version": "2018.1811.2",
-              "browser_version": "11.134",
-              "os_version": "1809",
-              "date": "2019-05-03",
               "output": [
                 {
                   "command": "previous_item",
@@ -1202,10 +1028,6 @@
               "notes": ""
             },
             "firefox": {
-              "at_version": "2018.1811.2",
-              "browser_version": "66",
-              "os_version": "1809",
-              "date": "2019-05-03",
               "output": [
                 {
                   "command": "previous_item",
@@ -1226,10 +1048,6 @@
               "notes": ""
             },
             "chrome": {
-              "at_version": "2018.1811.2",
-              "browser_version": "74",
-              "os_version": "1809",
-              "date": "2019-05-03",
               "output": [
                 {
                   "command": "previous_item",
@@ -1254,10 +1072,6 @@
         "vo_macos": {
           "browsers": {
             "safari": {
-              "at_version": "10.14.4",
-              "browser_version": "12.1",
-              "os_version": "10.14.4",
-              "date": "2019-05-03",
               "output": [
                 {
                   "command": "previous_item",
@@ -1281,10 +1095,6 @@
         "vo_ios": {
           "browsers": {
             "ios_saf": {
-              "at_version": "12.2",
-              "browser_version": "12.2",
-              "os_version": "12.2",
-              "date": "2019-05-01",
               "output": [
                 {
                   "command": "previous_item",
@@ -1315,10 +1125,6 @@
         "narrator": {
           "browsers": {
             "edge": {
-              "at_version": "1809",
-              "browser_version": "44.17763",
-              "os_version": "1809",
-              "date": "2019-05-03",
               "output": [
                 {
                   "command": "table_move_to_next_column",
@@ -1347,10 +1153,6 @@
         "nvda": {
           "browsers": {
             "firefox": {
-              "at_version": "2018.2.1",
-              "browser_version": "61.0.1",
-              "os_version": "1803",
-              "date": "2018-07-30",
               "output": [
                 {
                   "command": "table_move_to_next_column",
@@ -1375,10 +1177,6 @@
               ]
             },
             "chrome": {
-              "at_version": "2018.1808.10",
-              "browser_version": "74",
-              "os_version": "1809",
-              "date": "2019-05-03",
               "output": [
                 {
                   "command": "table_move_to_next_column",
@@ -1407,10 +1205,6 @@
         "jaws": {
           "browsers": {
             "ie": {
-              "at_version": "2018.1811.2",
-              "browser_version": "11.134",
-              "os_version": "1809",
-              "date": "2019-05-03",
               "output": [
                 {
                   "command": "table_move_to_next_column",
@@ -1436,10 +1230,6 @@
               "notes": ""
             },
             "firefox": {
-              "at_version": "2018.1811.2",
-              "browser_version": "66",
-              "os_version": "1809",
-              "date": "2019-05-03",
               "output": [
                 {
                   "command": "table_move_to_next_column",
@@ -1465,10 +1255,6 @@
               "notes": ""
             },
             "chrome": {
-              "at_version": "2018.1811.2",
-              "browser_version": "74",
-              "os_version": "1809",
-              "date": "2019-05-03",
               "output": [
                 {
                   "command": "table_move_to_next_column",
@@ -1498,10 +1284,6 @@
         "vo_macos": {
           "browsers": {
             "safari": {
-              "at_version": "10.14.4",
-              "browser_version": "12.1",
-              "os_version": "10.14.4",
-              "date": "2019-05-03",
               "output": [
                 {
                   "command": "table_move_to_next_column",
@@ -1530,10 +1312,6 @@
         "vo_ios": {
           "browsers": {
             "ios_saf": {
-              "at_version": "12.2",
-              "browser_version": "12.2",
-              "os_version": "12.2",
-              "date": "2019-05-01",
               "output": [
                 {
                   "command": "next_item",
@@ -1562,5 +1340,75 @@
       "date": "2018-07-29",
       "message": "Sample data has been added. This data has not been verified."
     }
-  ]
+  ],
+  "versions": {
+    "jaws": {
+      "browsers": {
+        "chrome": {
+          "at_version": "2018.1811.2",
+          "browser_version": "74",
+          "os_version": "1809",
+          "date": "2019-05-03"
+        },
+        "ie": {
+          "at_version": "2018.1811.2",
+          "browser_version": "11.134",
+          "os_version": "1809",
+          "date": "2019-05-03"
+        },
+        "firefox": {
+          "at_version": "2018.1811.2",
+          "browser_version": "66",
+          "os_version": "1809",
+          "date": "2019-05-03"
+        }
+      }
+    },
+    "narrator": {
+      "browsers": {
+        "edge": {
+          "at_version": "1809",
+          "browser_version": "44.17763",
+          "os_version": "1809",
+          "date": "2019-05-03"
+        }
+      }
+    },
+    "nvda": {
+      "browsers": {
+        "chrome": {
+          "at_version": "2018.1808.10",
+          "browser_version": "74",
+          "os_version": "1809",
+          "date": "2019-05-03"
+        },
+        "firefox": {
+          "at_version": "2018.2.1",
+          "browser_version": "61.0.1",
+          "os_version": "1803",
+          "date": "2018-07-30"
+        }
+      }
+    },
+    "vo_ios": {
+      "browsers": {
+        "ios_saf": {
+          "at_version": "12.2",
+          "browser_version": "12.2",
+          "os_version": "12.2",
+          "date": "2019-05-01"
+        }
+      }
+    },
+    "vo_macos": {
+      "browsers": {
+        "safari": {
+          "at_version": "10.14.4",
+          "browser_version": "12.1",
+          "os_version": "10.14.4",
+          "date": "2019-05-03"
+        }
+      }
+    }
+  }
 }

--- a/data/tests/html_td_element_with_th(scope-row).json
+++ b/data/tests/html_td_element_with_th(scope-row).json
@@ -698,12 +698,12 @@
                   "result": "fail"
                 },
                 {
-                  "command": "read_additional_information",
+                  "command": "additional_information",
                   "output": "\"row 1 column 1\"",
                   "result": "fail"
                 },
                 {
-                  "command": "read_additional_information",
+                  "command": "additional_information",
                   "output": "\"row 1 column 2\"",
                   "result": "fail"
                 }
@@ -910,22 +910,12 @@
             "ios_saf": {
               "output": [
                 {
-                  "command": "table_move_to_next_column",
+                  "command": "next_item",
                   "output": "(position information is announced as column and rows are changed)",
                   "result": "pass"
                 },
                 {
-                  "command": "table_move_to_previous_column",
-                  "output": "(position information is announced as column and rows are changed)",
-                  "result": "pass"
-                },
-                {
-                  "command": "table_move_to_next_row",
-                  "output": "(position information is announced as column and rows are changed)",
-                  "result": "pass"
-                },
-                {
-                  "command": "table_move_to_previous_row",
+                  "command": "previous_item",
                   "output": "(position information is announced as column and rows are changed)",
                   "result": "pass"
                 }
@@ -1097,17 +1087,12 @@
             "ios_saf": {
               "output": [
                 {
+                  "command": "next_item",
+                  "output": "(no header semantics surfaced, which implies that this is a cell)",
+                  "result": "pass"
+                },
+                {
                   "command": "previous_item",
-                  "output": "(no header semantics surfaced, which implies that this is a cell)",
-                  "result": "pass"
-                },
-                {
-                  "command": "table_move_to_next_column",
-                  "output": "(no header semantics surfaced, which implies that this is a cell)",
-                  "result": "pass"
-                },
-                {
-                  "command": "table_move_to_next_row",
                   "output": "(no header semantics surfaced, which implies that this is a cell)",
                   "result": "pass"
                 }

--- a/data/tests/tech/aria/aria-details.json
+++ b/data/tests/tech/aria/aria-details.json
@@ -10,10 +10,6 @@
         "narrator": {
           "browsers": {
             "edge": {
-              "at_version": "1809",
-              "browser_version": "44.17763",
-              "os_version": "1809",
-              "date": "2019-05-19",
               "output": [
                 {
                   "command": "next_item",
@@ -28,10 +24,6 @@
         "nvda": {
           "browsers": {
             "firefox": {
-              "at_version": "2018.3.2",
-              "browser_version": "66",
-              "os_version": "1809",
-              "date": "2019-05-19",
               "output": [
                 {
                   "command": "next_item",
@@ -41,10 +33,6 @@
               ]
             },
             "chrome": {
-              "at_version": "2018.1808.10",
-              "browser_version": "74",
-              "os_version": "1809",
-              "date": "2019-05-19",
               "output": [
                 {
                   "command": "next_item",
@@ -58,10 +46,6 @@
         "jaws": {
           "browsers": {
             "ie": {
-              "at_version": "2018.1811.2",
-              "browser_version": "11.134",
-              "os_version": "1809",
-              "date": "2019-05-19",
               "output": [
                 {
                   "command": "next_item",
@@ -72,10 +56,6 @@
               "notes": ""
             },
             "firefox": {
-              "at_version": "2018.1811.2",
-              "browser_version": "66",
-              "os_version": "1809",
-              "date": "2019-05-19",
               "output": [
                 {
                   "command": "next_item",
@@ -86,10 +66,6 @@
               "notes": ""
             },
             "chrome": {
-              "at_version": "2018.1811.2",
-              "browser_version": "74",
-              "os_version": "1809",
-              "date": "2019-05-19",
               "output": [
                 {
                   "command": "next_item",
@@ -104,10 +80,6 @@
         "talkback": {
           "browsers": {
             "and_chr": {
-              "at_version": "8.0.0",
-              "browser_version": "75",
-              "os_version": "8.0.0",
-              "date": "2019-07-01",
               "output": [
                 {
                   "command": "next_item",
@@ -124,10 +96,6 @@
         "vo_macos": {
           "browsers": {
             "safari": {
-              "at_version": "10.14.4",
-              "browser_version": "12.1",
-              "os_version": "10.14.4",
-              "date": "2019-05-19",
               "output": [
                 {
                   "command": "next_item",
@@ -142,10 +110,6 @@
         "vo_ios": {
           "browsers": {
             "ios_saf": {
-              "at_version": "12.2",
-              "browser_version": "12.2",
-              "os_version": "12.2",
-              "date": "2019-05-19",
               "output": [
                 {
                   "command": "next_item",
@@ -166,10 +130,6 @@
         "narrator": {
           "browsers": {
             "edge": {
-              "at_version": "1809",
-              "browser_version": "44.17763",
-              "os_version": "1809",
-              "date": "2019-05-19",
               "output": [
                 {
                   "command": "next_item",
@@ -184,10 +144,6 @@
         "nvda": {
           "browsers": {
             "firefox": {
-              "at_version": "2018.3.2",
-              "browser_version": "66",
-              "os_version": "1809",
-              "date": "2019-05-19",
               "output": [
                 {
                   "command": "next_item",
@@ -198,10 +154,6 @@
               "notes": ""
             },
             "chrome": {
-              "at_version": "2018.1808.10",
-              "browser_version": "74",
-              "os_version": "1809",
-              "date": "2019-05-19",
               "output": [
                 {
                   "command": "next_item",
@@ -216,10 +168,6 @@
         "jaws": {
           "browsers": {
             "ie": {
-              "at_version": "2018.1811.2",
-              "browser_version": "11.134",
-              "os_version": "1809",
-              "date": "2019-05-19",
               "output": [
                 {
                   "command": "next_item",
@@ -229,10 +177,6 @@
               ]
             },
             "firefox": {
-              "at_version": "2018.1811.2",
-              "browser_version": "66",
-              "os_version": "1809",
-              "date": "2019-05-19",
               "output": [
                 {
                   "command": "follow_flowto",
@@ -242,10 +186,6 @@
               ]
             },
             "chrome": {
-              "at_version": "2018.1811.2",
-              "browser_version": "74",
-              "os_version": "1809",
-              "date": "2019-05-19",
               "output": [
                 {
                   "command": "follow_flowto",
@@ -259,10 +199,6 @@
         "talkback": {
           "browsers": {
             "and_chr": {
-              "at_version": "8.0.0",
-              "browser_version": "75",
-              "os_version": "8.0.0",
-              "date": "2019-07-01",
               "output": [
                 {
                   "command": "next_item",
@@ -279,10 +215,6 @@
         "vo_macos": {
           "browsers": {
             "safari": {
-              "at_version": "10.14.4",
-              "browser_version": "12.1",
-              "os_version": "10.14.4",
-              "date": "2019-05-19",
               "output": [
                 {
                   "command": "next_item",
@@ -297,10 +229,6 @@
         "vo_ios": {
           "browsers": {
             "ios_saf": {
-              "at_version": "12.2",
-              "browser_version": "12.2",
-              "os_version": "12.2",
-              "date": "2019-05-19",
               "output": [
                 {
                   "command": "next_item",
@@ -321,10 +249,6 @@
         "narrator": {
           "browsers": {
             "edge": {
-              "at_version": "1809",
-              "browser_version": "44.17763",
-              "os_version": "1809",
-              "date": "2019-05-19",
               "output": [
                 {
                   "command": "next_item",
@@ -339,10 +263,6 @@
         "nvda": {
           "browsers": {
             "firefox": {
-              "at_version": "2018.3.2",
-              "browser_version": "66",
-              "os_version": "1809",
-              "date": "2019-05-19",
               "output": [
                 {
                   "command": "next_item",
@@ -353,10 +273,6 @@
               "notes": ""
             },
             "chrome": {
-              "at_version": "2018.1808.10",
-              "browser_version": "74",
-              "os_version": "1809",
-              "date": "2019-05-19",
               "output": [
                 {
                   "command": "next_item",
@@ -371,10 +287,6 @@
         "jaws": {
           "browsers": {
             "ie": {
-              "at_version": "2018.1811.2",
-              "browser_version": "11.134",
-              "os_version": "1809",
-              "date": "2019-05-19",
               "output": [
                 {
                   "command": "next_item",
@@ -384,10 +296,6 @@
               ]
             },
             "firefox": {
-              "at_version": "2018.1811.2",
-              "browser_version": "66",
-              "os_version": "1809",
-              "date": "2019-05-19",
               "output": [
                 {
                   "command": "follow_flowto",
@@ -397,10 +305,6 @@
               ]
             },
             "chrome": {
-              "at_version": "2018.1811.2",
-              "browser_version": "74",
-              "os_version": "1809",
-              "date": "2019-05-19",
               "output": [
                 {
                   "command": "follow_flowto",
@@ -414,10 +318,6 @@
         "talkback": {
           "browsers": {
             "and_chr": {
-              "at_version": "8.0.0",
-              "browser_version": "75",
-              "os_version": "8.0.0",
-              "date": "2019-07-01",
               "output": [
                 {
                   "command": "next_item",
@@ -434,10 +334,6 @@
         "vo_macos": {
           "browsers": {
             "safari": {
-              "at_version": "10.14.4",
-              "browser_version": "12.1",
-              "os_version": "10.14.4",
-              "date": "2019-05-19",
               "output": [
                 {
                   "command": "next_item",
@@ -452,10 +348,6 @@
         "vo_ios": {
           "browsers": {
             "ios_saf": {
-              "at_version": "12.2",
-              "browser_version": "12.2",
-              "os_version": "12.2",
-              "date": "2019-05-19",
               "output": [
                 {
                   "command": "next_item",
@@ -477,10 +369,6 @@
         "narrator": {
           "browsers": {
             "edge": {
-              "at_version": "1809",
-              "browser_version": "44.17763",
-              "os_version": "1809",
-              "date": "2019-05-19",
               "output": [
                 {
                   "command": "next_item",
@@ -495,10 +383,6 @@
         "nvda": {
           "browsers": {
             "firefox": {
-              "at_version": "2018.3.2",
-              "browser_version": "66",
-              "os_version": "1809",
-              "date": "2019-05-19",
               "output": [
                 {
                   "command": "next_item",
@@ -509,10 +393,6 @@
               "notes": ""
             },
             "chrome": {
-              "at_version": "2018.1808.10",
-              "browser_version": "74",
-              "os_version": "1809",
-              "date": "2019-05-19",
               "output": [
                 {
                   "command": "next_item",
@@ -527,10 +407,6 @@
         "jaws": {
           "browsers": {
             "ie": {
-              "at_version": "2018.1811.2",
-              "browser_version": "11.134",
-              "os_version": "1809",
-              "date": "2019-05-19",
               "output": [
                 {
                   "command": "next_item",
@@ -545,10 +421,6 @@
               ]
             },
             "firefox": {
-              "at_version": "2018.1811.2",
-              "browser_version": "66",
-              "os_version": "1809",
-              "date": "2019-05-19",
               "output": [
                 {
                   "command": "next_item",
@@ -563,10 +435,6 @@
               ]
             },
             "chrome": {
-              "at_version": "2018.1811.2",
-              "browser_version": "74",
-              "os_version": "1809",
-              "date": "2019-05-19",
               "output": [
                 {
                   "command": "next_item",
@@ -585,10 +453,6 @@
         "talkback": {
           "browsers": {
             "and_chr": {
-              "at_version": "8.0.0",
-              "browser_version": "75",
-              "os_version": "8.0.0",
-              "date": "2019-07-01",
               "output": [
                 {
                   "command": "next_item",
@@ -605,10 +469,6 @@
         "vo_macos": {
           "browsers": {
             "safari": {
-              "at_version": "10.14.4",
-              "browser_version": "12.1",
-              "os_version": "10.14.4",
-              "date": "2019-05-19",
               "output": [
                 {
                   "command": "next_item",
@@ -623,10 +483,6 @@
         "vo_ios": {
           "browsers": {
             "ios_saf": {
-              "at_version": "12.2",
-              "browser_version": "12.2",
-              "os_version": "12.2",
-              "date": "2019-05-19",
               "output": [
                 {
                   "command": "next_item",
@@ -646,5 +502,85 @@
       "date": "2019-05-19",
       "message": "Test created"
     }
-  ]
+  ],
+  "versions": {
+    "jaws": {
+      "browsers": {
+        "chrome": {
+          "at_version": "2018.1811.2",
+          "browser_version": "74",
+          "os_version": "1809",
+          "date": "2019-05-19"
+        },
+        "ie": {
+          "at_version": "2018.1811.2",
+          "browser_version": "11.134",
+          "os_version": "1809",
+          "date": "2019-05-19"
+        },
+        "firefox": {
+          "at_version": "2018.1811.2",
+          "browser_version": "66",
+          "os_version": "1809",
+          "date": "2019-05-19"
+        }
+      }
+    },
+    "narrator": {
+      "browsers": {
+        "edge": {
+          "at_version": "1809",
+          "browser_version": "44.17763",
+          "os_version": "1809",
+          "date": "2019-05-19"
+        }
+      }
+    },
+    "nvda": {
+      "browsers": {
+        "chrome": {
+          "at_version": "2018.1808.10",
+          "browser_version": "74",
+          "os_version": "1809",
+          "date": "2019-05-19"
+        },
+        "firefox": {
+          "at_version": "2018.3.2",
+          "browser_version": "66",
+          "os_version": "1809",
+          "date": "2019-05-19"
+        }
+      }
+    },
+    "talkback": {
+      "browsers": {
+        "and_chr": {
+          "at_version": "8.0.0",
+          "browser_version": "75",
+          "os_version": "8.0.0",
+          "date": "2019-07-01"
+        }
+      }
+    },
+    "vo_ios": {
+      "browsers": {
+        "ios_saf": {
+          "at_version": "12.2",
+          "browser_version": "12.2",
+          "os_version": "12.2",
+          "date": "2019-05-19"
+        }
+      }
+    },
+    "vo_macos": {
+      "browsers": {
+        "safari": {
+          "at_version": "10.14.4",
+          "browser_version": "12.1",
+          "os_version": "10.14.4",
+          "date": "2019-05-19"
+        }
+      }
+    }
+  }
 }

--- a/data/tests/tech/aria/aria-flowto.json
+++ b/data/tests/tech/aria/aria-flowto.json
@@ -10,10 +10,6 @@
         "narrator": {
           "browsers": {
             "edge": {
-              "at_version": "1809",
-              "browser_version": "44.17763",
-              "os_version": "1809",
-              "date": "2019-05-02",
               "output": [
                 {
                   "command": "next_item",
@@ -33,10 +29,6 @@
         "nvda": {
           "browsers": {
             "firefox": {
-              "at_version": "2018.3.2",
-              "browser_version": "66",
-              "os_version": "1809",
-              "date": "2019-09-04",
               "output": [
                 {
                   "command": "next_item",
@@ -46,10 +38,6 @@
               ]
             },
             "chrome": {
-              "at_version": "2018.1808.10",
-              "browser_version": "74",
-              "os_version": "1809",
-              "date": "2019-05-02",
               "output": [
                 {
                   "command": "next_item",
@@ -63,10 +51,6 @@
         "jaws": {
           "browsers": {
             "ie": {
-              "at_version": "2018.1811.2",
-              "browser_version": "11.134",
-              "os_version": "1809",
-              "date": "2019-05-02",
               "output": [
                 {
                   "command": "next_item",
@@ -77,10 +61,6 @@
               "notes": ""
             },
             "firefox": {
-              "at_version": "2018.1811.2",
-              "browser_version": "66",
-              "os_version": "1809",
-              "date": "2019-05-02",
               "output": [
                 {
                   "command": "next_item",
@@ -91,10 +71,6 @@
               "notes": ""
             },
             "chrome": {
-              "at_version": "2018.1811.2",
-              "browser_version": "74",
-              "os_version": "1809",
-              "date": "2019-05-02",
               "output": [
                 {
                   "command": "next_item",
@@ -109,10 +85,6 @@
         "vo_macos": {
           "browsers": {
             "safari": {
-              "at_version": "10.14.4",
-              "browser_version": "12.1",
-              "os_version": "10.14.4",
-              "date": "2019-05-08",
               "output": [
                 {
                   "command": "next_item",
@@ -127,10 +99,6 @@
         "vo_ios": {
           "browsers": {
             "ios_saf": {
-              "at_version": "12.2",
-              "browser_version": "12.2",
-              "os_version": "12.2",
-              "date": "2019-05-08",
               "output": [
                 {
                   "command": "next_item",
@@ -151,10 +119,6 @@
         "narrator": {
           "browsers": {
             "edge": {
-              "at_version": "1809",
-              "browser_version": "44.17763",
-              "os_version": "1809",
-              "date": "2019-05-02",
               "output": [
                 {
                   "command": "next_item",
@@ -174,10 +138,6 @@
         "nvda": {
           "browsers": {
             "firefox": {
-              "at_version": "2018.3.2",
-              "browser_version": "66",
-              "os_version": "1809",
-              "date": "2019-09-04",
               "output": [
                 {
                   "command": "next_item",
@@ -187,10 +147,6 @@
               ]
             },
             "chrome": {
-              "at_version": "2018.1808.10",
-              "browser_version": "74",
-              "os_version": "1809",
-              "date": "2019-05-02",
               "output": [
                 {
                   "command": "next_item",
@@ -204,10 +160,6 @@
         "jaws": {
           "browsers": {
             "ie": {
-              "at_version": "2018.1811.2",
-              "browser_version": "11.134",
-              "os_version": "1809",
-              "date": "2019-05-02",
               "output": [
                 {
                   "command": "next_item",
@@ -218,10 +170,6 @@
               "notes": ""
             },
             "firefox": {
-              "at_version": "2018.1811.2",
-              "browser_version": "66",
-              "os_version": "1809",
-              "date": "2019-05-02",
               "output": [
                 {
                   "command": "next_item",
@@ -232,10 +180,6 @@
               "notes": ""
             },
             "chrome": {
-              "at_version": "2018.1811.2",
-              "browser_version": "74",
-              "os_version": "1809",
-              "date": "2019-05-02",
               "output": [
                 {
                   "command": "next_item",
@@ -250,10 +194,6 @@
         "vo_macos": {
           "browsers": {
             "safari": {
-              "at_version": "10.14.4",
-              "browser_version": "12.1",
-              "os_version": "10.14.4",
-              "date": "2019-05-08",
               "output": [
                 {
                   "command": "next_item",
@@ -268,10 +208,6 @@
         "vo_ios": {
           "browsers": {
             "ios_saf": {
-              "at_version": "12.2",
-              "browser_version": "12.2",
-              "os_version": "12.2",
-              "date": "2019-05-08",
               "output": [
                 {
                   "command": "next_item",
@@ -292,10 +228,6 @@
         "narrator": {
           "browsers": {
             "edge": {
-              "at_version": "1809",
-              "browser_version": "44.17763",
-              "os_version": "1809",
-              "date": "2019-05-02",
               "output": [
                 {
                   "command": "next_item",
@@ -315,10 +247,6 @@
         "nvda": {
           "browsers": {
             "firefox": {
-              "at_version": "2018.3.2",
-              "browser_version": "66",
-              "os_version": "1809",
-              "date": "2019-09-04",
               "output": [
                 {
                   "command": "next_item",
@@ -329,10 +257,6 @@
               "notes": ""
             },
             "chrome": {
-              "at_version": "2018.1808.10",
-              "browser_version": "74",
-              "os_version": "1809",
-              "date": "2019-05-02",
               "output": [
                 {
                   "command": "next_item",
@@ -347,10 +271,6 @@
         "jaws": {
           "browsers": {
             "ie": {
-              "at_version": "2018.1811.2",
-              "browser_version": "11.134",
-              "os_version": "1809",
-              "date": "2019-05-02",
               "output": [
                 {
                   "command": "follow_flowto",
@@ -361,10 +281,6 @@
               "notes": "relationships are displayed in a dialog, but only targets that have an aria-label are labelled in the dialog. The rest appear without a textual label."
             },
             "firefox": {
-              "at_version": "2018.1811.2",
-              "browser_version": "66",
-              "os_version": "1809",
-              "date": "2019-05-02",
               "output": [
                 {
                   "command": "follow_flowto",
@@ -375,10 +291,6 @@
               "notes": "partial support because a reference to multiple elements is not supported"
             },
             "chrome": {
-              "at_version": "2018.1811.2",
-              "browser_version": "74",
-              "os_version": "1809",
-              "date": "2019-05-02",
               "output": [
                 {
                   "command": "follow_flowto",
@@ -393,10 +305,6 @@
         "vo_macos": {
           "browsers": {
             "safari": {
-              "at_version": "10.14.4",
-              "browser_version": "12.1",
-              "os_version": "10.14.4",
-              "date": "2019-05-08",
               "output": [
                 {
                   "command": "next_item",
@@ -411,10 +319,6 @@
         "vo_ios": {
           "browsers": {
             "ios_saf": {
-              "at_version": "12.2",
-              "browser_version": "12.2",
-              "os_version": "12.2",
-              "date": "2019-05-08",
               "output": [
                 {
                   "command": "next_item",
@@ -435,10 +339,6 @@
         "narrator": {
           "browsers": {
             "edge": {
-              "at_version": "1809",
-              "browser_version": "44.17763",
-              "os_version": "1809",
-              "date": "2019-05-02",
               "output": [
                 {
                   "command": "next_item",
@@ -458,10 +358,6 @@
         "nvda": {
           "browsers": {
             "firefox": {
-              "at_version": "2018.3.2",
-              "browser_version": "66",
-              "os_version": "1809",
-              "date": "2019-09-04",
               "output": [
                 {
                   "command": "next_item",
@@ -472,10 +368,6 @@
               "notes": ""
             },
             "chrome": {
-              "at_version": "2018.1808.10",
-              "browser_version": "74",
-              "os_version": "1809",
-              "date": "2019-05-02",
               "output": [
                 {
                   "command": "next_item",
@@ -490,10 +382,6 @@
         "jaws": {
           "browsers": {
             "ie": {
-              "at_version": "2018.1811.2",
-              "browser_version": "11.134",
-              "os_version": "1809",
-              "date": "2019-05-02",
               "output": [
                 {
                   "command": "follow_flowfrom",
@@ -504,10 +392,6 @@
               "notes": "relationships are displayed in a dialog, but only targets that have an aria-label are labelled in the dialog. The rest appear without a textual label."
             },
             "firefox": {
-              "at_version": "2018.1811.2",
-              "browser_version": "66",
-              "os_version": "1809",
-              "date": "2019-05-02",
               "output": [
                 {
                   "command": "follow_flowfrom",
@@ -518,10 +402,6 @@
               "notes": "partial support because a reference to multiple elements is not supported"
             },
             "chrome": {
-              "at_version": "2018.1811.2",
-              "browser_version": "74",
-              "os_version": "1809",
-              "date": "2019-05-02",
               "output": [
                 {
                   "command": "follow_flowfrom",
@@ -536,10 +416,6 @@
         "vo_macos": {
           "browsers": {
             "safari": {
-              "at_version": "10.14.4",
-              "browser_version": "12.1",
-              "os_version": "10.14.4",
-              "date": "2019-05-08",
               "output": [
                 {
                   "command": "next_item",
@@ -554,10 +430,6 @@
         "vo_ios": {
           "browsers": {
             "ios_saf": {
-              "at_version": "12.2",
-              "browser_version": "12.2",
-              "os_version": "12.2",
-              "date": "2019-05-08",
               "output": [
                 {
                   "command": "next_item",
@@ -577,5 +449,75 @@
       "date": "2019-05-08",
       "message": "Test created"
     }
-  ]
+  ],
+  "versions": {
+    "jaws": {
+      "browsers": {
+        "chrome": {
+          "at_version": "2018.1811.2",
+          "browser_version": "74",
+          "os_version": "1809",
+          "date": "2019-05-02"
+        },
+        "ie": {
+          "at_version": "2018.1811.2",
+          "browser_version": "11.134",
+          "os_version": "1809",
+          "date": "2019-05-02"
+        },
+        "firefox": {
+          "at_version": "2018.1811.2",
+          "browser_version": "66",
+          "os_version": "1809",
+          "date": "2019-05-02"
+        }
+      }
+    },
+    "narrator": {
+      "browsers": {
+        "edge": {
+          "at_version": "1809",
+          "browser_version": "44.17763",
+          "os_version": "1809",
+          "date": "2019-05-02"
+        }
+      }
+    },
+    "nvda": {
+      "browsers": {
+        "chrome": {
+          "at_version": "2018.1808.10",
+          "browser_version": "74",
+          "os_version": "1809",
+          "date": "2019-05-02"
+        },
+        "firefox": {
+          "at_version": "2018.3.2",
+          "browser_version": "66",
+          "os_version": "1809",
+          "date": "2019-09-04"
+        }
+      }
+    },
+    "vo_ios": {
+      "browsers": {
+        "ios_saf": {
+          "at_version": "12.2",
+          "browser_version": "12.2",
+          "os_version": "12.2",
+          "date": "2019-05-08"
+        }
+      }
+    },
+    "vo_macos": {
+      "browsers": {
+        "safari": {
+          "at_version": "10.14.4",
+          "browser_version": "12.1",
+          "os_version": "10.14.4",
+          "date": "2019-05-08"
+        }
+      }
+    }
+  }
 }

--- a/data/tests/tech/aria/aria-required-radiogroup.json
+++ b/data/tests/tech/aria/aria-required-radiogroup.json
@@ -11,9 +11,6 @@
         "jaws": {
           "browsers": {
             "firefox": {
-              "at_version": "2019.1906.10",
-              "browser_version": "67",
-              "os_version": "1903",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -22,13 +19,9 @@
                   "output": "\"animal, required, cat radio button, not checked, 1 of 2\"",
                   "result": "pass"
                 }
-              ],
-              "date": "2019-07-01"
+              ]
             },
             "chrome": {
-              "at_version": "2019.1906.10",
-              "browser_version": "75",
-              "os_version": "1903",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -37,13 +30,9 @@
                   "output": "\"animal, required, cat radio button, not checked, 1 of 2\"",
                   "result": "pass"
                 }
-              ],
-              "date": "2019-07-01"
+              ]
             },
             "ie": {
-              "at_version": "2019.1906.10",
-              "browser_version": "11",
-              "os_version": "1903",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -52,18 +41,13 @@
                   "output": "\"animal, required, cat radio button, not checked\"",
                   "result": "pass"
                 }
-              ],
-              "date": "2019-07-01"
+              ]
             }
           }
         },
         "narrator": {
           "browsers": {
             "edge": {
-              "at_version": "1903",
-              "browser_version": "44.17763",
-              "os_version": "1903",
-              "date": "2019-07-01",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -79,10 +63,6 @@
         "nvda": {
           "browsers": {
             "firefox": {
-              "at_version": "2019.1.1",
-              "browser_version": "67",
-              "os_version": "1903",
-              "date": "2019-07-01",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -94,10 +74,6 @@
               ]
             },
             "chrome": {
-              "at_version": "2019.1.1",
-              "browser_version": "75",
-              "os_version": "1903",
-              "date": "2019-07-01",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -113,10 +89,6 @@
         "vo_ios": {
           "browsers": {
             "ios_saf": {
-              "at_version": "12.3.1",
-              "browser_version": "12.3.1",
-              "os_version": "12.3.1",
-              "date": "2019-07-01",
               "output": [
                 {
                   "command": "next_item",
@@ -132,10 +104,6 @@
         "vo_macos": {
           "browsers": {
             "safari": {
-              "at_version": "10.14.5",
-              "browser_version": "12.1.1",
-              "os_version": "10.14.5",
-              "date": "2019-07-01",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -157,9 +125,6 @@
         "jaws": {
           "browsers": {
             "firefox": {
-              "at_version": "2019.1906.10",
-              "browser_version": "67",
-              "os_version": "1903",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -182,13 +147,9 @@
                   "output": "\"group end\"",
                   "result": "pass"
                 }
-              ],
-              "date": "2019-07-01"
+              ]
             },
             "chrome": {
-              "at_version": "2019.1906.10",
-              "browser_version": "75",
-              "os_version": "1903",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -211,13 +172,9 @@
                   "output": "\"group end\"",
                   "result": "pass"
                 }
-              ],
-              "date": "2019-07-01"
+              ]
             },
             "ie": {
-              "at_version": "2019.1906.10",
-              "browser_version": "11",
-              "os_version": "1903",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -240,18 +197,13 @@
                   "output": "\"group end\"",
                   "result": "pass"
                 }
-              ],
-              "date": "2019-07-01"
+              ]
             }
           }
         },
         "narrator": {
           "browsers": {
             "edge": {
-              "at_version": "1903",
-              "browser_version": "44.17763",
-              "os_version": "1903",
-              "date": "2019-07-01",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -282,10 +234,6 @@
         "nvda": {
           "browsers": {
             "firefox": {
-              "at_version": "2019.1.1",
-              "browser_version": "67",
-              "os_version": "1903",
-              "date": "2019-07-01",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -311,10 +259,6 @@
               ]
             },
             "chrome": {
-              "at_version": "2019.1.1",
-              "browser_version": "75",
-              "os_version": "1903",
-              "date": "2019-07-01",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -344,10 +288,6 @@
         "vo_ios": {
           "browsers": {
             "ios_saf": {
-              "at_version": "12.3.1",
-              "browser_version": "12.3.1",
-              "os_version": "12.3.1",
-              "date": "2019-07-01",
               "output": [
                 {
                   "command": "next_item",
@@ -377,10 +317,6 @@
         "vo_macos": {
           "browsers": {
             "safari": {
-              "at_version": "10.14.5",
-              "browser_version": "12.1.1",
-              "os_version": "10.14.5",
-              "date": "2019-07-01",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -416,9 +352,6 @@
         "jaws": {
           "browsers": {
             "firefox": {
-              "at_version": "2019.1906.10",
-              "browser_version": "67",
-              "os_version": "1903",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -441,13 +374,9 @@
                   "output": "\"group end\"",
                   "result": "fail"
                 }
-              ],
-              "date": "2019-07-01"
+              ]
             },
             "chrome": {
-              "at_version": "2019.1906.10",
-              "browser_version": "75",
-              "os_version": "1903",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -470,13 +399,9 @@
                   "output": "\"group end\"",
                   "result": "fail"
                 }
-              ],
-              "date": "2019-07-01"
+              ]
             },
             "ie": {
-              "at_version": "2019.1906.10",
-              "browser_version": "11",
-              "os_version": "1903",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -499,18 +424,13 @@
                   "output": "\"group end\"",
                   "result": "fail"
                 }
-              ],
-              "date": "2019-07-01"
+              ]
             }
           }
         },
         "narrator": {
           "browsers": {
             "edge": {
-              "at_version": "1903",
-              "browser_version": "44.17763",
-              "os_version": "1903",
-              "date": "2019-07-01",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -526,10 +446,6 @@
         "nvda": {
           "browsers": {
             "firefox": {
-              "at_version": "2019.1.1",
-              "browser_version": "67",
-              "os_version": "1903",
-              "date": "2019-07-01",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -541,10 +457,6 @@
               ]
             },
             "chrome": {
-              "at_version": "2019.1.1",
-              "browser_version": "75",
-              "os_version": "1903",
-              "date": "2019-07-01",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -560,10 +472,6 @@
         "vo_ios": {
           "browsers": {
             "ios_saf": {
-              "at_version": "12.3.1",
-              "browser_version": "12.3.1",
-              "os_version": "12.3.1",
-              "date": "2019-07-01",
               "output": [
                 {
                   "command": "next_item",
@@ -593,10 +501,6 @@
         "vo_macos": {
           "browsers": {
             "safari": {
-              "at_version": "10.14.5",
-              "browser_version": "12.1.1",
-              "os_version": "10.14.5",
-              "date": "2019-07-01",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -632,9 +536,6 @@
         "jaws": {
           "browsers": {
             "firefox": {
-              "at_version": "2019.1906.10",
-              "browser_version": "67",
-              "os_version": "1903",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -657,13 +558,9 @@
                   "output": "\"group end\"",
                   "result": "pass"
                 }
-              ],
-              "date": "2019-07-01"
+              ]
             },
             "chrome": {
-              "at_version": "2019.1906.10",
-              "browser_version": "75",
-              "os_version": "1903",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -686,13 +583,9 @@
                   "output": "\"group end\"",
                   "result": "pass"
                 }
-              ],
-              "date": "2019-07-01"
+              ]
             },
             "ie": {
-              "at_version": "2019.1906.10",
-              "browser_version": "11",
-              "os_version": "1903",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -715,18 +608,13 @@
                   "output": "\"group end\"",
                   "result": "pass"
                 }
-              ],
-              "date": "2019-07-01"
+              ]
             }
           }
         },
         "narrator": {
           "browsers": {
             "edge": {
-              "at_version": "1903",
-              "browser_version": "44.17763",
-              "os_version": "1903",
-              "date": "2019-07-01",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -757,10 +645,6 @@
         "nvda": {
           "browsers": {
             "firefox": {
-              "at_version": "2019.1.1",
-              "browser_version": "67",
-              "os_version": "1903",
-              "date": "2019-07-01",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -793,10 +677,6 @@
               ]
             },
             "chrome": {
-              "at_version": "2019.1.1",
-              "browser_version": "75",
-              "os_version": "1903",
-              "date": "2019-07-01",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -833,10 +713,6 @@
         "vo_ios": {
           "browsers": {
             "ios_saf": {
-              "at_version": "12.3.1",
-              "browser_version": "12.3.1",
-              "os_version": "12.3.1",
-              "date": "2019-07-01",
               "output": [
                 {
                   "command": "next_item",
@@ -866,10 +742,6 @@
         "vo_macos": {
           "browsers": {
             "safari": {
-              "at_version": "10.14.5",
-              "browser_version": "12.1.1",
-              "os_version": "10.14.5",
-              "date": "2019-07-01",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -904,5 +776,75 @@
       "date": "2019-07-01",
       "message": "Test created"
     }
-  ]
+  ],
+  "versions": {
+    "jaws": {
+      "browsers": {
+        "chrome": {
+          "at_version": "2019.1906.10",
+          "browser_version": "75",
+          "os_version": "1903",
+          "date": "2019-07-01"
+        },
+        "ie": {
+          "at_version": "2019.1906.10",
+          "browser_version": "11",
+          "os_version": "1903",
+          "date": "2019-07-01"
+        },
+        "firefox": {
+          "at_version": "2019.1906.10",
+          "browser_version": "67",
+          "os_version": "1903",
+          "date": "2019-07-01"
+        }
+      }
+    },
+    "narrator": {
+      "browsers": {
+        "edge": {
+          "at_version": "1903",
+          "browser_version": "44.17763",
+          "os_version": "1903",
+          "date": "2019-07-01"
+        }
+      }
+    },
+    "nvda": {
+      "browsers": {
+        "chrome": {
+          "at_version": "2019.1.1",
+          "browser_version": "75",
+          "os_version": "1903",
+          "date": "2019-07-01"
+        },
+        "firefox": {
+          "at_version": "2019.1.1",
+          "browser_version": "67",
+          "os_version": "1903",
+          "date": "2019-07-01"
+        }
+      }
+    },
+    "vo_ios": {
+      "browsers": {
+        "ios_saf": {
+          "at_version": "12.3.1",
+          "browser_version": "12.3.1",
+          "os_version": "12.3.1",
+          "date": "2019-07-01"
+        }
+      }
+    },
+    "vo_macos": {
+      "browsers": {
+        "safari": {
+          "at_version": "10.14.5",
+          "browser_version": "12.1.1",
+          "os_version": "10.14.5",
+          "date": "2019-07-01"
+        }
+      }
+    }
+  }
 }

--- a/data/tests/tech/aria/aria-required.json
+++ b/data/tests/tech/aria/aria-required.json
@@ -10,9 +10,6 @@
         "jaws": {
           "browsers": {
             "firefox": {
-              "at_version": "2019.1906.10",
-              "browser_version": "67",
-              "os_version": "1903",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -21,13 +18,9 @@
                   "output": "\"fruit edit. type in text.\"",
                   "result": "pass"
                 }
-              ],
-              "date": "2019-07-01"
+              ]
             },
             "chrome": {
-              "at_version": "2019.1906.10",
-              "browser_version": "75",
-              "os_version": "1903",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -36,13 +29,9 @@
                   "output": "\"fruit edit. type in text.\"",
                   "result": "pass"
                 }
-              ],
-              "date": "2019-07-01"
+              ]
             },
             "ie": {
-              "at_version": "2019.1906.10",
-              "browser_version": "11",
-              "os_version": "1903",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -51,18 +40,13 @@
                   "output": "\"fruit edit. type in text.\"",
                   "result": "pass"
                 }
-              ],
-              "date": "2019-07-01"
+              ]
             }
           }
         },
         "narrator": {
           "browsers": {
             "edge": {
-              "at_version": "1903",
-              "browser_version": "44.17763",
-              "os_version": "1903",
-              "date": "2019-07-01",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -78,10 +62,6 @@
         "nvda": {
           "browsers": {
             "firefox": {
-              "at_version": "2019.1.1",
-              "browser_version": "67",
-              "os_version": "1903",
-              "date": "2019-07-01",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -93,10 +73,6 @@
               ]
             },
             "chrome": {
-              "at_version": "2019.1.1",
-              "browser_version": "75",
-              "os_version": "1903",
-              "date": "2019-07-01",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -112,10 +88,6 @@
         "vo_ios": {
           "browsers": {
             "ios_saf": {
-              "at_version": "12.3.1",
-              "browser_version": "12.3.1",
-              "os_version": "12.3.1",
-              "date": "2019-07-01",
               "output": [
                 {
                   "command": "next_item",
@@ -131,10 +103,6 @@
         "vo_macos": {
           "browsers": {
             "safari": {
-              "at_version": "10.14.5",
-              "browser_version": "12.1.1",
-              "os_version": "10.14.5",
-              "date": "2019-07-01",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -156,9 +124,6 @@
         "jaws": {
           "browsers": {
             "firefox": {
-              "at_version": "2019.1906.10",
-              "browser_version": "67",
-              "os_version": "1903",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -167,13 +132,9 @@
                   "output": "\"veggie edit. required. type in text.\"",
                   "result": "pass"
                 }
-              ],
-              "date": "2019-07-01"
+              ]
             },
             "chrome": {
-              "at_version": "2019.1906.10",
-              "browser_version": "75",
-              "os_version": "1903",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -182,13 +143,9 @@
                   "output": "\"veggie edit. required. type in text.\"",
                   "result": "pass"
                 }
-              ],
-              "date": "2019-07-01"
+              ]
             },
             "ie": {
-              "at_version": "2019.1906.10",
-              "browser_version": "11",
-              "os_version": "1903",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -197,18 +154,13 @@
                   "output": "\"veggie edit. required. type in text.\"",
                   "result": "pass"
                 }
-              ],
-              "date": "2019-07-01"
+              ]
             }
           }
         },
         "narrator": {
           "browsers": {
             "edge": {
-              "at_version": "1903",
-              "browser_version": "44.17763",
-              "os_version": "1903",
-              "date": "2019-07-01",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -224,10 +176,6 @@
         "nvda": {
           "browsers": {
             "firefox": {
-              "at_version": "2019.1.1",
-              "browser_version": "67",
-              "os_version": "1903",
-              "date": "2019-07-01",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -239,10 +187,6 @@
               ]
             },
             "chrome": {
-              "at_version": "2019.1.1",
-              "browser_version": "75",
-              "os_version": "1903",
-              "date": "2019-07-01",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -258,10 +202,6 @@
         "vo_ios": {
           "browsers": {
             "ios_saf": {
-              "at_version": "12.3.1",
-              "browser_version": "12.3.1",
-              "os_version": "12.3.1",
-              "date": "2019-07-01",
               "output": [
                 {
                   "command": "next_item",
@@ -277,10 +217,6 @@
         "vo_macos": {
           "browsers": {
             "safari": {
-              "at_version": "10.14.5",
-              "browser_version": "12.1.1",
-              "os_version": "10.14.5",
-              "date": "2019-07-01",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -301,5 +237,75 @@
       "date": "2019-07-01",
       "message": "Test created"
     }
-  ]
+  ],
+  "versions": {
+    "jaws": {
+      "browsers": {
+        "chrome": {
+          "at_version": "2019.1906.10",
+          "browser_version": "75",
+          "os_version": "1903",
+          "date": "2019-07-01"
+        },
+        "ie": {
+          "at_version": "2019.1906.10",
+          "browser_version": "11",
+          "os_version": "1903",
+          "date": "2019-07-01"
+        },
+        "firefox": {
+          "at_version": "2019.1906.10",
+          "browser_version": "67",
+          "os_version": "1903",
+          "date": "2019-07-01"
+        }
+      }
+    },
+    "narrator": {
+      "browsers": {
+        "edge": {
+          "at_version": "1903",
+          "browser_version": "44.17763",
+          "os_version": "1903",
+          "date": "2019-07-01"
+        }
+      }
+    },
+    "nvda": {
+      "browsers": {
+        "chrome": {
+          "at_version": "2019.1.1",
+          "browser_version": "75",
+          "os_version": "1903",
+          "date": "2019-07-01"
+        },
+        "firefox": {
+          "at_version": "2019.1.1",
+          "browser_version": "67",
+          "os_version": "1903",
+          "date": "2019-07-01"
+        }
+      }
+    },
+    "vo_ios": {
+      "browsers": {
+        "ios_saf": {
+          "at_version": "12.3.1",
+          "browser_version": "12.3.1",
+          "os_version": "12.3.1",
+          "date": "2019-07-01"
+        }
+      }
+    },
+    "vo_macos": {
+      "browsers": {
+        "safari": {
+          "at_version": "10.14.5",
+          "browser_version": "12.1.1",
+          "os_version": "10.14.5",
+          "date": "2019-07-01"
+        }
+      }
+    }
+  }
 }

--- a/data/tests/tech/aria/aria_controls.json
+++ b/data/tests/tech/aria/aria_controls.json
@@ -3,180 +3,224 @@
   "description": "Tests the aria-controls attribute. This test just asserts that a screen reader conveys that the target element controls something. Screen readers might convey this differently. They may announce that the element controls something, or/and announce the keyboard shortcut to jump to the target. This test does not assert that a screen reader supports jumping to the target.",
   "html_file": "aria/aria-controls.html",
   "assertions": [
-      {
-        "feature_id": "aria/aria-controls_attribute",
-        "feature_assertion_id": "convey_presence_if_not_empty_and_valid",
-        "results": {
-          "jaws": {
-            "browsers": {
-              "firefox": {
-                "at_version": "2018.1811.2",
-                "browser_version": "66",
-                "os_version": "1809",
-                "output": [
-                  {
-                    "command": "next_focusable_item",
-                    "output": "target button, use jaws key + alt + M to move to controlled element",
-                    "result": "pass"
-                  }
-                ],
-                "date": "2019-04-09"
-              },
-              "chrome": {
-                "at_version": "2018.1811.2",
-                "browser_version": "73",
-                "os_version": "1809",
-                "output": [
-                  {
-                    "command": "next_focusable_item",
-                    "output": "target button, use jaws key + alt + M to move to controlled element",
-                    "result": "pass"
-                  }
-                ],
-                "date": "2019-04-09"
-              },
-              "ie": {
-                "at_version": "2018.1811.2",
-                "browser_version": "11",
-                "os_version": "1809",
-                "output": [
-                  {
-                    "command": "next_focusable_item",
-                    "output": "target button, use jaws key + alt + M to move to controlled element",
-                    "result": "pass"
-                  }
-                ],
-                "date": "2019-04-09"
-              },
-              "edge": {
-                "at_version": "2018.1811.2",
-                "browser_version": "44",
-                "os_version": "1809",
-                "output": [
-                  {
-                    "command": "next_focusable_item",
-                    "output": "target button",
-                    "result": "fail"
-                  }
-                ],
-                "date": "2019-04-09"
-              }
+    {
+      "feature_id": "aria/aria-controls_attribute",
+      "feature_assertion_id": "convey_presence_if_not_empty_and_valid",
+      "results": {
+        "jaws": {
+          "browsers": {
+            "firefox": {
+              "output": [
+                {
+                  "command": "next_focusable_item",
+                  "output": "target button, use jaws key + alt + M to move to controlled element",
+                  "result": "pass"
+                }
+              ]
+            },
+            "chrome": {
+              "output": [
+                {
+                  "command": "next_focusable_item",
+                  "output": "target button, use jaws key + alt + M to move to controlled element",
+                  "result": "pass"
+                }
+              ]
+            },
+            "ie": {
+              "output": [
+                {
+                  "command": "next_focusable_item",
+                  "output": "target button, use jaws key + alt + M to move to controlled element",
+                  "result": "pass"
+                }
+              ]
+            },
+            "edge": {
+              "output": [
+                {
+                  "command": "next_focusable_item",
+                  "output": "target button",
+                  "result": "fail"
+                }
+              ]
             }
-          },
-          "narrator": {
-            "browsers": {
-              "edge": {
-                "at_version": "1809",
-                "browser_version": "44.17763",
-                "os_version": "1809",
-                "date": "2019-04-09",
-                "output": [
-                  {
-                    "command": "next_focusable_item",
-                    "output": "(property was not conveyed)",
-                    "result": "fail"
-                  }
-                ]
-              }
+          }
+        },
+        "narrator": {
+          "browsers": {
+            "edge": {
+              "output": [
+                {
+                  "command": "next_focusable_item",
+                  "output": "(property was not conveyed)",
+                  "result": "fail"
+                }
+              ]
             }
-          },
-          "nvda": {
-            "browsers": {
-              "firefox": {
-                "at_version": "2019.0.1",
-                "browser_version": "66",
-                "os_version": "1809",
-                "date": "2019-04-09",
-                "output": [
-                  {
-                    "command": "next_focusable_item",
-                    "output": "(property was not conveyed)",
-                    "result": "fail"
-                  }
-                ]
-              },
-              "chrome": {
-                "at_version": "2019.0.1",
-                "browser_version": "73",
-                "os_version": "1809",
-                "date": "2019-04-09",
-                "output": [
-                  {
-                    "command": "next_focusable_item",
-                    "output": "(property was not conveyed)",
-                    "result": "fail"
-                  }
-                ]
-              },
-              "edge": {
-                "at_version": "2019.0.1",
-                "browser_version": "44.17763",
-                "os_version": "1809",
-                "date": "2019-04-09",
-                "output": [
-                  {
-                    "command": "next_focusable_item",
-                    "output": "(property was not conveyed)",
-                    "result": "fail"
-                  }
-                ]
-              },
-              "ie": {
-                "at_version": "2019.0.1",
-                "browser_version": "11",
-                "os_version": "1809",
-                "date": "2019-04-09",
-                "output": [
-                  {
-                    "command": "next_focusable_item",
-                    "output": "(property was not conveyed)",
-                    "result": "fail"
-                  }
-                ]
-              }
+          }
+        },
+        "nvda": {
+          "browsers": {
+            "firefox": {
+              "output": [
+                {
+                  "command": "next_focusable_item",
+                  "output": "(property was not conveyed)",
+                  "result": "fail"
+                }
+              ]
+            },
+            "chrome": {
+              "output": [
+                {
+                  "command": "next_focusable_item",
+                  "output": "(property was not conveyed)",
+                  "result": "fail"
+                }
+              ]
+            },
+            "edge": {
+              "output": [
+                {
+                  "command": "next_focusable_item",
+                  "output": "(property was not conveyed)",
+                  "result": "fail"
+                }
+              ]
+            },
+            "ie": {
+              "output": [
+                {
+                  "command": "next_focusable_item",
+                  "output": "(property was not conveyed)",
+                  "result": "fail"
+                }
+              ]
             }
-          },
-          "vo_ios": {
-            "browsers": {
-              "ios_saf": {
-                "at_version": "12.2",
-                "browser_version": "12.2",
-                "os_version": "12.2",
-                "date": "2019-04-09",
-                "output": [
-                  {
-                    "command": "next_item",
-                    "output": "(property was not conveyed)",
-                    "result": "fail"
-                  }
-                ]
-              }
+          }
+        },
+        "vo_ios": {
+          "browsers": {
+            "ios_saf": {
+              "output": [
+                {
+                  "command": "next_item",
+                  "output": "(property was not conveyed)",
+                  "result": "fail"
+                }
+              ]
             }
-          },
-          "vo_macos": {
-            "browsers": {
-              "safari": {
-                "at_version": "10.14.4",
-                "browser_version": "12.1",
-                "os_version": "10.14.4",
-                "date": "2019-04-09",
-                "output": [
-                  {
-                    "command": "next_focusable_item",
-                    "output": "(property was not conveyed)",
-                    "result": "fail"
-                  }
-                ]
-              }
+          }
+        },
+        "vo_macos": {
+          "browsers": {
+            "safari": {
+              "output": [
+                {
+                  "command": "next_focusable_item",
+                  "output": "(property was not conveyed)",
+                  "result": "fail"
+                }
+              ]
             }
           }
         }
       }
+    }
   ],
   "history": [
-      {
-        "date": "2019-04-09",
-        "message": "Test created"
+    {
+      "date": "2019-04-09",
+      "message": "Test created"
+    }
+  ],
+  "versions": {
+    "jaws": {
+      "browsers": {
+        "chrome": {
+          "at_version": "2018.1811.2",
+          "browser_version": "73",
+          "os_version": "1809",
+          "date": "2019-04-09"
+        },
+        "ie": {
+          "at_version": "2018.1811.2",
+          "browser_version": "11",
+          "os_version": "1809",
+          "date": "2019-04-09"
+        },
+        "firefox": {
+          "at_version": "2018.1811.2",
+          "browser_version": "66",
+          "os_version": "1809",
+          "date": "2019-04-09"
+        },
+        "edge": {
+          "at_version": "2018.1811.2",
+          "browser_version": "44",
+          "os_version": "1809",
+          "date": "2019-04-09"
+        }
       }
-  ]
+    },
+    "narrator": {
+      "browsers": {
+        "edge": {
+          "at_version": "1809",
+          "browser_version": "44.17763",
+          "os_version": "1809",
+          "date": "2019-04-09"
+        }
+      }
+    },
+    "nvda": {
+      "browsers": {
+        "chrome": {
+          "at_version": "2019.0.1",
+          "browser_version": "73",
+          "os_version": "1809",
+          "date": "2019-04-09"
+        },
+        "firefox": {
+          "at_version": "2019.0.1",
+          "browser_version": "66",
+          "os_version": "1809",
+          "date": "2019-04-09"
+        },
+        "ie": {
+          "at_version": "2019.0.1",
+          "browser_version": "11",
+          "os_version": "1809",
+          "date": "2019-04-09"
+        },
+        "edge": {
+          "at_version": "2019.0.1",
+          "browser_version": "44.17763",
+          "os_version": "1809",
+          "date": "2019-04-09"
+        }
+      }
+    },
+    "vo_ios": {
+      "browsers": {
+        "ios_saf": {
+          "at_version": "12.2",
+          "browser_version": "12.2",
+          "os_version": "12.2",
+          "date": "2019-04-09"
+        }
+      }
+    },
+    "vo_macos": {
+      "browsers": {
+        "safari": {
+          "at_version": "10.14.4",
+          "browser_version": "12.1",
+          "os_version": "10.14.4",
+          "date": "2019-04-09"
+        }
+      }
+    }
+  }
 }

--- a/data/tests/tech/aria/aria_current.json
+++ b/data/tests/tech/aria/aria_current.json
@@ -10,66 +10,46 @@
         "jaws": {
           "browsers": {
             "firefox": {
-              "at_version": "2018.1811.2",
-              "browser_version": "66",
-              "os_version": "1809",
               "output": [
                 {
                   "command": "next_item",
                   "output": "current date",
                   "result": "pass"
                 }
-              ],
-              "date": "2019-03-29"
+              ]
             },
             "chrome": {
-              "at_version": "2018.1811.2",
-              "browser_version": "73",
-              "os_version": "1809",
               "output": [
                 {
                   "command": "next_item",
                   "output": "current date",
                   "result": "pass"
                 }
-              ],
-              "date": "2019-03-29"
+              ]
             },
             "ie": {
-              "at_version": "2018.1811.2",
-              "browser_version": "11",
-              "os_version": "1809",
               "output": [
                 {
                   "command": "next_item",
                   "output": "current date",
                   "result": "pass"
                 }
-              ],
-              "date": "2019-03-29"
+              ]
             },
             "edge": {
-              "at_version": "2018.1811.2",
-              "browser_version": "44",
-              "os_version": "1809",
               "output": [
                 {
                   "command": "next_item",
                   "output": "(not announced)",
                   "result": "fail"
                 }
-              ],
-              "date": "2019-03-29"
+              ]
             }
           }
         },
         "narrator": {
           "browsers": {
             "edge": {
-              "at_version": "1809",
-              "browser_version": "44.17763",
-              "os_version": "1809",
-              "date": "2019-03-29",
               "output": [
                 {
                   "command": "next_item",
@@ -83,10 +63,6 @@
         "nvda": {
           "browsers": {
             "firefox": {
-              "at_version": "2019.0.1",
-              "browser_version": "66",
-              "os_version": "1809",
-              "date": "2019-03-29",
               "output": [
                 {
                   "command": "next_item",
@@ -96,10 +72,6 @@
               ]
             },
             "chrome": {
-              "at_version": "2019.0.1",
-              "browser_version": "73",
-              "os_version": "1809",
-              "date": "2019-03-29",
               "output": [
                 {
                   "command": "next_item",
@@ -109,10 +81,6 @@
               ]
             },
             "edge": {
-              "at_version": "2019.0.1",
-              "browser_version": "44.17763",
-              "os_version": "1809",
-              "date": "2019-03-29",
               "output": [
                 {
                   "command": "next_item",
@@ -122,10 +90,6 @@
               ]
             },
             "ie": {
-              "at_version": "2019.0.1",
-              "browser_version": "11",
-              "os_version": "1809",
-              "date": "2019-03-29",
               "output": [
                 {
                   "command": "next_item",
@@ -139,10 +103,6 @@
         "talkback": {
           "browsers": {
             "firefox": {
-              "at_version": "unknown",
-              "browser_version": "unknown",
-              "os_version": "unknown",
-              "date": "2018-02-03",
               "output": [
                 {
                   "command": "next_item",
@@ -156,10 +116,6 @@
         "vo_ios": {
           "browsers": {
             "ios_saf": {
-              "at_version": "12.2",
-              "browser_version": "12.2",
-              "os_version": "12.2",
-              "date": "2019-03-29",
               "output": [
                 {
                   "command": "next_item",
@@ -173,10 +129,6 @@
         "vo_macos": {
           "browsers": {
             "safari": {
-              "at_version": "10.14.4",
-              "browser_version": "12.1",
-              "os_version": "10.14.4",
-              "date": "2019-03-29",
               "output": [
                 {
                   "command": "next_item",
@@ -196,66 +148,46 @@
         "jaws": {
           "browsers": {
             "firefox": {
-              "at_version": "2018.1811.2",
-              "browser_version": "66",
-              "os_version": "1809",
               "output": [
                 {
                   "command": "next_item",
                   "output": "current location",
                   "result": "pass"
                 }
-              ],
-              "date": "2019-03-29"
+              ]
             },
             "chrome": {
-              "at_version": "2018.1811.2",
-              "browser_version": "73",
-              "os_version": "1809",
               "output": [
                 {
                   "command": "next_item",
                   "output": "current location",
                   "result": "pass"
                 }
-              ],
-              "date": "2019-03-29"
+              ]
             },
             "ie": {
-              "at_version": "2018.1811.2",
-              "browser_version": "11",
-              "os_version": "1809",
               "output": [
                 {
                   "command": "next_item",
                   "output": "current location",
                   "result": "pass"
                 }
-              ],
-              "date": "2019-03-29"
+              ]
             },
             "edge": {
-              "at_version": "2018.1811.2",
-              "browser_version": "44",
-              "os_version": "1809",
               "output": [
                 {
                   "command": "next_item",
                   "output": "(not announced)",
                   "result": "fail"
                 }
-              ],
-              "date": "2019-03-29"
+              ]
             }
           }
         },
         "narrator": {
           "browsers": {
             "edge": {
-              "at_version": "1809",
-              "browser_version": "44.17763",
-              "os_version": "1809",
-              "date": "2019-03-29",
               "output": [
                 {
                   "command": "next_item",
@@ -269,10 +201,6 @@
         "nvda": {
           "browsers": {
             "firefox": {
-              "at_version": "2019.0.1",
-              "browser_version": "66",
-              "os_version": "1809",
-              "date": "2019-03-29",
               "output": [
                 {
                   "command": "next_item",
@@ -282,10 +210,6 @@
               ]
             },
             "chrome": {
-              "at_version": "2019.0.1",
-              "browser_version": "73",
-              "os_version": "1809",
-              "date": "2019-03-29",
               "output": [
                 {
                   "command": "next_item",
@@ -295,10 +219,6 @@
               ]
             },
             "edge": {
-              "at_version": "2019.0.1",
-              "browser_version": "44.17763",
-              "os_version": "1809",
-              "date": "2019-03-29",
               "output": [
                 {
                   "command": "next_item",
@@ -308,10 +228,6 @@
               ]
             },
             "ie": {
-              "at_version": "2019.0.1",
-              "browser_version": "11",
-              "os_version": "1809",
-              "date": "2019-03-29",
               "output": [
                 {
                   "command": "next_item",
@@ -325,10 +241,6 @@
         "talkback": {
           "browsers": {
             "firefox": {
-              "at_version": "unknown",
-              "browser_version": "unknown",
-              "os_version": "unknown",
-              "date": "2018-02-03",
               "output": [
                 {
                   "command": "next_item",
@@ -342,10 +254,6 @@
         "vo_ios": {
           "browsers": {
             "ios_saf": {
-              "at_version": "12.2",
-              "browser_version": "12.2",
-              "os_version": "12.2",
-              "date": "2019-03-29",
               "output": [
                 {
                   "command": "next_item",
@@ -359,10 +267,6 @@
         "vo_macos": {
           "browsers": {
             "safari": {
-              "at_version": "10.14.4",
-              "browser_version": "12.1",
-              "os_version": "10.14.4",
-              "date": "2019-03-29",
               "output": [
                 {
                   "command": "next_item",
@@ -382,66 +286,46 @@
         "jaws": {
           "browsers": {
             "firefox": {
-              "at_version": "2018.1811.2",
-              "browser_version": "66",
-              "os_version": "1809",
               "output": [
                 {
                   "command": "next_item",
                   "output": "current page",
                   "result": "pass"
                 }
-              ],
-              "date": "2019-03-29"
+              ]
             },
             "chrome": {
-              "at_version": "2018.1811.2",
-              "browser_version": "73",
-              "os_version": "1809",
               "output": [
                 {
                   "command": "next_item",
                   "output": "current page",
                   "result": "pass"
                 }
-              ],
-              "date": "2019-03-29"
+              ]
             },
             "ie": {
-              "at_version": "2018.1811.2",
-              "browser_version": "11",
-              "os_version": "1809",
               "output": [
                 {
                   "command": "next_item",
                   "output": "current page",
                   "result": "pass"
                 }
-              ],
-              "date": "2019-03-29"
+              ]
             },
             "edge": {
-              "at_version": "2018.1811.2",
-              "browser_version": "44",
-              "os_version": "1809",
               "output": [
                 {
                   "command": "next_item",
                   "output": "(not announced)",
                   "result": "fail"
                 }
-              ],
-              "date": "2019-03-29"
+              ]
             }
           }
         },
         "narrator": {
           "browsers": {
             "edge": {
-              "at_version": "1809",
-              "browser_version": "44.17763",
-              "os_version": "1809",
-              "date": "2019-03-29",
               "output": [
                 {
                   "command": "next_item",
@@ -455,10 +339,6 @@
         "nvda": {
           "browsers": {
             "firefox": {
-              "at_version": "2019.0.1",
-              "browser_version": "66",
-              "os_version": "1809",
-              "date": "2019-03-29",
               "output": [
                 {
                   "command": "next_item",
@@ -468,10 +348,6 @@
               ]
             },
             "chrome": {
-              "at_version": "2019.0.1",
-              "browser_version": "73",
-              "os_version": "1809",
-              "date": "2019-03-29",
               "output": [
                 {
                   "command": "next_item",
@@ -481,10 +357,6 @@
               ]
             },
             "edge": {
-              "at_version": "2019.0.1",
-              "browser_version": "44.17763",
-              "os_version": "1809",
-              "date": "2019-03-29",
               "output": [
                 {
                   "command": "next_item",
@@ -494,10 +366,6 @@
               ]
             },
             "ie": {
-              "at_version": "2019.0.1",
-              "browser_version": "11",
-              "os_version": "1809",
-              "date": "2019-03-29",
               "output": [
                 {
                   "command": "next_item",
@@ -511,10 +379,6 @@
         "talkback": {
           "browsers": {
             "firefox": {
-              "at_version": "unknown",
-              "browser_version": "unknown",
-              "os_version": "unknown",
-              "date": "2018-02-03",
               "output": [
                 {
                   "command": "next_item",
@@ -528,10 +392,6 @@
         "vo_ios": {
           "browsers": {
             "ios_saf": {
-              "at_version": "12.2",
-              "browser_version": "12.2",
-              "os_version": "12.2",
-              "date": "2019-03-29",
               "output": [
                 {
                   "command": "next_item",
@@ -545,10 +405,6 @@
         "vo_macos": {
           "browsers": {
             "safari": {
-              "at_version": "10.14.4",
-              "browser_version": "12.1",
-              "os_version": "10.14.4",
-              "date": "2019-03-29",
               "output": [
                 {
                   "command": "next_item",
@@ -568,66 +424,46 @@
         "jaws": {
           "browsers": {
             "firefox": {
-              "at_version": "2018.1811.2",
-              "browser_version": "66",
-              "os_version": "1809",
               "output": [
                 {
                   "command": "next_item",
                   "output": "current step",
                   "result": "pass"
                 }
-              ],
-              "date": "2019-03-29"
+              ]
             },
             "chrome": {
-              "at_version": "2018.1811.2",
-              "browser_version": "73",
-              "os_version": "1809",
               "output": [
                 {
                   "command": "next_item",
                   "output": "current step",
                   "result": "pass"
                 }
-              ],
-              "date": "2019-03-29"
+              ]
             },
             "ie": {
-              "at_version": "2018.1811.2",
-              "browser_version": "11",
-              "os_version": "1809",
               "output": [
                 {
                   "command": "next_item",
                   "output": "current step",
                   "result": "pass"
                 }
-              ],
-              "date": "2019-03-29"
+              ]
             },
             "edge": {
-              "at_version": "2018.1811.2",
-              "browser_version": "44",
-              "os_version": "1809",
               "output": [
                 {
                   "command": "next_item",
                   "output": "(not announced)",
                   "result": "fail"
                 }
-              ],
-              "date": "2019-03-29"
+              ]
             }
           }
         },
         "narrator": {
           "browsers": {
             "edge": {
-              "at_version": "1809",
-              "browser_version": "44.17763",
-              "os_version": "1809",
-              "date": "2019-03-29",
               "output": [
                 {
                   "command": "next_item",
@@ -641,10 +477,6 @@
         "nvda": {
           "browsers": {
             "firefox": {
-              "at_version": "2019.0.1",
-              "browser_version": "66",
-              "os_version": "1809",
-              "date": "2019-03-29",
               "output": [
                 {
                   "command": "next_item",
@@ -654,10 +486,6 @@
               ]
             },
             "chrome": {
-              "at_version": "2019.0.1",
-              "browser_version": "73",
-              "os_version": "1809",
-              "date": "2019-03-29",
               "output": [
                 {
                   "command": "next_item",
@@ -667,10 +495,6 @@
               ]
             },
             "edge": {
-              "at_version": "2019.0.1",
-              "browser_version": "44.17763",
-              "os_version": "1809",
-              "date": "2019-03-29",
               "output": [
                 {
                   "command": "next_item",
@@ -680,10 +504,6 @@
               ]
             },
             "ie": {
-              "at_version": "2019.0.1",
-              "browser_version": "11",
-              "os_version": "1809",
-              "date": "2019-03-29",
               "output": [
                 {
                   "command": "next_item",
@@ -697,10 +517,6 @@
         "talkback": {
           "browsers": {
             "firefox": {
-              "at_version": "unknown",
-              "browser_version": "unknown",
-              "os_version": "unknown",
-              "date": "2018-02-03",
               "output": [
                 {
                   "command": "next_item",
@@ -714,10 +530,6 @@
         "vo_ios": {
           "browsers": {
             "ios_saf": {
-              "at_version": "12.2",
-              "browser_version": "12.2",
-              "os_version": "12.2",
-              "date": "2019-03-29",
               "output": [
                 {
                   "command": "next_item",
@@ -731,10 +543,6 @@
         "vo_macos": {
           "browsers": {
             "safari": {
-              "at_version": "10.14.4",
-              "browser_version": "12.1",
-              "os_version": "10.14.4",
-              "date": "2019-03-29",
               "output": [
                 {
                   "command": "next_item",
@@ -754,66 +562,46 @@
         "jaws": {
           "browsers": {
             "firefox": {
-              "at_version": "2018.1811.2",
-              "browser_version": "66",
-              "os_version": "1809",
               "output": [
                 {
                   "command": "next_item",
                   "output": "current time",
                   "result": "pass"
                 }
-              ],
-              "date": "2019-03-29"
+              ]
             },
             "chrome": {
-              "at_version": "2018.1811.2",
-              "browser_version": "73",
-              "os_version": "1809",
               "output": [
                 {
                   "command": "next_item",
                   "output": "current time",
                   "result": "pass"
                 }
-              ],
-              "date": "2019-03-29"
+              ]
             },
             "ie": {
-              "at_version": "2018.1811.2",
-              "browser_version": "11",
-              "os_version": "1809",
               "output": [
                 {
                   "command": "next_item",
                   "output": "current time",
                   "result": "pass"
                 }
-              ],
-              "date": "2019-03-29"
+              ]
             },
             "edge": {
-              "at_version": "2018.1811.2",
-              "browser_version": "44",
-              "os_version": "1809",
               "output": [
                 {
                   "command": "next_item",
                   "output": "(not announced)",
                   "result": "fail"
                 }
-              ],
-              "date": "2019-03-29"
+              ]
             }
           }
         },
         "narrator": {
           "browsers": {
             "edge": {
-              "at_version": "1809",
-              "browser_version": "44.17763",
-              "os_version": "1809",
-              "date": "2019-03-29",
               "output": [
                 {
                   "command": "next_item",
@@ -827,10 +615,6 @@
         "nvda": {
           "browsers": {
             "firefox": {
-              "at_version": "2019.0.1",
-              "browser_version": "66",
-              "os_version": "1809",
-              "date": "2019-03-29",
               "output": [
                 {
                   "command": "next_item",
@@ -840,10 +624,6 @@
               ]
             },
             "chrome": {
-              "at_version": "2019.0.1",
-              "browser_version": "73",
-              "os_version": "1809",
-              "date": "2019-03-29",
               "output": [
                 {
                   "command": "next_item",
@@ -853,10 +633,6 @@
               ]
             },
             "edge": {
-              "at_version": "2019.0.1",
-              "browser_version": "44.17763",
-              "os_version": "1809",
-              "date": "2019-03-29",
               "output": [
                 {
                   "command": "next_item",
@@ -866,10 +642,6 @@
               ]
             },
             "ie": {
-              "at_version": "2019.0.1",
-              "browser_version": "11",
-              "os_version": "1809",
-              "date": "2019-03-29",
               "output": [
                 {
                   "command": "next_item",
@@ -883,10 +655,6 @@
         "talkback": {
           "browsers": {
             "firefox": {
-              "at_version": "unknown",
-              "browser_version": "unknown",
-              "os_version": "unknown",
-              "date": "2018-02-03",
               "output": [
                 {
                   "command": "next_item",
@@ -900,10 +668,6 @@
         "vo_ios": {
           "browsers": {
             "ios_saf": {
-              "at_version": "12.2",
-              "browser_version": "12.2",
-              "os_version": "12.2",
-              "date": "2019-03-29",
               "output": [
                 {
                   "command": "next_item",
@@ -917,10 +681,6 @@
         "vo_macos": {
           "browsers": {
             "safari": {
-              "at_version": "10.14.4",
-              "browser_version": "12.1",
-              "os_version": "10.14.4",
-              "date": "2019-03-29",
               "output": [
                 {
                   "command": "next_item",
@@ -940,66 +700,46 @@
         "jaws": {
           "browsers": {
             "firefox": {
-              "at_version": "2018.1811.2",
-              "browser_version": "66",
-              "os_version": "1809",
               "output": [
                 {
                   "command": "next_item",
                   "output": "current",
                   "result": "pass"
                 }
-              ],
-              "date": "2019-03-29"
+              ]
             },
             "chrome": {
-              "at_version": "2018.1811.2",
-              "browser_version": "73",
-              "os_version": "1809",
               "output": [
                 {
                   "command": "next_item",
                   "output": "current",
                   "result": "pass"
                 }
-              ],
-              "date": "2019-03-29"
+              ]
             },
             "ie": {
-              "at_version": "2018.1811.2",
-              "browser_version": "11",
-              "os_version": "1809",
               "output": [
                 {
                   "command": "next_item",
                   "output": "current",
                   "result": "pass"
                 }
-              ],
-              "date": "2019-03-29"
+              ]
             },
             "edge": {
-              "at_version": "2018.1811.2",
-              "browser_version": "44",
-              "os_version": "1809",
               "output": [
                 {
                   "command": "next_item",
                   "output": "(not announced)",
                   "result": "fail"
                 }
-              ],
-              "date": "2019-03-29"
+              ]
             }
           }
         },
         "narrator": {
           "browsers": {
             "edge": {
-              "at_version": "1809",
-              "browser_version": "44.17763",
-              "os_version": "1809",
-              "date": "2019-03-29",
               "output": [
                 {
                   "command": "next_item",
@@ -1013,10 +753,6 @@
         "nvda": {
           "browsers": {
             "firefox": {
-              "at_version": "2019.0.1",
-              "browser_version": "66",
-              "os_version": "1809",
-              "date": "2019-03-29",
               "output": [
                 {
                   "command": "next_item",
@@ -1026,10 +762,6 @@
               ]
             },
             "chrome": {
-              "at_version": "2019.0.1",
-              "browser_version": "73",
-              "os_version": "1809",
-              "date": "2019-03-29",
               "output": [
                 {
                   "command": "next_item",
@@ -1039,10 +771,6 @@
               ]
             },
             "edge": {
-              "at_version": "2019.0.1",
-              "browser_version": "44.17763",
-              "os_version": "1809",
-              "date": "2019-03-29",
               "output": [
                 {
                   "command": "next_item",
@@ -1052,10 +780,6 @@
               ]
             },
             "ie": {
-              "at_version": "2019.0.1",
-              "browser_version": "11",
-              "os_version": "1809",
-              "date": "2019-03-29",
               "output": [
                 {
                   "command": "next_item",
@@ -1069,10 +793,6 @@
         "talkback": {
           "browsers": {
             "firefox": {
-              "at_version": "unknown",
-              "browser_version": "unknown",
-              "os_version": "unknown",
-              "date": "2018-02-03",
               "output": [
                 {
                   "command": "next_item",
@@ -1086,10 +806,6 @@
         "vo_ios": {
           "browsers": {
             "ios_saf": {
-              "at_version": "12.2",
-              "browser_version": "12.2",
-              "os_version": "12.2",
-              "date": "2019-03-29",
               "output": [
                 {
                   "command": "next_item",
@@ -1103,10 +819,6 @@
         "vo_macos": {
           "browsers": {
             "safari": {
-              "at_version": "10.14.4",
-              "browser_version": "12.1",
-              "os_version": "10.14.4",
-              "date": "2019-03-29",
               "output": [
                 {
                   "command": "next_item",
@@ -1125,5 +837,103 @@
       "date": "2019-03-29",
       "message": "Test created"
     }
-  ]
+  ],
+  "versions": {
+    "jaws": {
+      "browsers": {
+        "chrome": {
+          "at_version": "2018.1811.2",
+          "browser_version": "73",
+          "os_version": "1809",
+          "date": "2019-03-29"
+        },
+        "ie": {
+          "at_version": "2018.1811.2",
+          "browser_version": "11",
+          "os_version": "1809",
+          "date": "2019-03-29"
+        },
+        "firefox": {
+          "at_version": "2018.1811.2",
+          "browser_version": "66",
+          "os_version": "1809",
+          "date": "2019-03-29"
+        },
+        "edge": {
+          "at_version": "2018.1811.2",
+          "browser_version": "44",
+          "os_version": "1809",
+          "date": "2019-03-29"
+        }
+      }
+    },
+    "narrator": {
+      "browsers": {
+        "edge": {
+          "at_version": "1809",
+          "browser_version": "44.17763",
+          "os_version": "1809",
+          "date": "2019-03-29"
+        }
+      }
+    },
+    "nvda": {
+      "browsers": {
+        "chrome": {
+          "at_version": "2019.0.1",
+          "browser_version": "73",
+          "os_version": "1809",
+          "date": "2019-03-29"
+        },
+        "firefox": {
+          "at_version": "2019.0.1",
+          "browser_version": "66",
+          "os_version": "1809",
+          "date": "2019-03-29"
+        },
+        "ie": {
+          "at_version": "2019.0.1",
+          "browser_version": "11",
+          "os_version": "1809",
+          "date": "2019-03-29"
+        },
+        "edge": {
+          "at_version": "2019.0.1",
+          "browser_version": "44.17763",
+          "os_version": "1809",
+          "date": "2019-03-29"
+        }
+      }
+    },
+    "talkback": {
+      "browsers": {
+        "firefox": {
+          "at_version": "unknown",
+          "browser_version": "unknown",
+          "os_version": "unknown",
+          "date": "2018-02-03"
+        }
+      }
+    },
+    "vo_ios": {
+      "browsers": {
+        "ios_saf": {
+          "at_version": "12.2",
+          "browser_version": "12.2",
+          "os_version": "12.2",
+          "date": "2019-03-29"
+        }
+      }
+    },
+    "vo_macos": {
+      "browsers": {
+        "safari": {
+          "at_version": "10.14.4",
+          "browser_version": "12.1",
+          "os_version": "10.14.4",
+          "date": "2019-03-29"
+        }
+      }
+    }
+  }
 }

--- a/data/tests/tech/aria/aria_describedby.json
+++ b/data/tests/tech/aria/aria_describedby.json
@@ -10,66 +10,46 @@
         "jaws": {
           "browsers": {
             "firefox": {
-              "at_version": "2018.1811.2",
-              "browser_version": "60",
-              "os_version": "1809",
               "output": [
                 {
                   "command": "next_focusable_item",
                   "output": "Example label, edit, error",
                   "result": "pass"
                 }
-              ],
-              "date": "2019-03-08"
+              ]
             },
             "chrome": {
-              "at_version": "2018.1811.2",
-              "browser_version": "72",
-              "os_version": "1809",
               "output": [
                 {
                   "command": "next_focusable_item",
                   "output": "Example label, edit, error",
                   "result": "pass"
                 }
-              ],
-              "date": "2019-03-08"
+              ]
             },
             "ie": {
-              "at_version": "2018.1811.2",
-              "browser_version": "11",
-              "os_version": "1809",
               "output": [
                 {
                   "command": "next_focusable_item",
                   "output": "Example label, edit, error",
                   "result": "pass"
                 }
-              ],
-              "date": "2019-03-08"
+              ]
             },
             "edge": {
-              "at_version": "2018.1811.2",
-              "browser_version": "44",
-              "os_version": "1809",
               "output": [
                 {
                   "command": "next_focusable_item",
                   "output": "Example label, edit",
                   "result": "fail"
                 }
-              ],
-              "date": "2019-03-08"
+              ]
             }
           }
         },
         "narrator": {
           "browsers": {
             "edge": {
-              "at_version": "1809",
-              "browser_version": "44.17763",
-              "os_version": "1809",
-              "date": "2019-03-08",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -83,10 +63,6 @@
         "nvda": {
           "browsers": {
             "firefox": {
-              "at_version": "2018.4.1",
-              "browser_version": "65.0.2",
-              "os_version": "1804",
-              "date": "2019-03-08",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -100,10 +76,6 @@
         "vo_ios": {
           "browsers": {
             "ios_saf": {
-              "at_version": "12.1.4",
-              "browser_version": "12.1.4",
-              "os_version": "12.1.4",
-              "date": "2019-03-08",
               "output": [
                 {
                   "command": "next_item",
@@ -117,10 +89,6 @@
         "vo_macos": {
           "browsers": {
             "safari": {
-              "at_version": "10.14.3",
-              "browser_version": "12.0.3",
-              "os_version": "10.14.3",
-              "date": "2019-03-08",
               "output": [
                 {
                   "command": "next_item",
@@ -139,5 +107,75 @@
       "date": "2019-02-08",
       "message": "Test created"
     }
-  ]
+  ],
+  "versions": {
+    "jaws": {
+      "browsers": {
+        "chrome": {
+          "at_version": "2018.1811.2",
+          "browser_version": "72",
+          "os_version": "1809",
+          "date": "2019-03-08"
+        },
+        "ie": {
+          "at_version": "2018.1811.2",
+          "browser_version": "11",
+          "os_version": "1809",
+          "date": "2019-03-08"
+        },
+        "firefox": {
+          "at_version": "2018.1811.2",
+          "browser_version": "60",
+          "os_version": "1809",
+          "date": "2019-03-08"
+        },
+        "edge": {
+          "at_version": "2018.1811.2",
+          "browser_version": "44",
+          "os_version": "1809",
+          "date": "2019-03-08"
+        }
+      }
+    },
+    "narrator": {
+      "browsers": {
+        "edge": {
+          "at_version": "1809",
+          "browser_version": "44.17763",
+          "os_version": "1809",
+          "date": "2019-03-08"
+        }
+      }
+    },
+    "nvda": {
+      "browsers": {
+        "firefox": {
+          "at_version": "2018.4.1",
+          "browser_version": "65.0.2",
+          "os_version": "1804",
+          "date": "2019-03-08"
+        }
+      }
+    },
+    "vo_ios": {
+      "browsers": {
+        "ios_saf": {
+          "at_version": "12.1.4",
+          "browser_version": "12.1.4",
+          "os_version": "12.1.4",
+          "date": "2019-03-08"
+        }
+      }
+    },
+    "vo_macos": {
+      "browsers": {
+        "safari": {
+          "at_version": "10.14.3",
+          "browser_version": "12.0.3",
+          "os_version": "10.14.3",
+          "date": "2019-03-08"
+        }
+      }
+    }
+  }
 }

--- a/data/tests/tech/aria/aria_describedby_with_role_alert.json
+++ b/data/tests/tech/aria/aria_describedby_with_role_alert.json
@@ -10,66 +10,46 @@
         "jaws": {
           "browsers": {
             "firefox": {
-              "at_version": "2018.1811.2",
-              "browser_version": "60",
-              "os_version": "1809",
               "output": [
                 {
                   "command": "next_focusable_item",
                   "output": "Example label, edit, error",
                   "result": "pass"
                 }
-              ],
-              "date": "2019-03-08"
+              ]
             },
             "chrome": {
-              "at_version": "2018.1811.2",
-              "browser_version": "72",
-              "os_version": "1809",
               "output": [
                 {
                   "command": "next_focusable_item",
                   "output": "Example label, edit, error",
                   "result": "pass"
                 }
-              ],
-              "date": "2019-03-08"
+              ]
             },
             "ie": {
-              "at_version": "2018.1811.2",
-              "browser_version": "11",
-              "os_version": "1809",
               "output": [
                 {
                   "command": "next_focusable_item",
                   "output": "Example label, edit, error",
                   "result": "pass"
                 }
-              ],
-              "date": "2019-03-08"
+              ]
             },
             "edge": {
-              "at_version": "2018.1811.2",
-              "browser_version": "44",
-              "os_version": "1809",
               "output": [
                 {
                   "command": "next_focusable_item",
                   "output": "Example label, edit",
                   "result": "fail"
                 }
-              ],
-              "date": "2019-03-08"
+              ]
             }
           }
         },
         "narrator": {
           "browsers": {
             "edge": {
-              "at_version": "1809",
-              "browser_version": "44.17763",
-              "os_version": "1809",
-              "date": "2019-03-08",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -83,10 +63,6 @@
         "nvda": {
           "browsers": {
             "firefox": {
-              "at_version": "2018.4.1",
-              "browser_version": "65.0.2",
-              "os_version": "1804",
-              "date": "2019-03-08",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -100,10 +76,6 @@
         "vo_ios": {
           "browsers": {
             "ios_saf": {
-              "at_version": "12.1.4",
-              "browser_version": "12.1.4",
-              "os_version": "12.1.4",
-              "date": "2019-03-08",
               "output": [
                 {
                   "command": "next_item",
@@ -117,10 +89,6 @@
         "vo_macos": {
           "browsers": {
             "safari": {
-              "at_version": "10.14.3",
-              "browser_version": "12.0.3",
-              "os_version": "10.14.3",
-              "date": "2019-03-08",
               "output": [
                 {
                   "command": "next_item",
@@ -139,5 +107,75 @@
       "date": "2019-02-08",
       "message": "Test created"
     }
-  ]
+  ],
+  "versions": {
+    "jaws": {
+      "browsers": {
+        "chrome": {
+          "at_version": "2018.1811.2",
+          "browser_version": "72",
+          "os_version": "1809",
+          "date": "2019-03-08"
+        },
+        "ie": {
+          "at_version": "2018.1811.2",
+          "browser_version": "11",
+          "os_version": "1809",
+          "date": "2019-03-08"
+        },
+        "firefox": {
+          "at_version": "2018.1811.2",
+          "browser_version": "60",
+          "os_version": "1809",
+          "date": "2019-03-08"
+        },
+        "edge": {
+          "at_version": "2018.1811.2",
+          "browser_version": "44",
+          "os_version": "1809",
+          "date": "2019-03-08"
+        }
+      }
+    },
+    "narrator": {
+      "browsers": {
+        "edge": {
+          "at_version": "1809",
+          "browser_version": "44.17763",
+          "os_version": "1809",
+          "date": "2019-03-08"
+        }
+      }
+    },
+    "nvda": {
+      "browsers": {
+        "firefox": {
+          "at_version": "2018.4.1",
+          "browser_version": "65.0.2",
+          "os_version": "1804",
+          "date": "2019-03-08"
+        }
+      }
+    },
+    "vo_ios": {
+      "browsers": {
+        "ios_saf": {
+          "at_version": "12.1.4",
+          "browser_version": "12.1.4",
+          "os_version": "12.1.4",
+          "date": "2019-03-08"
+        }
+      }
+    },
+    "vo_macos": {
+      "browsers": {
+        "safari": {
+          "at_version": "10.14.3",
+          "browser_version": "12.0.3",
+          "os_version": "10.14.3",
+          "date": "2019-03-08"
+        }
+      }
+    }
+  }
 }

--- a/data/tests/tech/aria/aria_errormessage_with_aria_invalid_true.json
+++ b/data/tests/tech/aria/aria_errormessage_with_aria_invalid_true.json
@@ -10,66 +10,46 @@
         "jaws": {
           "browsers": {
             "firefox": {
-              "at_version": "2018.1811.2",
-              "browser_version": "66",
-              "os_version": "1809",
               "output": [
                 {
                   "command": "next_focusable_item",
                   "output": "(error message not conveyed)",
                   "result": "fail"
                 }
-              ],
-              "date": "2019-04-02"
+              ]
             },
             "chrome": {
-              "at_version": "2018.1811.2",
-              "browser_version": "73",
-              "os_version": "1809",
               "output": [
                 {
                   "command": "next_focusable_item",
                   "output": "(error message not conveyed)",
                   "result": "fail"
                 }
-              ],
-              "date": "2019-04-02"
+              ]
             },
             "ie": {
-              "at_version": "2018.1811.2",
-              "browser_version": "11",
-              "os_version": "1809",
               "output": [
                 {
                   "command": "next_focusable_item",
                   "output": "(error message not conveyed)",
                   "result": "fail"
                 }
-              ],
-              "date": "2019-04-02"
+              ]
             },
             "edge": {
-              "at_version": "2018.1811.2",
-              "browser_version": "44",
-              "os_version": "1809",
               "output": [
                 {
                   "command": "next_focusable_item",
                   "output": "(error message not conveyed)",
                   "result": "fail"
                 }
-              ],
-              "date": "2019-04-02"
+              ]
             }
           }
         },
         "narrator": {
           "browsers": {
             "edge": {
-              "at_version": "1809",
-              "browser_version": "44.17763",
-              "os_version": "1809",
-              "date": "2019-04-02",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -83,10 +63,6 @@
         "nvda": {
           "browsers": {
             "firefox": {
-              "at_version": "2019.0.1",
-              "browser_version": "66",
-              "os_version": "1809",
-              "date": "2019-04-02",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -96,10 +72,6 @@
               ]
             },
             "chrome": {
-              "at_version": "2019.0.1",
-              "browser_version": "73",
-              "os_version": "1809",
-              "date": "2019-04-02",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -109,10 +81,6 @@
               ]
             },
             "edge": {
-              "at_version": "2019.0.1",
-              "browser_version": "44.17763",
-              "os_version": "1809",
-              "date": "2019-04-02",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -122,10 +90,6 @@
               ]
             },
             "ie": {
-              "at_version": "2019.0.1",
-              "browser_version": "11",
-              "os_version": "1809",
-              "date": "2019-04-02",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -139,10 +103,6 @@
         "vo_ios": {
           "browsers": {
             "ios_saf": {
-              "at_version": "12.2",
-              "browser_version": "12.2",
-              "os_version": "12.2",
-              "date": "2019-04-02",
               "output": [
                 {
                   "command": "next_item",
@@ -156,10 +116,6 @@
         "vo_macos": {
           "browsers": {
             "safari": {
-              "at_version": "10.14.4",
-              "browser_version": "12.1",
-              "os_version": "10.14.4",
-              "date": "2019-04-02",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -178,5 +134,93 @@
       "date": "2019-04-09",
       "message": "Test created"
     }
-  ]
+  ],
+  "versions": {
+    "jaws": {
+      "browsers": {
+        "chrome": {
+          "at_version": "2018.1811.2",
+          "browser_version": "73",
+          "os_version": "1809",
+          "date": "2019-04-02"
+        },
+        "ie": {
+          "at_version": "2018.1811.2",
+          "browser_version": "11",
+          "os_version": "1809",
+          "date": "2019-04-02"
+        },
+        "firefox": {
+          "at_version": "2018.1811.2",
+          "browser_version": "66",
+          "os_version": "1809",
+          "date": "2019-04-02"
+        },
+        "edge": {
+          "at_version": "2018.1811.2",
+          "browser_version": "44",
+          "os_version": "1809",
+          "date": "2019-04-02"
+        }
+      }
+    },
+    "narrator": {
+      "browsers": {
+        "edge": {
+          "at_version": "1809",
+          "browser_version": "44.17763",
+          "os_version": "1809",
+          "date": "2019-04-02"
+        }
+      }
+    },
+    "nvda": {
+      "browsers": {
+        "chrome": {
+          "at_version": "2019.0.1",
+          "browser_version": "73",
+          "os_version": "1809",
+          "date": "2019-04-02"
+        },
+        "firefox": {
+          "at_version": "2019.0.1",
+          "browser_version": "66",
+          "os_version": "1809",
+          "date": "2019-04-02"
+        },
+        "ie": {
+          "at_version": "2019.0.1",
+          "browser_version": "11",
+          "os_version": "1809",
+          "date": "2019-04-02"
+        },
+        "edge": {
+          "at_version": "2019.0.1",
+          "browser_version": "44.17763",
+          "os_version": "1809",
+          "date": "2019-04-02"
+        }
+      }
+    },
+    "vo_ios": {
+      "browsers": {
+        "ios_saf": {
+          "at_version": "12.2",
+          "browser_version": "12.2",
+          "os_version": "12.2",
+          "date": "2019-04-02"
+        }
+      }
+    },
+    "vo_macos": {
+      "browsers": {
+        "safari": {
+          "at_version": "10.14.4",
+          "browser_version": "12.1",
+          "os_version": "10.14.4",
+          "date": "2019-04-02"
+        }
+      }
+    }
+  }
 }

--- a/data/tests/tech/aria/aria_haspopup_attribute.json
+++ b/data/tests/tech/aria/aria_haspopup_attribute.json
@@ -16,9 +16,6 @@
         "jaws": {
           "browsers": {
             "firefox": {
-              "at_version": "2019.1906.10",
-              "browser_version": "67",
-              "os_version": "1903",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -27,13 +24,9 @@
                   "output": "\"action button\"",
                   "result": "pass"
                 }
-              ],
-              "date": "2019-06-28"
+              ]
             },
             "chrome": {
-              "at_version": "2019.1906.10",
-              "browser_version": "75",
-              "os_version": "1903",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -42,13 +35,9 @@
                   "output": "\"action button\"",
                   "result": "pass"
                 }
-              ],
-              "date": "2019-06-28"
+              ]
             },
             "ie": {
-              "at_version": "2019.1906.10",
-              "browser_version": "11",
-              "os_version": "1903",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -57,13 +46,9 @@
                   "output": "\"action button\"",
                   "result": "pass"
                 }
-              ],
-              "date": "2019-06-28"
+              ]
             },
             "edge": {
-              "at_version": "2019.1906.10",
-              "browser_version": "44",
-              "os_version": "1903",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -72,18 +57,13 @@
                   "output": "\"action button\"",
                   "result": "pass"
                 }
-              ],
-              "date": "2019-06-28"
+              ]
             }
           }
         },
         "narrator": {
           "browsers": {
             "edge": {
-              "at_version": "1903",
-              "browser_version": "44.17763",
-              "os_version": "1903",
-              "date": "2019-06-28",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -99,10 +79,6 @@
         "nvda": {
           "browsers": {
             "firefox": {
-              "at_version": "2019.1.1",
-              "browser_version": "67",
-              "os_version": "1903",
-              "date": "2019-06-28",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -114,10 +90,6 @@
               ]
             },
             "chrome": {
-              "at_version": "2019.1.1",
-              "browser_version": "75",
-              "os_version": "1903",
-              "date": "2019-06-28",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -129,10 +101,6 @@
               ]
             },
             "edge": {
-              "at_version": "2019.1.1",
-              "browser_version": "44.17763",
-              "os_version": "1903",
-              "date": "2019-06-28",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -144,10 +112,6 @@
               ]
             },
             "ie": {
-              "at_version": "2019.1.1",
-              "browser_version": "11",
-              "os_version": "1903",
-              "date": "2019-06-28",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -163,10 +127,6 @@
         "vo_ios": {
           "browsers": {
             "ios_saf": {
-              "at_version": "12.3.1",
-              "browser_version": "12.3.1",
-              "os_version": "12.3.1",
-              "date": "2019-06-28",
               "output": [
                 {
                   "command": "next_item",
@@ -182,10 +142,6 @@
         "vo_macos": {
           "browsers": {
             "safari": {
-              "at_version": "10.14.5",
-              "browser_version": "12.1.1",
-              "os_version": "10.14.5",
-              "date": "2019-06-28",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -207,9 +163,6 @@
         "jaws": {
           "browsers": {
             "firefox": {
-              "at_version": "2019.1906.10",
-              "browser_version": "67",
-              "os_version": "1903",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -218,13 +171,9 @@
                   "output": "\"action button menu\"",
                   "result": "fail"
                 }
-              ],
-              "date": "2019-06-28"
+              ]
             },
             "chrome": {
-              "at_version": "2019.1906.10",
-              "browser_version": "75",
-              "os_version": "1903",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -233,13 +182,9 @@
                   "output": "\"action button menu\"",
                   "result": "fail"
                 }
-              ],
-              "date": "2019-06-28"
+              ]
             },
             "ie": {
-              "at_version": "2019.1906.10",
-              "browser_version": "11",
-              "os_version": "1903",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -248,13 +193,9 @@
                   "output": "\"action button menu\"",
                   "result": "fail"
                 }
-              ],
-              "date": "2019-06-28"
+              ]
             },
             "edge": {
-              "at_version": "2019.1906.10",
-              "browser_version": "44",
-              "os_version": "1903",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -263,18 +204,13 @@
                   "output": "\"action button\"",
                   "result": "fail"
                 }
-              ],
-              "date": "2019-06-28"
+              ]
             }
           }
         },
         "narrator": {
           "browsers": {
             "edge": {
-              "at_version": "1903",
-              "browser_version": "44.17763",
-              "os_version": "1903",
-              "date": "2019-06-28",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -290,10 +226,6 @@
         "nvda": {
           "browsers": {
             "firefox": {
-              "at_version": "2019.1.1",
-              "browser_version": "67",
-              "os_version": "1903",
-              "date": "2019-06-28",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -305,10 +237,6 @@
               ]
             },
             "chrome": {
-              "at_version": "2019.1.1",
-              "browser_version": "75",
-              "os_version": "1903",
-              "date": "2019-06-28",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -320,10 +248,6 @@
               ]
             },
             "edge": {
-              "at_version": "2019.1.1",
-              "browser_version": "44.17763",
-              "os_version": "1903",
-              "date": "2019-06-28",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -335,10 +259,6 @@
               ]
             },
             "ie": {
-              "at_version": "2019.1.1",
-              "browser_version": "11",
-              "os_version": "1903",
-              "date": "2019-06-28",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -354,10 +274,6 @@
         "vo_ios": {
           "browsers": {
             "ios_saf": {
-              "at_version": "12.3.1",
-              "browser_version": "12.3.1",
-              "os_version": "12.3.1",
-              "date": "2019-06-28",
               "output": [
                 {
                   "command": "next_item",
@@ -373,10 +289,6 @@
         "vo_macos": {
           "browsers": {
             "safari": {
-              "at_version": "10.14.5",
-              "browser_version": "12.1.1",
-              "os_version": "10.14.5",
-              "date": "2019-06-28",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -398,9 +310,6 @@
         "jaws": {
           "browsers": {
             "firefox": {
-              "at_version": "2019.1906.10",
-              "browser_version": "67",
-              "os_version": "1903",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -409,13 +318,9 @@
                   "output": "\"action button menu\"",
                   "result": "fail"
                 }
-              ],
-              "date": "2019-06-28"
+              ]
             },
             "chrome": {
-              "at_version": "2019.1906.10",
-              "browser_version": "75",
-              "os_version": "1903",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -424,13 +329,9 @@
                   "output": "\"action button menu\"",
                   "result": "fail"
                 }
-              ],
-              "date": "2019-06-28"
+              ]
             },
             "ie": {
-              "at_version": "2019.1906.10",
-              "browser_version": "11",
-              "os_version": "1903",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -439,13 +340,9 @@
                   "output": "\"action button menu\"",
                   "result": "fail"
                 }
-              ],
-              "date": "2019-06-28"
+              ]
             },
             "edge": {
-              "at_version": "2019.1906.10",
-              "browser_version": "44",
-              "os_version": "1903",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -454,18 +351,13 @@
                   "output": "\"action button\"",
                   "result": "fail"
                 }
-              ],
-              "date": "2019-06-28"
+              ]
             }
           }
         },
         "narrator": {
           "browsers": {
             "edge": {
-              "at_version": "1903",
-              "browser_version": "44.17763",
-              "os_version": "1903",
-              "date": "2019-06-28",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -481,10 +373,6 @@
         "nvda": {
           "browsers": {
             "firefox": {
-              "at_version": "2019.1.1",
-              "browser_version": "67",
-              "os_version": "1903",
-              "date": "2019-06-28",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -496,10 +384,6 @@
               ]
             },
             "chrome": {
-              "at_version": "2019.1.1",
-              "browser_version": "75",
-              "os_version": "1903",
-              "date": "2019-06-28",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -511,10 +395,6 @@
               ]
             },
             "edge": {
-              "at_version": "2019.1.1",
-              "browser_version": "44.17763",
-              "os_version": "1903",
-              "date": "2019-06-28",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -526,10 +406,6 @@
               ]
             },
             "ie": {
-              "at_version": "2019.1.1",
-              "browser_version": "11",
-              "os_version": "1903",
-              "date": "2019-06-28",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -545,10 +421,6 @@
         "vo_ios": {
           "browsers": {
             "ios_saf": {
-              "at_version": "12.3.1",
-              "browser_version": "12.3.1",
-              "os_version": "12.3.1",
-              "date": "2019-06-28",
               "output": [
                 {
                   "command": "next_item",
@@ -564,10 +436,6 @@
         "vo_macos": {
           "browsers": {
             "safari": {
-              "at_version": "10.14.5",
-              "browser_version": "12.1.1",
-              "os_version": "10.14.5",
-              "date": "2019-06-28",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -589,9 +457,6 @@
         "jaws": {
           "browsers": {
             "firefox": {
-              "at_version": "2019.1906.10",
-              "browser_version": "67",
-              "os_version": "1903",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -600,13 +465,9 @@
                   "output": "\"action button menu\"",
                   "result": "fail"
                 }
-              ],
-              "date": "2019-06-28"
+              ]
             },
             "chrome": {
-              "at_version": "2019.1906.10",
-              "browser_version": "75",
-              "os_version": "1903",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -615,13 +476,9 @@
                   "output": "\"action button menu\"",
                   "result": "fail"
                 }
-              ],
-              "date": "2019-06-28"
+              ]
             },
             "ie": {
-              "at_version": "2019.1906.10",
-              "browser_version": "11",
-              "os_version": "1903",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -630,13 +487,9 @@
                   "output": "\"action button menu\"",
                   "result": "fail"
                 }
-              ],
-              "date": "2019-06-28"
+              ]
             },
             "edge": {
-              "at_version": "2019.1906.10",
-              "browser_version": "44",
-              "os_version": "1903",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -645,18 +498,13 @@
                   "output": "\"action button\"",
                   "result": "fail"
                 }
-              ],
-              "date": "2019-06-28"
+              ]
             }
           }
         },
         "narrator": {
           "browsers": {
             "edge": {
-              "at_version": "1903",
-              "browser_version": "44.17763",
-              "os_version": "1903",
-              "date": "2019-06-28",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -672,10 +520,6 @@
         "nvda": {
           "browsers": {
             "firefox": {
-              "at_version": "2019.1.1",
-              "browser_version": "67",
-              "os_version": "1903",
-              "date": "2019-06-28",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -687,10 +531,6 @@
               ]
             },
             "chrome": {
-              "at_version": "2019.1.1",
-              "browser_version": "75",
-              "os_version": "1903",
-              "date": "2019-06-28",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -702,10 +542,6 @@
               ]
             },
             "edge": {
-              "at_version": "2019.1.1",
-              "browser_version": "44.17763",
-              "os_version": "1903",
-              "date": "2019-06-28",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -717,10 +553,6 @@
               ]
             },
             "ie": {
-              "at_version": "2019.1.1",
-              "browser_version": "11",
-              "os_version": "1903",
-              "date": "2019-06-28",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -736,10 +568,6 @@
         "vo_ios": {
           "browsers": {
             "ios_saf": {
-              "at_version": "12.3.1",
-              "browser_version": "12.3.1",
-              "os_version": "12.3.1",
-              "date": "2019-06-28",
               "output": [
                 {
                   "command": "next_item",
@@ -755,10 +583,6 @@
         "vo_macos": {
           "browsers": {
             "safari": {
-              "at_version": "10.14.5",
-              "browser_version": "12.1.1",
-              "os_version": "10.14.5",
-              "date": "2019-06-28",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -780,9 +604,6 @@
         "jaws": {
           "browsers": {
             "firefox": {
-              "at_version": "2019.1906.10",
-              "browser_version": "67",
-              "os_version": "1903",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -791,13 +612,9 @@
                   "output": "\"action button menu\"",
                   "result": "pass"
                 }
-              ],
-              "date": "2019-06-28"
+              ]
             },
             "chrome": {
-              "at_version": "2019.1906.10",
-              "browser_version": "75",
-              "os_version": "1903",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -806,13 +623,9 @@
                   "output": "\"action button menu\"",
                   "result": "pass"
                 }
-              ],
-              "date": "2019-06-28"
+              ]
             },
             "ie": {
-              "at_version": "2019.1906.10",
-              "browser_version": "11",
-              "os_version": "1903",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -821,13 +634,9 @@
                   "output": "\"action button menu\"",
                   "result": "pass"
                 }
-              ],
-              "date": "2019-06-28"
+              ]
             },
             "edge": {
-              "at_version": "2019.1906.10",
-              "browser_version": "44",
-              "os_version": "1903",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -836,18 +645,13 @@
                   "output": "\"action button\"",
                   "result": "fail"
                 }
-              ],
-              "date": "2019-06-28"
+              ]
             }
           }
         },
         "narrator": {
           "browsers": {
             "edge": {
-              "at_version": "1903",
-              "browser_version": "44.17763",
-              "os_version": "1903",
-              "date": "2019-06-28",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -863,10 +667,6 @@
         "nvda": {
           "browsers": {
             "firefox": {
-              "at_version": "2019.1.1",
-              "browser_version": "67",
-              "os_version": "1903",
-              "date": "2019-06-28",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -878,10 +678,6 @@
               ]
             },
             "chrome": {
-              "at_version": "2019.1.1",
-              "browser_version": "75",
-              "os_version": "1903",
-              "date": "2019-06-28",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -893,10 +689,6 @@
               ]
             },
             "edge": {
-              "at_version": "2019.1.1",
-              "browser_version": "44.17763",
-              "os_version": "1903",
-              "date": "2019-06-28",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -908,10 +700,6 @@
               ]
             },
             "ie": {
-              "at_version": "2019.1.1",
-              "browser_version": "11",
-              "os_version": "1903",
-              "date": "2019-06-28",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -927,10 +715,6 @@
         "vo_ios": {
           "browsers": {
             "ios_saf": {
-              "at_version": "12.3.1",
-              "browser_version": "12.3.1",
-              "os_version": "12.3.1",
-              "date": "2019-06-28",
               "output": [
                 {
                   "command": "next_item",
@@ -946,10 +730,6 @@
         "vo_macos": {
           "browsers": {
             "safari": {
-              "at_version": "10.14.5",
-              "browser_version": "12.1.1",
-              "os_version": "10.14.5",
-              "date": "2019-06-28",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -971,9 +751,6 @@
         "jaws": {
           "browsers": {
             "firefox": {
-              "at_version": "2019.1906.10",
-              "browser_version": "67",
-              "os_version": "1903",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -982,13 +759,9 @@
                   "output": "\"action button menu\"",
                   "result": "fail"
                 }
-              ],
-              "date": "2019-06-28"
+              ]
             },
             "chrome": {
-              "at_version": "2019.1906.10",
-              "browser_version": "75",
-              "os_version": "1903",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -997,13 +770,9 @@
                   "output": "\"action button menu\"",
                   "result": "fail"
                 }
-              ],
-              "date": "2019-06-28"
+              ]
             },
             "ie": {
-              "at_version": "2019.1906.10",
-              "browser_version": "11",
-              "os_version": "1903",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -1012,13 +781,9 @@
                   "output": "\"action button menu\"",
                   "result": "fail"
                 }
-              ],
-              "date": "2019-06-28"
+              ]
             },
             "edge": {
-              "at_version": "2019.1906.10",
-              "browser_version": "44",
-              "os_version": "1903",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -1027,18 +792,13 @@
                   "output": "\"action button\"",
                   "result": "fail"
                 }
-              ],
-              "date": "2019-06-28"
+              ]
             }
           }
         },
         "narrator": {
           "browsers": {
             "edge": {
-              "at_version": "1903",
-              "browser_version": "44.17763",
-              "os_version": "1903",
-              "date": "2019-06-28",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -1054,10 +814,6 @@
         "nvda": {
           "browsers": {
             "firefox": {
-              "at_version": "2019.1.1",
-              "browser_version": "67",
-              "os_version": "1903",
-              "date": "2019-06-28",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -1069,10 +825,6 @@
               ]
             },
             "chrome": {
-              "at_version": "2019.1.1",
-              "browser_version": "75",
-              "os_version": "1903",
-              "date": "2019-06-28",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -1084,10 +836,6 @@
               ]
             },
             "edge": {
-              "at_version": "2019.1.1",
-              "browser_version": "44.17763",
-              "os_version": "1903",
-              "date": "2019-06-28",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -1099,10 +847,6 @@
               ]
             },
             "ie": {
-              "at_version": "2019.1.1",
-              "browser_version": "11",
-              "os_version": "1903",
-              "date": "2019-06-28",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -1118,10 +862,6 @@
         "vo_ios": {
           "browsers": {
             "ios_saf": {
-              "at_version": "12.3.1",
-              "browser_version": "12.3.1",
-              "os_version": "12.3.1",
-              "date": "2019-06-28",
               "output": [
                 {
                   "command": "next_item",
@@ -1137,10 +877,6 @@
         "vo_macos": {
           "browsers": {
             "safari": {
-              "at_version": "10.14.5",
-              "browser_version": "12.1.1",
-              "os_version": "10.14.5",
-              "date": "2019-06-28",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -1162,9 +898,6 @@
         "jaws": {
           "browsers": {
             "firefox": {
-              "at_version": "2019.1906.10",
-              "browser_version": "67",
-              "os_version": "1903",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -1173,13 +906,9 @@
                   "output": "\"action button menu\"",
                   "result": "pass"
                 }
-              ],
-              "date": "2019-06-28"
+              ]
             },
             "chrome": {
-              "at_version": "2019.1906.10",
-              "browser_version": "75",
-              "os_version": "1903",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -1188,13 +917,9 @@
                   "output": "\"action button menu\"",
                   "result": "pass"
                 }
-              ],
-              "date": "2019-06-28"
+              ]
             },
             "ie": {
-              "at_version": "2019.1906.10",
-              "browser_version": "11",
-              "os_version": "1903",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -1203,13 +928,9 @@
                   "output": "\"action button menu\"",
                   "result": "pass"
                 }
-              ],
-              "date": "2019-06-28"
+              ]
             },
             "edge": {
-              "at_version": "2019.1906.10",
-              "browser_version": "44",
-              "os_version": "1903",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -1218,18 +939,13 @@
                   "output": "\"action button\"",
                   "result": "fail"
                 }
-              ],
-              "date": "2019-06-28"
+              ]
             }
           }
         },
         "narrator": {
           "browsers": {
             "edge": {
-              "at_version": "1903",
-              "browser_version": "44.17763",
-              "os_version": "1903",
-              "date": "2019-06-28",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -1245,10 +961,6 @@
         "nvda": {
           "browsers": {
             "firefox": {
-              "at_version": "2019.1.1",
-              "browser_version": "67",
-              "os_version": "1903",
-              "date": "2019-06-28",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -1260,10 +972,6 @@
               ]
             },
             "chrome": {
-              "at_version": "2019.1.1",
-              "browser_version": "75",
-              "os_version": "1903",
-              "date": "2019-06-28",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -1275,10 +983,6 @@
               ]
             },
             "edge": {
-              "at_version": "2019.1.1",
-              "browser_version": "44.17763",
-              "os_version": "1903",
-              "date": "2019-06-28",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -1290,10 +994,6 @@
               ]
             },
             "ie": {
-              "at_version": "2019.1.1",
-              "browser_version": "11",
-              "os_version": "1903",
-              "date": "2019-06-28",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -1309,10 +1009,6 @@
         "vo_ios": {
           "browsers": {
             "ios_saf": {
-              "at_version": "12.3.1",
-              "browser_version": "12.3.1",
-              "os_version": "12.3.1",
-              "date": "2019-06-28",
               "output": [
                 {
                   "command": "next_item",
@@ -1328,10 +1024,6 @@
         "vo_macos": {
           "browsers": {
             "safari": {
-              "at_version": "10.14.5",
-              "browser_version": "12.1.1",
-              "os_version": "10.14.5",
-              "date": "2019-06-28",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -1346,6 +1038,93 @@
         }
       }
     }
-
-  ]
+  ],
+  "versions": {
+    "jaws": {
+      "browsers": {
+        "chrome": {
+          "at_version": "2019.1906.10",
+          "browser_version": "75",
+          "os_version": "1903",
+          "date": "2019-06-28"
+        },
+        "ie": {
+          "at_version": "2019.1906.10",
+          "browser_version": "11",
+          "os_version": "1903",
+          "date": "2019-06-28"
+        },
+        "firefox": {
+          "at_version": "2019.1906.10",
+          "browser_version": "67",
+          "os_version": "1903",
+          "date": "2019-06-28"
+        },
+        "edge": {
+          "at_version": "2019.1906.10",
+          "browser_version": "44",
+          "os_version": "1903",
+          "date": "2019-06-28"
+        }
+      }
+    },
+    "narrator": {
+      "browsers": {
+        "edge": {
+          "at_version": "1903",
+          "browser_version": "44.17763",
+          "os_version": "1903",
+          "date": "2019-06-28"
+        }
+      }
+    },
+    "nvda": {
+      "browsers": {
+        "chrome": {
+          "at_version": "2019.1.1",
+          "browser_version": "75",
+          "os_version": "1903",
+          "date": "2019-06-28"
+        },
+        "firefox": {
+          "at_version": "2019.1.1",
+          "browser_version": "67",
+          "os_version": "1903",
+          "date": "2019-06-28"
+        },
+        "ie": {
+          "at_version": "2019.1.1",
+          "browser_version": "11",
+          "os_version": "1903",
+          "date": "2019-06-28"
+        },
+        "edge": {
+          "at_version": "2019.1.1",
+          "browser_version": "44.17763",
+          "os_version": "1903",
+          "date": "2019-06-28"
+        }
+      }
+    },
+    "vo_ios": {
+      "browsers": {
+        "ios_saf": {
+          "at_version": "12.3.1",
+          "browser_version": "12.3.1",
+          "os_version": "12.3.1",
+          "date": "2019-06-28"
+        }
+      }
+    },
+    "vo_macos": {
+      "browsers": {
+        "safari": {
+          "at_version": "10.14.5",
+          "browser_version": "12.1.1",
+          "os_version": "10.14.5",
+          "date": "2019-06-28"
+        }
+      }
+    }
+  }
 }

--- a/data/tests/tech/aria/role_button_name_from_inner.json
+++ b/data/tests/tech/aria/role_button_name_from_inner.json
@@ -11,10 +11,6 @@
         "dragon_win": {
           "browsers": {
             "ie": {
-              "at_version": "15.30",
-              "browser_version": "11.253",
-              "os_version": "1809",
-              "date": "2018-11-15",
               "output": [
                 {
                   "command": "activate_actionable_item",
@@ -38,5 +34,17 @@
       "date": "2019-02-08",
       "message": "Test created"
     }
-  ]
+  ],
+  "versions": {
+    "dragon_win": {
+      "browsers": {
+        "ie": {
+          "at_version": "15.30",
+          "browser_version": "11.253",
+          "os_version": "1809",
+          "date": "2018-11-15"
+        }
+      }
+    }
+  }
 }

--- a/data/tests/tech/aria/role_button_name_from_label.json
+++ b/data/tests/tech/aria/role_button_name_from_label.json
@@ -11,10 +11,6 @@
         "dragon_win": {
           "browsers": {
             "ie": {
-              "at_version": "15.30",
-              "browser_version": "11.253",
-              "os_version": "1809",
-              "date": "2018-11-15",
               "output": [
                 {
                   "command": "activate_actionable_item",
@@ -38,5 +34,17 @@
       "date": "2019-02-08",
       "message": "Test created"
     }
-  ]
+  ],
+  "versions": {
+    "dragon_win": {
+      "browsers": {
+        "ie": {
+          "at_version": "15.30",
+          "browser_version": "11.253",
+          "os_version": "1809",
+          "date": "2018-11-15"
+        }
+      }
+    }
+  }
 }

--- a/data/tests/tech/aria/role_link_name_from_inner.json
+++ b/data/tests/tech/aria/role_link_name_from_inner.json
@@ -11,10 +11,6 @@
         "dragon_win": {
           "browsers": {
             "ie": {
-              "at_version": "15.30",
-              "browser_version": "11.253",
-              "os_version": "1809",
-              "date": "2018-11-15",
               "output": [
                 {
                   "command": "activate_actionable_item",
@@ -38,5 +34,17 @@
       "date": "2019-02-08",
       "message": "Test created"
     }
-  ]
+  ],
+  "versions": {
+    "dragon_win": {
+      "browsers": {
+        "ie": {
+          "at_version": "15.30",
+          "browser_version": "11.253",
+          "os_version": "1809",
+          "date": "2018-11-15"
+        }
+      }
+    }
+  }
 }

--- a/data/tests/tech/aria/role_link_name_from_label.json
+++ b/data/tests/tech/aria/role_link_name_from_label.json
@@ -11,10 +11,6 @@
         "dragon_win": {
           "browsers": {
             "ie": {
-              "at_version": "15.30",
-              "browser_version": "11.253",
-              "os_version": "1809",
-              "date": "2018-11-15",
               "output": [
                 {
                   "command": "activate_actionable_item",
@@ -38,5 +34,17 @@
       "date": "2019-02-08",
       "message": "Test created"
     }
-  ]
+  ],
+  "versions": {
+    "dragon_win": {
+      "browsers": {
+        "ie": {
+          "at_version": "15.30",
+          "browser_version": "11.253",
+          "os_version": "1809",
+          "date": "2018-11-15"
+        }
+      }
+    }
+  }
 }

--- a/data/tests/tech/checkbox-two-state.json
+++ b/data/tests/tech/checkbox-two-state.json
@@ -10,10 +10,6 @@
         "jaws": {
           "browsers": {
             "ie": {
-              "at_version": "2019.1904.60",
-              "browser_version": "11.134",
-              "os_version": "1903",
-              "date": "2019-05-23",
               "output": [
                 {
                   "command": "next_item",
@@ -61,10 +57,6 @@
               "notes": "Pressing the TAB or SHIFT+TAB keys to focus the first (or last) checkbox in the group caused the group label to be announced, but not the group role."
             },
             "firefox": {
-              "at_version": "2019.1904.60",
-              "browser_version": "66",
-              "os_version": "1903",
-              "date": "2019-05-23",
               "output": [
                 {
                   "command": "next_item",
@@ -112,10 +104,6 @@
               "notes": "Pressing the TAB or SHIFT+TAB keys to focus the first (or last) checkbox in the group caused the group label to be announced, but not the group role."
             },
             "chrome": {
-              "at_version": "2019.1904.60",
-              "browser_version": "74",
-              "os_version": "1903",
-              "date": "2019-05-23",
               "output": [
                 {
                   "command": "next_item",
@@ -167,10 +155,6 @@
         "narrator": {
           "browsers": {
             "edge": {
-              "at_version": "1903",
-              "browser_version": "44.17763.1.0",
-              "os_version": "1903",
-              "date": "2019-05-24",
               "output": [
                 {
                   "command": "next_item",
@@ -207,10 +191,6 @@
         "nvda": {
           "browsers": {
             "firefox": {
-              "at_version": "2019.1.1",
-              "browser_version": "67",
-              "os_version": "1903",
-              "date": "2019-05-24",
               "output": [
                 {
                   "command": "next_item",
@@ -243,10 +223,6 @@
               ]
             },
             "chrome": {
-              "at_version": "2019.1.1",
-              "browser_version": "74",
-              "os_version": "1903",
-              "date": "2019-05-24",
               "output": [
                 {
                   "command": "next_item",
@@ -283,10 +259,6 @@
         "vo_macos": {
           "browsers": {
             "safari": {
-              "at_version": "10.14.5",
-              "browser_version": "12.1.1",
-              "os_version": "10.14.5",
-              "date": "2019-05-24",
               "output": [
                 {
                   "command": "next_item",
@@ -323,10 +295,6 @@
         "vo_ios": {
           "browsers": {
             "ios_saf": {
-              "at_version": "12.3",
-              "browser_version": "12.3",
-              "os_version": "12.3",
-              "date": "2019-05-24",
               "output": [
                 {
                   "command": "next_item",
@@ -356,10 +324,6 @@
         "jaws": {
           "browsers": {
             "ie": {
-              "at_version": "2019.1904.60",
-              "browser_version": "11.134",
-              "os_version": "1903",
-              "date": "2019-05-23",
               "output": [
                 {
                   "command": "next_item",
@@ -392,10 +356,6 @@
               ]
             },
             "firefox": {
-              "at_version": "2019.1904.60",
-              "browser_version": "66",
-              "os_version": "1903",
-              "date": "2019-05-23",
               "output": [
                 {
                   "command": "next_item",
@@ -428,10 +388,6 @@
               ]
             },
             "chrome": {
-              "at_version": "2019.1904.60",
-              "browser_version": "74",
-              "os_version": "1903",
-              "date": "2019-05-23",
               "output": [
                 {
                   "command": "next_item",
@@ -468,10 +424,6 @@
         "narrator": {
           "browsers": {
             "edge": {
-              "at_version": "1903",
-              "browser_version": "44.17763.1.0",
-              "os_version": "1903",
-              "date": "2019-05-24",
               "output": [
                 {
                   "command": "next_item",
@@ -508,10 +460,6 @@
         "nvda": {
           "browsers": {
             "firefox": {
-              "at_version": "2019.1.1",
-              "browser_version": "67",
-              "os_version": "1903",
-              "date": "2019-05-24",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -530,10 +478,6 @@
               ]
             },
             "chrome": {
-              "at_version": "2019.1.1",
-              "browser_version": "74",
-              "os_version": "1903",
-              "date": "2019-05-24",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -556,10 +500,6 @@
         "vo_macos": {
           "browsers": {
             "safari": {
-              "at_version": "10.14.5",
-              "browser_version": "12.1.1",
-              "os_version": "10.14.5",
-              "date": "2019-05-24",
               "output": [
                 {
                   "command": "next_item",
@@ -596,10 +536,6 @@
         "vo_ios": {
           "browsers": {
             "ios_saf": {
-              "at_version": "12.3",
-              "browser_version": "12.3",
-              "os_version": "12.3",
-              "date": "2019-05-24",
               "output": [
                 {
                   "command": "next_item",
@@ -629,10 +565,6 @@
         "jaws": {
           "browsers": {
             "ie": {
-              "at_version": "2019.1904.60",
-              "browser_version": "11.134",
-              "os_version": "1903",
-              "date": "2019-05-23",
               "output": [
                 {
                   "command": "next_item",
@@ -679,10 +611,6 @@
               ]
             },
             "firefox": {
-              "at_version": "2019.1904.60",
-              "browser_version": "66",
-              "os_version": "1903",
-              "date": "2019-05-23",
               "output": [
                 {
                   "command": "next_item",
@@ -729,10 +657,6 @@
               ]
             },
             "chrome": {
-              "at_version": "2019.1904.60",
-              "browser_version": "74",
-              "os_version": "1903",
-              "date": "2019-05-23",
               "output": [
                 {
                   "command": "next_item",
@@ -783,10 +707,6 @@
         "narrator": {
           "browsers": {
             "edge": {
-              "at_version": "1903",
-              "browser_version": "44.17763.1.0",
-              "os_version": "1903",
-              "date": "2019-05-24",
               "output": [
                 {
                   "command": "next_item",
@@ -844,10 +764,6 @@
         "nvda": {
           "browsers": {
             "firefox": {
-              "at_version": "2019.1.1",
-              "browser_version": "67",
-              "os_version": "1903",
-              "date": "2019-05-24",
               "output": [
                 {
                   "command": "next_item",
@@ -894,10 +810,6 @@
               ]
             },
             "chrome": {
-              "at_version": "2019.1.1",
-              "browser_version": "74",
-              "os_version": "1903",
-              "date": "2019-05-24",
               "output": [
                 {
                   "command": "next_item",
@@ -948,10 +860,6 @@
         "vo_macos": {
           "browsers": {
             "safari": {
-              "at_version": "10.14.5",
-              "browser_version": "12.1.1",
-              "os_version": "10.14.5",
-              "date": "2019-05-24",
               "output": [
                 {
                   "command": "next_item",
@@ -1002,10 +910,6 @@
         "vo_ios": {
           "browsers": {
             "ios_saf": {
-              "at_version": "12.3",
-              "browser_version": "12.3",
-              "os_version": "12.3",
-              "date": "2019-05-24",
               "output": [
                 {
                   "command": "next_item",
@@ -1035,10 +939,6 @@
         "jaws": {
           "browsers": {
             "ie": {
-              "at_version": "2019.1904.60",
-              "browser_version": "11.134",
-              "os_version": "1903",
-              "date": "2019-05-23",
               "output": [
                 {
                   "command": "next_item",
@@ -1072,10 +972,6 @@
               "notes": "Pressing the TAB or SHIFT+TAB keys to focus the first (or last) checkbox in the group caused the group label to be announced"
             },
             "firefox": {
-              "at_version": "2019.1904.60",
-              "browser_version": "66",
-              "os_version": "1903",
-              "date": "2019-05-23",
               "output": [
                 {
                   "command": "next_item",
@@ -1109,10 +1005,6 @@
               "notes": "Pressing the TAB or SHIFT+TAB keys to focus the first (or last) checkbox in the group caused the group label to be announced"
             },
             "chrome": {
-              "at_version": "2019.1904.60",
-              "browser_version": "74",
-              "os_version": "1903",
-              "date": "2019-05-23",
               "output": [
                 {
                   "command": "next_item",
@@ -1150,10 +1042,6 @@
         "narrator": {
           "browsers": {
             "edge": {
-              "at_version": "1903",
-              "browser_version": "44.17763.1.0",
-              "os_version": "1903",
-              "date": "2019-05-24",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -1176,10 +1064,6 @@
         "nvda": {
           "browsers": {
             "firefox": {
-              "at_version": "2019.1.1",
-              "browser_version": "67",
-              "os_version": "1903",
-              "date": "2019-05-24",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -1198,10 +1082,6 @@
               ]
             },
             "chrome": {
-              "at_version": "2019.1.1",
-              "browser_version": "74",
-              "os_version": "1903",
-              "date": "2019-05-24",
               "output": [
                 {
                   "command": "next_focusable_item",
@@ -1224,10 +1104,6 @@
         "vo_macos": {
           "browsers": {
             "safari": {
-              "at_version": "10.14.5",
-              "browser_version": "12.1.1",
-              "os_version": "10.14.5",
-              "date": "2019-05-24",
               "output": [
                 {
                   "command": "next_item",
@@ -1278,10 +1154,6 @@
         "vo_ios": {
           "browsers": {
             "ios_saf": {
-              "at_version": "12.3",
-              "browser_version": "12.3",
-              "os_version": "12.3",
-              "date": "2019-05-24",
               "output": [
                 {
                   "command": "next_item",
@@ -1311,10 +1183,6 @@
         "jaws": {
           "browsers": {
             "ie": {
-              "at_version": "2019.1904.60",
-              "browser_version": "11.134",
-              "os_version": "1903",
-              "date": "2019-05-23",
               "output": [
                 {
                   "command": "next_item",
@@ -1347,10 +1215,6 @@
               ]
             },
             "firefox": {
-              "at_version": "2019.1904.60",
-              "browser_version": "66",
-              "os_version": "1903",
-              "date": "2019-05-23",
               "output": [
                 {
                   "command": "next_item",
@@ -1383,10 +1247,6 @@
               ]
             },
             "chrome": {
-              "at_version": "2019.1904.60",
-              "browser_version": "74",
-              "os_version": "1903",
-              "date": "2019-05-23",
               "output": [
                 {
                   "command": "next_item",
@@ -1423,10 +1283,6 @@
         "narrator": {
           "browsers": {
             "edge": {
-              "at_version": "1903",
-              "browser_version": "44.17763.1.0",
-              "os_version": "1903",
-              "date": "2019-05-24",
               "output": [
                 {
                   "command": "next_item",
@@ -1463,10 +1319,6 @@
         "nvda": {
           "browsers": {
             "firefox": {
-              "at_version": "2019.1.1",
-              "browser_version": "67",
-              "os_version": "1903",
-              "date": "2019-05-24",
               "output": [
                 {
                   "command": "next_item",
@@ -1499,10 +1351,6 @@
               ]
             },
             "chrome": {
-              "at_version": "2019.1.1",
-              "browser_version": "74",
-              "os_version": "1903",
-              "date": "2019-05-24",
               "output": [
                 {
                   "command": "next_item",
@@ -1539,10 +1387,6 @@
         "vo_macos": {
           "browsers": {
             "safari": {
-              "at_version": "10.14.5",
-              "browser_version": "12.1.1",
-              "os_version": "10.14.5",
-              "date": "2019-05-24",
               "output": [
                 {
                   "command": "next_item",
@@ -1579,10 +1423,6 @@
         "vo_ios": {
           "browsers": {
             "ios_saf": {
-              "at_version": "12.3",
-              "browser_version": "12.3",
-              "os_version": "12.3",
-              "date": "2019-05-24",
               "output": [
                 {
                   "command": "next_item",
@@ -1612,10 +1452,6 @@
         "jaws": {
           "browsers": {
             "ie": {
-              "at_version": "2019.1904.60",
-              "browser_version": "11.134",
-              "os_version": "1903",
-              "date": "2019-05-23",
               "output": [
                 {
                   "command": "next_item",
@@ -1648,10 +1484,6 @@
               ]
             },
             "firefox": {
-              "at_version": "2019.1904.60",
-              "browser_version": "66",
-              "os_version": "1903",
-              "date": "2019-05-23",
               "output": [
                 {
                   "command": "next_item",
@@ -1684,10 +1516,6 @@
               ]
             },
             "chrome": {
-              "at_version": "2019.1904.60",
-              "browser_version": "74",
-              "os_version": "1903",
-              "date": "2019-05-23",
               "output": [
                 {
                   "command": "next_item",
@@ -1724,10 +1552,6 @@
         "narrator": {
           "browsers": {
             "edge": {
-              "at_version": "1903",
-              "browser_version": "44.17763.1.0",
-              "os_version": "1903",
-              "date": "2019-05-24",
               "output": [
                 {
                   "command": "next_item",
@@ -1764,10 +1588,6 @@
         "nvda": {
           "browsers": {
             "firefox": {
-              "at_version": "2019.1.1",
-              "browser_version": "67",
-              "os_version": "1903",
-              "date": "2019-05-24",
               "output": [
                 {
                   "command": "next_item",
@@ -1800,10 +1620,6 @@
               ]
             },
             "chrome": {
-              "at_version": "2019.1.1",
-              "browser_version": "74",
-              "os_version": "1903",
-              "date": "2019-05-24",
               "output": [
                 {
                   "command": "next_item",
@@ -1840,10 +1656,6 @@
         "vo_macos": {
           "browsers": {
             "safari": {
-              "at_version": "10.14.5",
-              "browser_version": "12.1.1",
-              "os_version": "10.14.5",
-              "date": "2019-05-24",
               "output": [
                 {
                   "command": "next_item",
@@ -1880,10 +1692,6 @@
         "vo_ios": {
           "browsers": {
             "ios_saf": {
-              "at_version": "12.3",
-              "browser_version": "12.3",
-              "os_version": "12.3",
-              "date": "2019-05-24",
               "output": [
                 {
                   "command": "next_item",
@@ -1913,10 +1721,6 @@
         "jaws": {
           "browsers": {
             "ie": {
-              "at_version": "2019.1904.60",
-              "browser_version": "11.134",
-              "os_version": "1903",
-              "date": "2019-05-23",
               "output": [
                 {
                   "command": "next_item",
@@ -1949,10 +1753,6 @@
               ]
             },
             "firefox": {
-              "at_version": "2019.1904.60",
-              "browser_version": "66",
-              "os_version": "1903",
-              "date": "2019-05-23",
               "output": [
                 {
                   "command": "next_item",
@@ -1985,10 +1785,6 @@
               ]
             },
             "chrome": {
-              "at_version": "2019.1904.60",
-              "browser_version": "74",
-              "os_version": "1903",
-              "date": "2019-05-23",
               "output": [
                 {
                   "command": "next_item",
@@ -2025,10 +1821,6 @@
         "narrator": {
           "browsers": {
             "edge": {
-              "at_version": "1903",
-              "browser_version": "44.17763.1.0",
-              "os_version": "1903",
-              "date": "2019-05-24",
               "output": [
                 {
                   "command": "next_item",
@@ -2065,10 +1857,6 @@
         "nvda": {
           "browsers": {
             "firefox": {
-              "at_version": "2019.1.1",
-              "browser_version": "67",
-              "os_version": "1903",
-              "date": "2019-05-24",
               "output": [
                 {
                   "command": "next_item",
@@ -2101,10 +1889,6 @@
               ]
             },
             "chrome": {
-              "at_version": "2019.1.1",
-              "browser_version": "74",
-              "os_version": "1903",
-              "date": "2019-05-24",
               "output": [
                 {
                   "command": "next_item",
@@ -2141,10 +1925,6 @@
         "vo_macos": {
           "browsers": {
             "safari": {
-              "at_version": "10.14.5",
-              "browser_version": "12.1.1",
-              "os_version": "10.14.5",
-              "date": "2019-05-24",
               "output": [
                 {
                   "command": "next_item",
@@ -2181,10 +1961,6 @@
         "vo_ios": {
           "browsers": {
             "ios_saf": {
-              "at_version": "12.3",
-              "browser_version": "12.3",
-              "os_version": "12.3",
-              "date": "2019-05-24",
               "output": [
                 {
                   "command": "next_item",
@@ -2214,10 +1990,6 @@
         "jaws": {
           "browsers": {
             "ie": {
-              "at_version": "2019.1904.60",
-              "browser_version": "11.134",
-              "os_version": "1903",
-              "date": "2019-05-23",
               "output": [
                 {
                   "command": "next_item",
@@ -2250,10 +2022,6 @@
               ]
             },
             "firefox": {
-              "at_version": "2019.1904.60",
-              "browser_version": "66",
-              "os_version": "1903",
-              "date": "2019-05-23",
               "output": [
                 {
                   "command": "next_item",
@@ -2286,10 +2054,6 @@
               ]
             },
             "chrome": {
-              "at_version": "2019.1904.60",
-              "browser_version": "74",
-              "os_version": "1903",
-              "date": "2019-05-23",
               "output": [
                 {
                   "command": "next_item",
@@ -2326,10 +2090,6 @@
         "narrator": {
           "browsers": {
             "edge": {
-              "at_version": "1903",
-              "browser_version": "44.17763.1.0",
-              "os_version": "1903",
-              "date": "2019-05-24",
               "output": [
                 {
                   "command": "next_item",
@@ -2366,10 +2126,6 @@
         "nvda": {
           "browsers": {
             "firefox": {
-              "at_version": "2019.1.1",
-              "browser_version": "67",
-              "os_version": "1903",
-              "date": "2019-05-24",
               "output": [
                 {
                   "command": "next_item",
@@ -2402,10 +2158,6 @@
               ]
             },
             "chrome": {
-              "at_version": "2019.1.1",
-              "browser_version": "74",
-              "os_version": "1903",
-              "date": "2019-05-24",
               "output": [
                 {
                   "command": "next_item",
@@ -2442,10 +2194,6 @@
         "vo_macos": {
           "browsers": {
             "safari": {
-              "at_version": "10.14.5",
-              "browser_version": "12.1.1",
-              "os_version": "10.14.5",
-              "date": "2019-05-24",
               "output": [
                 {
                   "command": "next_item",
@@ -2482,10 +2230,6 @@
         "vo_ios": {
           "browsers": {
             "ios_saf": {
-              "at_version": "12.3",
-              "browser_version": "12.3",
-              "os_version": "12.3",
-              "date": "2019-05-24",
               "output": [
                 {
                   "command": "next_item",
@@ -2515,10 +2259,6 @@
         "jaws": {
           "browsers": {
             "ie": {
-              "at_version": "2019.1904.60",
-              "browser_version": "11.134",
-              "os_version": "1903",
-              "date": "2019-05-23",
               "output": [
                 {
                   "command": "activate_form_control",
@@ -2537,10 +2277,6 @@
               ]
             },
             "firefox": {
-              "at_version": "2019.1904.60",
-              "browser_version": "66",
-              "os_version": "1903",
-              "date": "2019-05-23",
               "output": [
                 {
                   "command": "activate_form_control",
@@ -2559,10 +2295,6 @@
               ]
             },
             "chrome": {
-              "at_version": "2019.1904.60",
-              "browser_version": "74",
-              "os_version": "1903",
-              "date": "2019-05-23",
               "output": [
                 {
                   "command": "activate_form_control",
@@ -2585,10 +2317,6 @@
         "narrator": {
           "browsers": {
             "edge": {
-              "at_version": "1903",
-              "browser_version": "44.17763.1.0",
-              "os_version": "1903",
-              "date": "2019-05-24",
               "output": [
                 {
                   "command": "activate_form_control",
@@ -2611,10 +2339,6 @@
         "nvda": {
           "browsers": {
             "firefox": {
-              "at_version": "2019.1.1",
-              "browser_version": "67",
-              "os_version": "1903",
-              "date": "2019-05-24",
               "output": [
                 {
                   "command": "activate_form_control",
@@ -2633,10 +2357,6 @@
               ]
             },
             "chrome": {
-              "at_version": "2019.1.1",
-              "browser_version": "74",
-              "os_version": "1903",
-              "date": "2019-05-24",
               "output": [
                 {
                   "command": "activate_form_control",
@@ -2659,10 +2379,6 @@
         "vo_macos": {
           "browsers": {
             "safari": {
-              "at_version": "10.14.5",
-              "browser_version": "12.1.1",
-              "os_version": "10.14.5",
-              "date": "2019-05-24",
               "output": [
                 {
                   "command": "activate_form_control",
@@ -2685,10 +2401,6 @@
         "vo_ios": {
           "browsers": {
             "ios_saf": {
-              "at_version": "12.3",
-              "browser_version": "12.3",
-              "os_version": "12.3",
-              "date": "2019-05-24",
               "output": [
                 {
                   "command": "activate_form_control",
@@ -2718,10 +2430,6 @@
         "jaws": {
           "browsers": {
             "ie": {
-              "at_version": "2019.1904.60",
-              "browser_version": "11.134",
-              "os_version": "1903",
-              "date": "2019-05-27",
               "output": [
                 {
                   "command": "next_item",
@@ -2754,10 +2462,6 @@
               ]
             },
             "firefox": {
-              "at_version": "2019.1904.60",
-              "browser_version": "66",
-              "os_version": "1903",
-              "date": "2019-05-27",
               "output": [
                 {
                   "command": "next_item",
@@ -2790,10 +2494,6 @@
               ]
             },
             "chrome": {
-              "at_version": "2019.1904.60",
-              "browser_version": "74",
-              "os_version": "1903",
-              "date": "2019-05-27",
               "output": [
                 {
                   "command": "next_item",
@@ -2830,15 +2530,11 @@
         "narrator": {
           "browsers": {
             "edge": {
-              "at_version": "1903",
-              "browser_version": "44.17763.1.0",
-              "os_version": "1903",
-              "date": "2019-05-24",
               "output": [
                 {
                   "command": "next_item",
                   "from": "before target",
-                  "to": "Within target",
+                  "to": "within target",
                   "output": "\"1 of 4, level 2\"",
                   "result": "pass"
                 },
@@ -2857,10 +2553,6 @@
         "nvda": {
           "browsers": {
             "firefox": {
-              "at_version": "2019.1.1",
-              "browser_version": "67",
-              "os_version": "1903",
-              "date": "2019-05-24",
               "output": [
                 {
                   "command": "next_item",
@@ -2893,10 +2585,6 @@
               ]
             },
             "chrome": {
-              "at_version": "2019.1.1",
-              "browser_version": "74",
-              "os_version": "1903",
-              "date": "2019-05-24",
               "output": [
                 {
                   "command": "next_item",
@@ -2933,10 +2621,6 @@
         "vo_macos": {
           "browsers": {
             "safari": {
-              "at_version": "10.14.5",
-              "browser_version": "12.1.1",
-              "os_version": "10.14.5",
-              "date": "2019-05-24",
               "output": [
                 {
                   "command": "next_item",
@@ -2973,10 +2657,6 @@
         "vo_ios": {
           "browsers": {
             "ios_saf": {
-              "at_version": "12.3",
-              "browser_version": "12.3",
-              "os_version": "12.3",
-              "date": "2019-05-24",
               "output": [
                 {
                   "command": "next_item",
@@ -3006,10 +2686,6 @@
         "jaws": {
           "browsers": {
             "ie": {
-              "at_version": "2019.1904.60",
-              "browser_version": "11.134",
-              "os_version": "1903",
-              "date": "2019-05-27",
               "output": [
                 {
                   "command": "next_item",
@@ -3056,10 +2732,6 @@
               ]
             },
             "firefox": {
-              "at_version": "2019.1904.60",
-              "browser_version": "66",
-              "os_version": "1903",
-              "date": "2019-05-27",
               "output": [
                 {
                   "command": "next_item",
@@ -3106,10 +2778,6 @@
               ]
             },
             "chrome": {
-              "at_version": "2019.1904.60",
-              "browser_version": "74",
-              "os_version": "1903",
-              "date": "2019-05-27",
               "output": [
                 {
                   "command": "next_item",
@@ -3160,15 +2828,11 @@
         "narrator": {
           "browsers": {
             "edge": {
-              "at_version": "1903",
-              "browser_version": "44.17763.1.0",
-              "os_version": "1903",
-              "date": "2019-05-24",
               "output": [
                 {
                   "command": "next_item",
                   "from": "before target",
-                  "to": "Within target",
+                  "to": "within target",
                   "output": "\"1 of 4, level 2\"",
                   "result": "pass"
                 },
@@ -3201,10 +2865,6 @@
         "nvda": {
           "browsers": {
             "firefox": {
-              "at_version": "2019.1.1",
-              "browser_version": "67",
-              "os_version": "1903",
-              "date": "2019-05-24",
               "output": [
                 {
                   "command": "next_item",
@@ -3216,7 +2876,7 @@
                 {
                   "command": "next_item",
                   "from": "within target",
-                  "to": "after of target",
+                  "to": "after target",
                   "output": "\"Out of list. Heading level 2. Keyboard support.",
                   "result": "pass"
                 },
@@ -3258,10 +2918,6 @@
               ]
             },
             "chrome": {
-              "at_version": "2019.1.1",
-              "browser_version": "74",
-              "os_version": "1903",
-              "date": "2019-05-24",
               "output": [
                 {
                   "command": "next_item",
@@ -3273,7 +2929,7 @@
                 {
                   "command": "next_item",
                   "from": "within target",
-                  "to": "after of target",
+                  "to": "after target",
                   "output": "\"Out of list. Heading level 2. Keyboard support.",
                   "result": "pass"
                 },
@@ -3319,10 +2975,6 @@
         "vo_macos": {
           "browsers": {
             "safari": {
-              "at_version": "10.14.5",
-              "browser_version": "12.1.1",
-              "os_version": "10.14.5",
-              "date": "2019-05-24",
               "output": [
                 {
                   "command": "next_item",
@@ -3359,10 +3011,6 @@
         "vo_ios": {
           "browsers": {
             "ios_saf": {
-              "at_version": "12.3",
-              "browser_version": "12.3",
-              "os_version": "12.3",
-              "date": "2019-05-24",
               "output": [
                 {
                   "command": "next_item",
@@ -3392,10 +3040,6 @@
         "jaws": {
           "browsers": {
             "ie": {
-              "at_version": "2019.1904.60",
-              "browser_version": "11.134",
-              "os_version": "1903",
-              "date": "2019-05-27",
               "output": [
                 {
                   "command": "next_item",
@@ -3428,10 +3072,6 @@
               ]
             },
             "firefox": {
-              "at_version": "2019.1904.60",
-              "browser_version": "66",
-              "os_version": "1903",
-              "date": "2019-05-27",
               "output": [
                 {
                   "command": "next_item",
@@ -3464,10 +3104,6 @@
               ]
             },
             "chrome": {
-              "at_version": "2019.1904.60",
-              "browser_version": "74",
-              "os_version": "1903",
-              "date": "2019-05-27",
               "output": [
                 {
                   "command": "next_item",
@@ -3504,15 +3140,11 @@
         "narrator": {
           "browsers": {
             "edge": {
-              "at_version": "1903",
-              "browser_version": "44.17763.1.0",
-              "os_version": "1903",
-              "date": "2019-05-24",
               "output": [
                 {
                   "command": "next_item",
                   "from": "before target",
-                  "to": "Within target",
+                  "to": "within target",
                   "output": "\"1 of 4, level 2\"",
                   "result": "pass"
                 },
@@ -3530,15 +3162,11 @@
         "nvda": {
           "browsers": {
             "firefox": {
-              "at_version": "2019.1.1",
-              "browser_version": "67",
-              "os_version": "1903",
-              "date": "2019-05-24",
               "output": [
                 {
                   "command": "next_item",
                   "from": "before target",
-                  "to": "Within target",
+                  "to": "within target",
                   "output": "\"Sandwich Condiments grouping. list  with 4 items. check box  not checked. Lettuce\"",
                   "result": "pass"
                 },
@@ -3552,15 +3180,11 @@
               ]
             },
             "chrome": {
-              "at_version": "2019.1.1",
-              "browser_version": "74",
-              "os_version": "1903",
-              "date": "2019-05-24",
               "output": [
                 {
                   "command": "next_item",
                   "from": "before target",
-                  "to": "Within target",
+                  "to": "within target",
                   "output": "\"Sandwich Condiments grouping. list  with 4 items. check box  not checked. Lettuce\"",
                   "result": "pass"
                 },
@@ -3578,10 +3202,6 @@
         "vo_macos": {
           "browsers": {
             "safari": {
-              "at_version": "10.14.5",
-              "browser_version": "12.1.1",
-              "os_version": "10.14.5",
-              "date": "2019-05-24",
               "output": [
                 {
                   "command": "next_item",
@@ -3618,10 +3238,6 @@
         "vo_ios": {
           "browsers": {
             "ios_saf": {
-              "at_version": "12.3",
-              "browser_version": "12.3",
-              "os_version": "12.3",
-              "date": "2019-05-24",
               "output": [
                 {
                   "command": "next_item",
@@ -3651,10 +3267,6 @@
         "jaws": {
           "browsers": {
             "ie": {
-              "at_version": "2019.1904.60",
-              "browser_version": "11.134",
-              "os_version": "1903",
-              "date": "2019-05-27",
               "output": [
                 {
                   "command": "next_item",
@@ -3687,10 +3299,6 @@
               ]
             },
             "firefox": {
-              "at_version": "2019.1904.60",
-              "browser_version": "66",
-              "os_version": "1903",
-              "date": "2019-05-27",
               "output": [
                 {
                   "command": "next_item",
@@ -3723,10 +3331,6 @@
               ]
             },
             "chrome": {
-              "at_version": "2019.1904.60",
-              "browser_version": "74",
-              "os_version": "1903",
-              "date": "2019-05-27",
               "output": [
                 {
                   "command": "next_item",
@@ -3763,10 +3367,6 @@
         "narrator": {
           "browsers": {
             "edge": {
-              "at_version": "1903",
-              "browser_version": "44.17763.1.0",
-              "os_version": "1903",
-              "date": "2019-05-24",
               "output": [
                 {
                   "command": "next_item",
@@ -3811,10 +3411,6 @@
         "nvda": {
           "browsers": {
             "firefox": {
-              "at_version": "2019.1.1",
-              "browser_version": "67",
-              "os_version": "1903",
-              "date": "2019-05-24",
               "output": [
                 {
                   "command": "next_item",
@@ -3855,10 +3451,6 @@
               "notes": "List item role implied when first entering the list due to list semantics being conveyed. However, once navigating items within the list, the list item role is not conveyed."
             },
             "chrome": {
-              "at_version": "2019.1.1",
-              "browser_version": "74",
-              "os_version": "1903",
-              "date": "2019-05-24",
               "output": [
                 {
                   "command": "next_item",
@@ -3902,10 +3494,6 @@
         "vo_macos": {
           "browsers": {
             "safari": {
-              "at_version": "10.14.5",
-              "browser_version": "12.1.1",
-              "os_version": "10.14.5",
-              "date": "2019-05-24",
               "output": [
                 {
                   "command": "next_item",
@@ -3942,10 +3530,6 @@
         "vo_ios": {
           "browsers": {
             "ios_saf": {
-              "at_version": "12.3",
-              "browser_version": "12.3",
-              "os_version": "12.3",
-              "date": "2019-05-24",
               "output": [
                 {
                   "command": "next_item",
@@ -3975,10 +3559,6 @@
         "jaws": {
           "browsers": {
             "ie": {
-              "at_version": "2019.1904.60",
-              "browser_version": "11.134",
-              "os_version": "1903",
-              "date": "2019-05-27",
               "output": [
                 {
                   "command": "next_item",
@@ -4011,10 +3591,6 @@
               ]
             },
             "firefox": {
-              "at_version": "2019.1904.60",
-              "browser_version": "66",
-              "os_version": "1903",
-              "date": "2019-05-27",
               "output": [
                 {
                   "command": "next_item",
@@ -4047,10 +3623,6 @@
               ]
             },
             "chrome": {
-              "at_version": "2019.1904.60",
-              "browser_version": "74",
-              "os_version": "1903",
-              "date": "2019-05-27",
               "output": [
                 {
                   "command": "next_item",
@@ -4087,10 +3659,6 @@
         "narrator": {
           "browsers": {
             "edge": {
-              "at_version": "1903",
-              "browser_version": "44.17763.1.0",
-              "os_version": "1903",
-              "date": "2019-05-24",
               "output": [
                 {
                   "command": "next_item",
@@ -4134,10 +3702,6 @@
         "nvda": {
           "browsers": {
             "firefox": {
-              "at_version": "2019.1.1",
-              "browser_version": "67",
-              "os_version": "1903",
-              "date": "2019-05-24",
               "output": [
                 {
                   "command": "next_item",
@@ -4178,10 +3742,6 @@
               "notes": "Position in set implied when first entering the list due to list semantics being conveyed for the first time. However, once navigating items within the list, the position in set information is no longer conveyed."
             },
             "chrome": {
-              "at_version": "2019.1.1",
-              "browser_version": "74",
-              "os_version": "1903",
-              "date": "2019-05-24",
               "output": [
                 {
                   "command": "next_item",
@@ -4226,10 +3786,6 @@
         "vo_macos": {
           "browsers": {
             "safari": {
-              "at_version": "10.14.5",
-              "browser_version": "12.1.1",
-              "os_version": "10.14.5",
-              "date": "2019-05-24",
               "output": [
                 {
                   "command": "next_item",
@@ -4266,10 +3822,6 @@
         "vo_ios": {
           "browsers": {
             "ios_saf": {
-              "at_version": "12.3",
-              "browser_version": "12.3",
-              "os_version": "12.3",
-              "date": "2019-05-24",
               "output": [
                 {
                   "command": "next_item",
@@ -4298,5 +3850,75 @@
       "date": "2019-05-24",
       "message": "Test created"
     }
-  ]
+  ],
+  "versions": {
+    "jaws": {
+      "browsers": {
+        "chrome": {
+          "at_version": "2019.1904.60",
+          "browser_version": "74",
+          "os_version": "1903",
+          "date": "2019-05-27"
+        },
+        "ie": {
+          "at_version": "2019.1904.60",
+          "browser_version": "11.134",
+          "os_version": "1903",
+          "date": "2019-05-27"
+        },
+        "firefox": {
+          "at_version": "2019.1904.60",
+          "browser_version": "66",
+          "os_version": "1903",
+          "date": "2019-05-27"
+        }
+      }
+    },
+    "narrator": {
+      "browsers": {
+        "edge": {
+          "at_version": "1903",
+          "browser_version": "44.17763.1.0",
+          "os_version": "1903",
+          "date": "2019-05-24"
+        }
+      }
+    },
+    "nvda": {
+      "browsers": {
+        "chrome": {
+          "at_version": "2019.1.1",
+          "browser_version": "74",
+          "os_version": "1903",
+          "date": "2019-05-24"
+        },
+        "firefox": {
+          "at_version": "2019.1.1",
+          "browser_version": "67",
+          "os_version": "1903",
+          "date": "2019-05-24"
+        }
+      }
+    },
+    "vo_ios": {
+      "browsers": {
+        "ios_saf": {
+          "at_version": "12.3",
+          "browser_version": "12.3",
+          "os_version": "12.3",
+          "date": "2019-05-24"
+        }
+      }
+    },
+    "vo_macos": {
+      "browsers": {
+        "safari": {
+          "at_version": "10.14.5",
+          "browser_version": "12.1.1",
+          "os_version": "10.14.5",
+          "date": "2019-05-24"
+        }
+      }
+    }
+  }
 }

--- a/data/tests/tech/html/dl-basic.json
+++ b/data/tests/tech/html/dl-basic.json
@@ -10,10 +10,6 @@
         "narrator": {
           "browsers": {
             "edge": {
-              "at_version": "1809",
-              "browser_version": "44.17763",
-              "os_version": "1809",
-              "date": "2019-05-02",
               "output": [
                 {
                   "command": "next_item",
@@ -33,10 +29,6 @@
         "nvda": {
           "browsers": {
             "firefox": {
-              "at_version": "2018.3.2",
-              "browser_version": "66",
-              "os_version": "1809",
-              "date": "2019-09-04",
               "output": [
                 {
                   "command": "next_item",
@@ -47,10 +39,6 @@
               "notes": "Conveyed as a list, but not a description list."
             },
             "chrome": {
-              "at_version": "2018.1808.10",
-              "browser_version": "74",
-              "os_version": "1809",
-              "date": "2019-05-02",
               "output": [
                 {
                   "command": "next_item",
@@ -65,10 +53,6 @@
         "jaws": {
           "browsers": {
             "ie": {
-              "at_version": "2018.1811.2",
-              "browser_version": "11.134",
-              "os_version": "1809",
-              "date": "2019-05-02",
               "output": [
                 {
                   "command": "next_item",
@@ -79,10 +63,6 @@
               "notes": ""
             },
             "firefox": {
-              "at_version": "2018.1811.2",
-              "browser_version": "66",
-              "os_version": "1809",
-              "date": "2019-05-02",
               "output": [
                 {
                   "command": "next_item",
@@ -93,10 +73,6 @@
               "notes": ""
             },
             "chrome": {
-              "at_version": "2018.1811.2",
-              "browser_version": "74",
-              "os_version": "1809",
-              "date": "2019-05-02",
               "output": [
                 {
                   "command": "next_item",
@@ -111,10 +87,6 @@
         "vo_macos": {
           "browsers": {
             "safari": {
-              "at_version": "10.14.4",
-              "browser_version": "12.1",
-              "os_version": "10.14.4",
-              "date": "2019-05-01",
               "output": [
                 {
                   "command": "next_item",
@@ -129,10 +101,6 @@
         "vo_ios": {
           "browsers": {
             "ios_saf": {
-              "at_version": "12.2",
-              "browser_version": "12.2",
-              "os_version": "12.2",
-              "date": "2019-05-01",
               "output": [
                 {
                   "command": "next_item",
@@ -154,10 +122,6 @@
         "narrator": {
           "browsers": {
             "edge": {
-              "at_version": "1809",
-              "browser_version": "44.17763",
-              "os_version": "1809",
-              "date": "2019-05-02",
               "output": [
                 {
                   "command": "next_item",
@@ -177,10 +141,6 @@
         "nvda": {
           "browsers": {
             "firefox": {
-              "at_version": "2018.3.2",
-              "browser_version": "66",
-              "os_version": "1809",
-              "date": "2019-09-04",
               "output": [
                 {
                   "command": "next_item",
@@ -191,10 +151,6 @@
               "notes": ""
             },
             "chrome": {
-              "at_version": "2018.1808.10",
-              "browser_version": "74",
-              "os_version": "1809",
-              "date": "2019-05-02",
               "output": [
                 {
                   "command": "next_item",
@@ -209,10 +165,6 @@
         "jaws": {
           "browsers": {
             "ie": {
-              "at_version": "2018.1811.2",
-              "browser_version": "11.134",
-              "os_version": "1809",
-              "date": "2019-05-02",
               "output": [
                 {
                   "command": "next_item",
@@ -223,10 +175,6 @@
               "notes": ""
             },
             "firefox": {
-              "at_version": "2018.1811.2",
-              "browser_version": "66",
-              "os_version": "1809",
-              "date": "2019-05-02",
               "output": [
                 {
                   "command": "next_item",
@@ -237,10 +185,6 @@
               "notes": ""
             },
             "chrome": {
-              "at_version": "2018.1811.2",
-              "browser_version": "74",
-              "os_version": "1809",
-              "date": "2019-05-02",
               "output": [
                 {
                   "command": "next_item",
@@ -255,10 +199,6 @@
         "vo_macos": {
           "browsers": {
             "safari": {
-              "at_version": "10.14.4",
-              "browser_version": "12.1",
-              "os_version": "10.14.4",
-              "date": "2019-05-01",
               "output": [
                 {
                   "command": "next_item",
@@ -273,10 +213,6 @@
         "vo_ios": {
           "browsers": {
             "ios_saf": {
-              "at_version": "12.2",
-              "browser_version": "12.2",
-              "os_version": "12.2",
-              "date": "2019-05-01",
               "output": [
                 {
                   "command": "next_item",
@@ -297,10 +233,6 @@
         "narrator": {
           "browsers": {
             "edge": {
-              "at_version": "1809",
-              "browser_version": "44.17763",
-              "os_version": "1809",
-              "date": "2019-05-02",
               "output": [
                 {
                   "command": "next_item",
@@ -340,10 +272,6 @@
         "nvda": {
           "browsers": {
             "firefox": {
-              "at_version": "2018.3.2",
-              "browser_version": "66",
-              "os_version": "1809",
-              "date": "2019-09-04",
               "output": [
                 {
                   "command": "next_item",
@@ -369,10 +297,6 @@
               "notes": ""
             },
             "chrome": {
-              "at_version": "2018.1808.10",
-              "browser_version": "74",
-              "os_version": "1809",
-              "date": "2019-05-02",
               "output": [
                 {
                   "command": "next_item",
@@ -402,10 +326,6 @@
         "jaws": {
           "browsers": {
             "ie": {
-              "at_version": "2018.1811.2",
-              "browser_version": "11.134",
-              "os_version": "1809",
-              "date": "2019-05-02",
               "output": [
                 {
                   "command": "next_item",
@@ -431,10 +351,6 @@
               "notes": ""
             },
             "firefox": {
-              "at_version": "2018.1811.2",
-              "browser_version": "66",
-              "os_version": "1809",
-              "date": "2019-05-02",
               "output": [
                 {
                   "command": "next_item",
@@ -460,10 +376,6 @@
               "notes": ""
             },
             "chrome": {
-              "at_version": "2018.1811.2",
-              "browser_version": "74",
-              "os_version": "1809",
-              "date": "2019-05-02",
               "output": [
                 {
                   "command": "next_item",
@@ -493,10 +405,6 @@
         "vo_macos": {
           "browsers": {
             "safari": {
-              "at_version": "10.14.4",
-              "browser_version": "12.1",
-              "os_version": "10.14.4",
-              "date": "2019-05-01",
               "output": [
                 {
                   "command": "next_item",
@@ -526,10 +434,6 @@
         "vo_ios": {
           "browsers": {
             "ios_saf": {
-              "at_version": "12.2",
-              "browser_version": "12.2",
-              "os_version": "12.2",
-              "date": "2019-05-01",
               "output": [
                 {
                   "command": "next_item",
@@ -565,10 +469,6 @@
         "narrator": {
           "browsers": {
             "edge": {
-              "at_version": "1809",
-              "browser_version": "44.17763",
-              "os_version": "1809",
-              "date": "2019-05-03",
               "output": [
                 {
                   "command": "next_item",
@@ -583,10 +483,6 @@
         "nvda": {
           "browsers": {
             "firefox": {
-              "at_version": "2018.3.2",
-              "browser_version": "66",
-              "os_version": "1809",
-              "date": "2019-05-02",
               "output": [
                 {
                   "command": "next_item",
@@ -602,10 +498,6 @@
               "notes": ""
             },
             "chrome": {
-              "at_version": "2018.1808.10",
-              "browser_version": "74",
-              "os_version": "1809",
-              "date": "2019-05-02",
               "output": [
                 {
                   "command": "next_item",
@@ -625,10 +517,6 @@
         "jaws": {
           "browsers": {
             "ie": {
-              "at_version": "2018.1811.2",
-              "browser_version": "11.134",
-              "os_version": "1809",
-              "date": "2019-05-02",
               "output": [
                 {
                   "command": "next_item",
@@ -639,10 +527,6 @@
               "notes": ""
             },
             "firefox": {
-              "at_version": "2018.1811.2",
-              "browser_version": "66",
-              "os_version": "1809",
-              "date": "2019-05-02",
               "output": [
                 {
                   "command": "next_item",
@@ -653,10 +537,6 @@
               "notes": ""
             },
             "chrome": {
-              "at_version": "2018.1811.2",
-              "browser_version": "74",
-              "os_version": "1809",
-              "date": "2019-05-02",
               "output": [
                 {
                   "command": "next_item",
@@ -671,10 +551,6 @@
         "vo_macos": {
           "browsers": {
             "safari": {
-              "at_version": "10.14.4",
-              "browser_version": "12.1",
-              "os_version": "10.14.4",
-              "date": "2019-05-01",
               "output": [
                 {
                   "command": "next_item",
@@ -689,10 +565,6 @@
         "vo_ios": {
           "browsers": {
             "ios_saf": {
-              "at_version": "12.2",
-              "browser_version": "12.2",
-              "os_version": "12.2",
-              "date": "2019-05-01",
               "output": [
                 {
                   "command": "next_item",
@@ -713,10 +585,6 @@
         "narrator": {
           "browsers": {
             "edge": {
-              "at_version": "1809",
-              "browser_version": "44.17763",
-              "os_version": "1809",
-              "date": "2019-05-02",
               "output": [
                 {
                   "command": "next_item",
@@ -736,10 +604,6 @@
         "nvda": {
           "browsers": {
             "firefox": {
-              "at_version": "2018.3.2",
-              "browser_version": "66",
-              "os_version": "1809",
-              "date": "2019-09-04",
               "output": [
                 {
                   "command": "next_item",
@@ -755,10 +619,6 @@
               "notes": ""
             },
             "chrome": {
-              "at_version": "2018.1808.10",
-              "browser_version": "74",
-              "os_version": "1809",
-              "date": "2019-05-02",
               "output": [
                 {
                   "command": "next_item",
@@ -778,10 +638,6 @@
         "jaws": {
           "browsers": {
             "ie": {
-              "at_version": "2018.1811.2",
-              "browser_version": "11.134",
-              "os_version": "1809",
-              "date": "2019-05-02",
               "output": [
                 {
                   "command": "next_item",
@@ -792,10 +648,6 @@
               "notes": ""
             },
             "firefox": {
-              "at_version": "2018.1811.2",
-              "browser_version": "66",
-              "os_version": "1809",
-              "date": "2019-05-02",
               "output": [
                 {
                   "command": "next_item",
@@ -806,10 +658,6 @@
               "notes": ""
             },
             "chrome": {
-              "at_version": "2018.1811.2",
-              "browser_version": "74",
-              "os_version": "1809",
-              "date": "2019-05-02",
               "output": [
                 {
                   "command": "next_item",
@@ -824,10 +672,6 @@
         "vo_macos": {
           "browsers": {
             "safari": {
-              "at_version": "10.14.4",
-              "browser_version": "12.1",
-              "os_version": "10.14.4",
-              "date": "2019-05-01",
               "output": [
                 {
                   "command": "next_item",
@@ -842,10 +686,6 @@
         "vo_ios": {
           "browsers": {
             "ios_saf": {
-              "at_version": "12.2",
-              "browser_version": "12.2",
-              "os_version": "12.2",
-              "date": "2019-05-01",
               "output": [
                 {
                   "command": "next_item",
@@ -866,10 +706,6 @@
         "narrator": {
           "browsers": {
             "edge": {
-              "at_version": "1809",
-              "browser_version": "44.17763",
-              "os_version": "1809",
-              "date": "2019-05-02",
               "output": [
                 {
                   "command": "next_item",
@@ -884,10 +720,6 @@
         "nvda": {
           "browsers": {
             "firefox": {
-              "at_version": "2018.3.2",
-              "browser_version": "66",
-              "os_version": "1809",
-              "date": "2019-09-04",
               "output": [
                 {
                   "command": "next_item",
@@ -903,10 +735,6 @@
               "notes": ""
             },
             "chrome": {
-              "at_version": "2018.1808.10",
-              "browser_version": "74",
-              "os_version": "1809",
-              "date": "2019-05-02",
               "output": [
                 {
                   "command": "next_item",
@@ -926,10 +754,6 @@
         "jaws": {
           "browsers": {
             "ie": {
-              "at_version": "2018.1811.2",
-              "browser_version": "11.134",
-              "os_version": "1809",
-              "date": "2019-05-02",
               "output": [
                 {
                   "command": "next_item",
@@ -940,10 +764,6 @@
               "notes": ""
             },
             "firefox": {
-              "at_version": "2018.1811.2",
-              "browser_version": "66",
-              "os_version": "1809",
-              "date": "2019-05-02",
               "output": [
                 {
                   "command": "next_item",
@@ -954,10 +774,6 @@
               "notes": ""
             },
             "chrome": {
-              "at_version": "2018.1811.2",
-              "browser_version": "74",
-              "os_version": "1809",
-              "date": "2019-05-02",
               "output": [
                 {
                   "command": "next_item",
@@ -972,10 +788,6 @@
         "vo_macos": {
           "browsers": {
             "safari": {
-              "at_version": "10.14.4",
-              "browser_version": "12.1",
-              "os_version": "10.14.4",
-              "date": "2019-05-01",
               "output": [
                 {
                   "command": "next_item",
@@ -990,10 +802,6 @@
         "vo_ios": {
           "browsers": {
             "ios_saf": {
-              "at_version": "12.2",
-              "browser_version": "12.2",
-              "os_version": "12.2",
-              "date": "2019-05-01",
               "output": [
                 {
                   "command": "next_item",
@@ -1014,10 +822,6 @@
         "narrator": {
           "browsers": {
             "edge": {
-              "at_version": "1809",
-              "browser_version": "44.17763",
-              "os_version": "1809",
-              "date": "2019-05-02",
               "output": [
                 {
                   "command": "next_item",
@@ -1037,10 +841,6 @@
         "nvda": {
           "browsers": {
             "firefox": {
-              "at_version": "2018.3.2",
-              "browser_version": "66",
-              "os_version": "1809",
-              "date": "2019-09-04",
               "output": [
                 {
                   "command": "next_item",
@@ -1056,10 +856,6 @@
               "notes": ""
             },
             "chrome": {
-              "at_version": "2018.1808.10",
-              "browser_version": "74",
-              "os_version": "1809",
-              "date": "2019-05-02",
               "output": [
                 {
                   "command": "next_item",
@@ -1079,10 +875,6 @@
         "jaws": {
           "browsers": {
             "ie": {
-              "at_version": "2018.1811.2",
-              "browser_version": "11.134",
-              "os_version": "1809",
-              "date": "2019-05-02",
               "output": [
                 {
                   "command": "next_item",
@@ -1093,10 +885,6 @@
               "notes": ""
             },
             "firefox": {
-              "at_version": "2018.1811.2",
-              "browser_version": "66",
-              "os_version": "1809",
-              "date": "2019-05-02",
               "output": [
                 {
                   "command": "next_item",
@@ -1107,10 +895,6 @@
               "notes": ""
             },
             "chrome": {
-              "at_version": "2018.1811.2",
-              "browser_version": "74",
-              "os_version": "1809",
-              "date": "2019-05-02",
               "output": [
                 {
                   "command": "next_item",
@@ -1125,10 +909,6 @@
         "vo_macos": {
           "browsers": {
             "safari": {
-              "at_version": "10.14.4",
-              "browser_version": "12.1",
-              "os_version": "10.14.4",
-              "date": "2019-05-01",
               "output": [
                 {
                   "command": "next_item",
@@ -1143,10 +923,6 @@
         "vo_ios": {
           "browsers": {
             "ios_saf": {
-              "at_version": "12.2",
-              "browser_version": "12.2",
-              "os_version": "12.2",
-              "date": "2019-05-01",
               "output": [
                 {
                   "command": "next_item",
@@ -1166,5 +942,75 @@
       "date": "2019-05-01",
       "message": "Test created"
     }
-  ]
+  ],
+  "versions": {
+    "jaws": {
+      "browsers": {
+        "chrome": {
+          "at_version": "2018.1811.2",
+          "browser_version": "74",
+          "os_version": "1809",
+          "date": "2019-05-02"
+        },
+        "ie": {
+          "at_version": "2018.1811.2",
+          "browser_version": "11.134",
+          "os_version": "1809",
+          "date": "2019-05-02"
+        },
+        "firefox": {
+          "at_version": "2018.1811.2",
+          "browser_version": "66",
+          "os_version": "1809",
+          "date": "2019-05-02"
+        }
+      }
+    },
+    "narrator": {
+      "browsers": {
+        "edge": {
+          "at_version": "1809",
+          "browser_version": "44.17763",
+          "os_version": "1809",
+          "date": "2019-05-02"
+        }
+      }
+    },
+    "nvda": {
+      "browsers": {
+        "chrome": {
+          "at_version": "2018.1808.10",
+          "browser_version": "74",
+          "os_version": "1809",
+          "date": "2019-05-02"
+        },
+        "firefox": {
+          "at_version": "2018.3.2",
+          "browser_version": "66",
+          "os_version": "1809",
+          "date": "2019-09-04"
+        }
+      }
+    },
+    "vo_ios": {
+      "browsers": {
+        "ios_saf": {
+          "at_version": "12.2",
+          "browser_version": "12.2",
+          "os_version": "12.2",
+          "date": "2019-05-01"
+        }
+      }
+    },
+    "vo_macos": {
+      "browsers": {
+        "safari": {
+          "at_version": "10.14.4",
+          "browser_version": "12.1",
+          "os_version": "10.14.4",
+          "date": "2019-05-01"
+        }
+      }
+    }
+  }
 }

--- a/data/tests/tech/html/dl-groups-wrapped.json
+++ b/data/tests/tech/html/dl-groups-wrapped.json
@@ -10,10 +10,6 @@
         "narrator": {
           "browsers": {
             "edge": {
-              "at_version": "1809",
-              "browser_version": "44.17763",
-              "os_version": "1809",
-              "date": "2019-05-04",
               "output": [
                 {
                   "command": "next_item",
@@ -33,10 +29,6 @@
         "nvda": {
           "browsers": {
             "firefox": {
-              "at_version": "2018.3.2",
-              "browser_version": "66",
-              "os_version": "1809",
-              "date": "2019-09-04",
               "output": [
                 {
                   "command": "next_item",
@@ -47,10 +39,6 @@
               "notes": "Conveyed as a list, but not a description list."
             },
             "chrome": {
-              "at_version": "2018.1808.10",
-              "browser_version": "74",
-              "os_version": "1809",
-              "date": "2019-05-04",
               "output": [
                 {
                   "command": "next_item",
@@ -65,10 +53,6 @@
         "jaws": {
           "browsers": {
             "ie": {
-              "at_version": "2018.1811.2",
-              "browser_version": "11.134",
-              "os_version": "1809",
-              "date": "2019-05-04",
               "output": [
                 {
                   "command": "next_item",
@@ -79,10 +63,6 @@
               "notes": ""
             },
             "firefox": {
-              "at_version": "2018.1811.2",
-              "browser_version": "66",
-              "os_version": "1809",
-              "date": "2019-05-04",
               "output": [
                 {
                   "command": "next_item",
@@ -93,10 +73,6 @@
               "notes": ""
             },
             "chrome": {
-              "at_version": "2018.1811.2",
-              "browser_version": "74",
-              "os_version": "1809",
-              "date": "2019-05-04",
               "output": [
                 {
                   "command": "next_item",
@@ -111,10 +87,6 @@
         "vo_macos": {
           "browsers": {
             "safari": {
-              "at_version": "10.14.4",
-              "browser_version": "12.1",
-              "os_version": "10.14.4",
-              "date": "2019-05-01",
               "output": [
                 {
                   "command": "next_item",
@@ -129,10 +101,6 @@
         "vo_ios": {
           "browsers": {
             "ios_saf": {
-              "at_version": "12.2",
-              "browser_version": "12.2",
-              "os_version": "12.2",
-              "date": "2019-05-01",
               "output": [
                 {
                   "command": "next_item",
@@ -154,10 +122,6 @@
         "narrator": {
           "browsers": {
             "edge": {
-              "at_version": "1809",
-              "browser_version": "44.17763",
-              "os_version": "1809",
-              "date": "2019-05-04",
               "output": [
                 {
                   "command": "next_item",
@@ -177,10 +141,6 @@
         "nvda": {
           "browsers": {
             "firefox": {
-              "at_version": "2018.3.2",
-              "browser_version": "66",
-              "os_version": "1809",
-              "date": "2019-09-04",
               "output": [
                 {
                   "command": "next_item",
@@ -191,10 +151,6 @@
               "notes": ""
             },
             "chrome": {
-              "at_version": "2018.1808.10",
-              "browser_version": "74",
-              "os_version": "1809",
-              "date": "2019-05-04",
               "output": [
                 {
                   "command": "next_item",
@@ -209,10 +165,6 @@
         "jaws": {
           "browsers": {
             "ie": {
-              "at_version": "2018.1811.2",
-              "browser_version": "11.134",
-              "os_version": "1809",
-              "date": "2019-05-04",
               "output": [
                 {
                   "command": "next_item",
@@ -223,10 +175,6 @@
               "notes": ""
             },
             "firefox": {
-              "at_version": "2018.1811.2",
-              "browser_version": "66",
-              "os_version": "1809",
-              "date": "2019-05-04",
               "output": [
                 {
                   "command": "next_item",
@@ -237,10 +185,6 @@
               "notes": ""
             },
             "chrome": {
-              "at_version": "2018.1811.2",
-              "browser_version": "74",
-              "os_version": "1809",
-              "date": "2019-05-04",
               "output": [
                 {
                   "command": "next_item",
@@ -255,10 +199,6 @@
         "vo_macos": {
           "browsers": {
             "safari": {
-              "at_version": "10.14.4",
-              "browser_version": "12.1",
-              "os_version": "10.14.4",
-              "date": "2019-05-01",
               "output": [
                 {
                   "command": "next_item",
@@ -273,10 +213,6 @@
         "vo_ios": {
           "browsers": {
             "ios_saf": {
-              "at_version": "12.2",
-              "browser_version": "12.2",
-              "os_version": "12.2",
-              "date": "2019-05-01",
               "output": [
                 {
                   "command": "next_item",
@@ -297,10 +233,6 @@
         "narrator": {
           "browsers": {
             "edge": {
-              "at_version": "1809",
-              "browser_version": "44.17763",
-              "os_version": "1809",
-              "date": "2019-05-04",
               "output": [
                 {
                   "command": "next_item",
@@ -340,10 +272,6 @@
         "nvda": {
           "browsers": {
             "firefox": {
-              "at_version": "2018.3.2",
-              "browser_version": "66",
-              "os_version": "1809",
-              "date": "2019-09-04",
               "output": [
                 {
                   "command": "next_item",
@@ -369,10 +297,6 @@
               "notes": ""
             },
             "chrome": {
-              "at_version": "2018.1808.10",
-              "browser_version": "74",
-              "os_version": "1809",
-              "date": "2019-05-04",
               "output": [
                 {
                   "command": "next_item",
@@ -402,10 +326,6 @@
         "jaws": {
           "browsers": {
             "ie": {
-              "at_version": "2018.1811.2",
-              "browser_version": "11.134",
-              "os_version": "1809",
-              "date": "2019-05-04",
               "output": [
                 {
                   "command": "next_item",
@@ -431,10 +351,6 @@
               "notes": ""
             },
             "firefox": {
-              "at_version": "2018.1811.2",
-              "browser_version": "66",
-              "os_version": "1809",
-              "date": "2019-05-04",
               "output": [
                 {
                   "command": "next_item",
@@ -460,10 +376,6 @@
               "notes": ""
             },
             "chrome": {
-              "at_version": "2018.1811.2",
-              "browser_version": "74",
-              "os_version": "1809",
-              "date": "2019-05-04",
               "output": [
                 {
                   "command": "next_item",
@@ -493,10 +405,6 @@
         "vo_macos": {
           "browsers": {
             "safari": {
-              "at_version": "10.14.4",
-              "browser_version": "12.1",
-              "os_version": "10.14.4",
-              "date": "2019-05-01",
               "output": [
                 {
                   "command": "next_item",
@@ -526,10 +434,6 @@
         "vo_ios": {
           "browsers": {
             "ios_saf": {
-              "at_version": "12.2",
-              "browser_version": "12.2",
-              "os_version": "12.2",
-              "date": "2019-05-01",
               "output": [
                 {
                   "command": "next_item",
@@ -565,10 +469,6 @@
         "narrator": {
           "browsers": {
             "edge": {
-              "at_version": "1809",
-              "browser_version": "44.17763",
-              "os_version": "1809",
-              "date": "2019-05-04",
               "output": [
                 {
                   "command": "next_item",
@@ -583,10 +483,6 @@
         "nvda": {
           "browsers": {
             "firefox": {
-              "at_version": "2018.3.2",
-              "browser_version": "66",
-              "os_version": "1809",
-              "date": "2019-09-04",
               "output": [
                 {
                   "command": "next_item",
@@ -602,10 +498,6 @@
               "notes": ""
             },
             "chrome": {
-              "at_version": "2018.1808.10",
-              "browser_version": "74",
-              "os_version": "1809",
-              "date": "2019-05-04",
               "output": [
                 {
                   "command": "next_item",
@@ -625,10 +517,6 @@
         "jaws": {
           "browsers": {
             "ie": {
-              "at_version": "2018.1811.2",
-              "browser_version": "11.134",
-              "os_version": "1809",
-              "date": "2019-05-04",
               "output": [
                 {
                   "command": "next_item",
@@ -639,10 +527,6 @@
               "notes": ""
             },
             "firefox": {
-              "at_version": "2018.1811.2",
-              "browser_version": "66",
-              "os_version": "1809",
-              "date": "2019-05-04",
               "output": [
                 {
                   "command": "next_item",
@@ -653,10 +537,6 @@
               "notes": ""
             },
             "chrome": {
-              "at_version": "2018.1811.2",
-              "browser_version": "74",
-              "os_version": "1809",
-              "date": "2019-05-04",
               "output": [
                 {
                   "command": "next_item",
@@ -671,10 +551,6 @@
         "vo_macos": {
           "browsers": {
             "safari": {
-              "at_version": "10.14.4",
-              "browser_version": "12.1",
-              "os_version": "10.14.4",
-              "date": "2019-05-01",
               "output": [
                 {
                   "command": "next_item",
@@ -689,10 +565,6 @@
         "vo_ios": {
           "browsers": {
             "ios_saf": {
-              "at_version": "12.2",
-              "browser_version": "12.2",
-              "os_version": "12.2",
-              "date": "2019-05-01",
               "output": [
                 {
                   "command": "next_item",
@@ -713,10 +585,6 @@
         "narrator": {
           "browsers": {
             "edge": {
-              "at_version": "1809",
-              "browser_version": "44.17763",
-              "os_version": "1809",
-              "date": "2019-05-04",
               "output": [
                 {
                   "command": "next_item",
@@ -736,10 +604,6 @@
         "nvda": {
           "browsers": {
             "firefox": {
-              "at_version": "2018.3.2",
-              "browser_version": "66",
-              "os_version": "1809",
-              "date": "2019-09-04",
               "output": [
                 {
                   "command": "next_item",
@@ -755,10 +619,6 @@
               "notes": ""
             },
             "chrome": {
-              "at_version": "2018.1808.10",
-              "browser_version": "74",
-              "os_version": "1809",
-              "date": "2019-05-04",
               "output": [
                 {
                   "command": "next_item",
@@ -778,10 +638,6 @@
         "jaws": {
           "browsers": {
             "ie": {
-              "at_version": "2018.1811.2",
-              "browser_version": "11.134",
-              "os_version": "1809",
-              "date": "2019-05-04",
               "output": [
                 {
                   "command": "next_item",
@@ -792,10 +648,6 @@
               "notes": ""
             },
             "firefox": {
-              "at_version": "2018.1811.2",
-              "browser_version": "66",
-              "os_version": "1809",
-              "date": "2019-05-04",
               "output": [
                 {
                   "command": "next_item",
@@ -806,10 +658,6 @@
               "notes": ""
             },
             "chrome": {
-              "at_version": "2018.1811.2",
-              "browser_version": "74",
-              "os_version": "1809",
-              "date": "2019-05-04",
               "output": [
                 {
                   "command": "next_item",
@@ -824,10 +672,6 @@
         "vo_macos": {
           "browsers": {
             "safari": {
-              "at_version": "10.14.4",
-              "browser_version": "12.1",
-              "os_version": "10.14.4",
-              "date": "2019-05-01",
               "output": [
                 {
                   "command": "next_item",
@@ -842,10 +686,6 @@
         "vo_ios": {
           "browsers": {
             "ios_saf": {
-              "at_version": "12.2",
-              "browser_version": "12.2",
-              "os_version": "12.2",
-              "date": "2019-05-01",
               "output": [
                 {
                   "command": "next_item",
@@ -866,10 +706,6 @@
         "narrator": {
           "browsers": {
             "edge": {
-              "at_version": "1809",
-              "browser_version": "44.17763",
-              "os_version": "1809",
-              "date": "2019-05-04",
               "output": [
                 {
                   "command": "next_item",
@@ -884,10 +720,6 @@
         "nvda": {
           "browsers": {
             "firefox": {
-              "at_version": "2018.3.2",
-              "browser_version": "66",
-              "os_version": "1809",
-              "date": "2019-09-04",
               "output": [
                 {
                   "command": "next_item",
@@ -903,10 +735,6 @@
               "notes": ""
             },
             "chrome": {
-              "at_version": "2018.1808.10",
-              "browser_version": "74",
-              "os_version": "1809",
-              "date": "2019-05-04",
               "output": [
                 {
                   "command": "next_item",
@@ -926,10 +754,6 @@
         "jaws": {
           "browsers": {
             "ie": {
-              "at_version": "2018.1811.2",
-              "browser_version": "11.134",
-              "os_version": "1809",
-              "date": "2019-05-04",
               "output": [
                 {
                   "command": "next_item",
@@ -940,10 +764,6 @@
               "notes": ""
             },
             "firefox": {
-              "at_version": "2018.1811.2",
-              "browser_version": "66",
-              "os_version": "1809",
-              "date": "2019-05-04",
               "output": [
                 {
                   "command": "next_item",
@@ -954,10 +774,6 @@
               "notes": ""
             },
             "chrome": {
-              "at_version": "2018.1811.2",
-              "browser_version": "74",
-              "os_version": "1809",
-              "date": "2019-05-04",
               "output": [
                 {
                   "command": "next_item",
@@ -972,10 +788,6 @@
         "vo_macos": {
           "browsers": {
             "safari": {
-              "at_version": "10.14.4",
-              "browser_version": "12.1",
-              "os_version": "10.14.4",
-              "date": "2019-05-01",
               "output": [
                 {
                   "command": "next_item",
@@ -990,10 +802,6 @@
         "vo_ios": {
           "browsers": {
             "ios_saf": {
-              "at_version": "12.2",
-              "browser_version": "12.2",
-              "os_version": "12.2",
-              "date": "2019-05-01",
               "output": [
                 {
                   "command": "next_item",
@@ -1014,10 +822,6 @@
         "narrator": {
           "browsers": {
             "edge": {
-              "at_version": "1809",
-              "browser_version": "44.17763",
-              "os_version": "1809",
-              "date": "2019-05-04",
               "output": [
                 {
                   "command": "next_item",
@@ -1037,10 +841,6 @@
         "nvda": {
           "browsers": {
             "firefox": {
-              "at_version": "2018.3.2",
-              "browser_version": "66",
-              "os_version": "1809",
-              "date": "2019-09-04",
               "output": [
                 {
                   "command": "next_item",
@@ -1056,10 +856,6 @@
               "notes": ""
             },
             "chrome": {
-              "at_version": "2018.1808.10",
-              "browser_version": "74",
-              "os_version": "1809",
-              "date": "2019-05-04",
               "output": [
                 {
                   "command": "next_item",
@@ -1079,10 +875,6 @@
         "jaws": {
           "browsers": {
             "ie": {
-              "at_version": "2018.1811.2",
-              "browser_version": "11.134",
-              "os_version": "1809",
-              "date": "2019-05-04",
               "output": [
                 {
                   "command": "next_item",
@@ -1093,10 +885,6 @@
               "notes": ""
             },
             "firefox": {
-              "at_version": "2018.1811.2",
-              "browser_version": "66",
-              "os_version": "1809",
-              "date": "2019-05-04",
               "output": [
                 {
                   "command": "next_item",
@@ -1107,10 +895,6 @@
               "notes": ""
             },
             "chrome": {
-              "at_version": "2018.1811.2",
-              "browser_version": "74",
-              "os_version": "1809",
-              "date": "2019-05-04",
               "output": [
                 {
                   "command": "next_item",
@@ -1125,10 +909,6 @@
         "vo_macos": {
           "browsers": {
             "safari": {
-              "at_version": "10.14.4",
-              "browser_version": "12.1",
-              "os_version": "10.14.4",
-              "date": "2019-05-01",
               "output": [
                 {
                   "command": "next_item",
@@ -1143,10 +923,6 @@
         "vo_ios": {
           "browsers": {
             "ios_saf": {
-              "at_version": "12.2",
-              "browser_version": "12.2",
-              "os_version": "12.2",
-              "date": "2019-05-01",
               "output": [
                 {
                   "command": "next_item",
@@ -1166,5 +942,75 @@
       "date": "2019-05-01",
       "message": "Test created"
     }
-  ]
+  ],
+  "versions": {
+    "jaws": {
+      "browsers": {
+        "chrome": {
+          "at_version": "2018.1811.2",
+          "browser_version": "74",
+          "os_version": "1809",
+          "date": "2019-05-04"
+        },
+        "ie": {
+          "at_version": "2018.1811.2",
+          "browser_version": "11.134",
+          "os_version": "1809",
+          "date": "2019-05-04"
+        },
+        "firefox": {
+          "at_version": "2018.1811.2",
+          "browser_version": "66",
+          "os_version": "1809",
+          "date": "2019-05-04"
+        }
+      }
+    },
+    "narrator": {
+      "browsers": {
+        "edge": {
+          "at_version": "1809",
+          "browser_version": "44.17763",
+          "os_version": "1809",
+          "date": "2019-05-04"
+        }
+      }
+    },
+    "nvda": {
+      "browsers": {
+        "chrome": {
+          "at_version": "2018.1808.10",
+          "browser_version": "74",
+          "os_version": "1809",
+          "date": "2019-05-04"
+        },
+        "firefox": {
+          "at_version": "2018.3.2",
+          "browser_version": "66",
+          "os_version": "1809",
+          "date": "2019-09-04"
+        }
+      }
+    },
+    "vo_ios": {
+      "browsers": {
+        "ios_saf": {
+          "at_version": "12.2",
+          "browser_version": "12.2",
+          "os_version": "12.2",
+          "date": "2019-05-01"
+        }
+      }
+    },
+    "vo_macos": {
+      "browsers": {
+        "safari": {
+          "at_version": "10.14.4",
+          "browser_version": "12.1",
+          "os_version": "10.14.4",
+          "date": "2019-05-01"
+        }
+      }
+    }
+  }
 }

--- a/data/tests/tech/html/html_figure/test_1.json
+++ b/data/tests/tech/html/html_figure/test_1.json
@@ -158,10 +158,6 @@
               ]
             },
             "and_ff": {
-              "at_version": "7.2",
-              "browser_version": "63.0.2",
-              "os_version": "8.1",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -253,6 +249,12 @@
         "and_chr": {
           "at_version": "7.2",
           "browser_version": "70",
+          "os_version": "8.1",
+          "date": "2019-01-22"
+        },
+        "and_ff": {
+          "at_version": "7.2",
+          "browser_version": "63.0.2",
           "os_version": "8.1",
           "date": "2019-01-22"
         }

--- a/data/tests/tech/html/html_figure/test_1.json
+++ b/data/tests/tech/html/html_figure/test_1.json
@@ -11,10 +11,6 @@
         "jaws": {
           "browsers": {
             "ie": {
-              "at_version": "2019",
-              "browser_version": "11",
-              "os_version": "1809",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -24,10 +20,6 @@
               ]
             },
             "firefox": {
-              "at_version": "2019",
-              "browser_version": "64.0.2",
-              "os_version": "1809",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -37,10 +29,6 @@
               ]
             },
             "chrome": {
-              "at_version": "2019",
-              "browser_version": "71",
-              "os_version": "1809",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -50,10 +38,6 @@
               ]
             },
             "edge": {
-              "at_version": "2019",
-              "browser_version": "42",
-              "os_version": "1809",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -67,10 +51,6 @@
         "narrator": {
           "browsers": {
             "edge": {
-              "at_version": "1804",
-              "browser_version": "42",
-              "os_version": "1804",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -85,10 +65,6 @@
         "nvda": {
           "browsers": {
             "firefox": {
-              "at_version": "2018.4.1",
-              "browser_version": "64.0.2",
-              "os_version": "1809",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -98,10 +74,6 @@
               ]
             },
             "ie": {
-              "at_version": "2018.4.1",
-              "browser_version": "11",
-              "os_version": "1809",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -111,10 +83,6 @@
               ]
             },
             "chrome": {
-              "at_version": "2018.4.1",
-              "browser_version": "72",
-              "os_version": "1809",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -124,10 +92,6 @@
               ]
             },
             "edge": {
-              "at_version": "2018.4.1",
-              "browser_version": "42",
-              "os_version": "1809",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -141,10 +105,6 @@
         "vo_macos": {
           "browsers": {
             "safari": {
-              "at_version": "10.14.2",
-              "browser_version": "12.0.2",
-              "os_version": "10.14.2",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -154,10 +114,6 @@
               ]
             },
             "chrome": {
-              "at_version": "10.14.2",
-              "browser_version": "71",
-              "os_version": "10.14.2",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -171,10 +127,6 @@
         "vo_ios": {
           "browsers": {
             "ios_saf": {
-              "at_version": "12.1",
-              "browser_version": "12.1.2",
-              "os_version": "12.1",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -184,10 +136,6 @@
               ]
             },
             "ios_chr": {
-              "at_version": "12.1",
-              "browser_version": "71",
-              "os_version": "12.1",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -201,10 +149,6 @@
         "talkback": {
           "browsers": {
             "and_chr": {
-              "at_version": "7.2",
-              "browser_version": "70",
-              "os_version": "8.1",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -236,5 +180,115 @@
       "date": "2019-01-22",
       "message": "Test created. Thank you @scottaohara."
     }
-  ]
+  ],
+  "versions": {
+    "jaws": {
+      "browsers": {
+        "chrome": {
+          "at_version": "2019",
+          "browser_version": "71",
+          "os_version": "1809",
+          "date": "2019-01-22"
+        },
+        "ie": {
+          "at_version": "2019",
+          "browser_version": "11",
+          "os_version": "1809",
+          "date": "2019-01-22"
+        },
+        "firefox": {
+          "at_version": "2019",
+          "browser_version": "64.0.2",
+          "os_version": "1809",
+          "date": "2019-01-22"
+        },
+        "edge": {
+          "at_version": "2019",
+          "browser_version": "42",
+          "os_version": "1809",
+          "date": "2019-01-22"
+        }
+      }
+    },
+    "narrator": {
+      "browsers": {
+        "edge": {
+          "at_version": "1804",
+          "browser_version": "42",
+          "os_version": "1804",
+          "date": "2019-01-22"
+        }
+      }
+    },
+    "nvda": {
+      "browsers": {
+        "chrome": {
+          "at_version": "2018.4.1",
+          "browser_version": "72",
+          "os_version": "1809",
+          "date": "2019-01-22"
+        },
+        "firefox": {
+          "at_version": "2018.4.1",
+          "browser_version": "64.0.2",
+          "os_version": "1809",
+          "date": "2019-01-22"
+        },
+        "ie": {
+          "at_version": "2018.4.1",
+          "browser_version": "11",
+          "os_version": "1809",
+          "date": "2019-01-22"
+        },
+        "edge": {
+          "at_version": "2018.4.1",
+          "browser_version": "42",
+          "os_version": "1809",
+          "date": "2019-01-22"
+        }
+      }
+    },
+    "talkback": {
+      "browsers": {
+        "and_chr": {
+          "at_version": "7.2",
+          "browser_version": "70",
+          "os_version": "8.1",
+          "date": "2019-01-22"
+        }
+      }
+    },
+    "vo_ios": {
+      "browsers": {
+        "ios_saf": {
+          "at_version": "12.1",
+          "browser_version": "12.1.2",
+          "os_version": "12.1",
+          "date": "2019-01-22"
+        },
+        "ios_chr": {
+          "at_version": "12.1",
+          "browser_version": "71",
+          "os_version": "12.1",
+          "date": "2019-01-22"
+        }
+      }
+    },
+    "vo_macos": {
+      "browsers": {
+        "safari": {
+          "at_version": "10.14.2",
+          "browser_version": "12.0.2",
+          "os_version": "10.14.2",
+          "date": "2019-01-22"
+        },
+        "chrome": {
+          "at_version": "10.14.2",
+          "browser_version": "71",
+          "os_version": "10.14.2",
+          "date": "2019-01-22"
+        }
+      }
+    }
+  }
 }

--- a/data/tests/tech/html/html_figure/test_10.json
+++ b/data/tests/tech/html/html_figure/test_10.json
@@ -158,10 +158,6 @@
               ]
             },
             "and_ff": {
-              "at_version": "7.2",
-              "browser_version": "63.0.2",
-              "os_version": "8.1",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -253,6 +249,12 @@
         "and_chr": {
           "at_version": "7.2",
           "browser_version": "70",
+          "os_version": "8.1",
+          "date": "2019-01-22"
+        },
+        "and_ff": {
+          "at_version": "7.2",
+          "browser_version": "63.0.2",
           "os_version": "8.1",
           "date": "2019-01-22"
         }

--- a/data/tests/tech/html/html_figure/test_10.json
+++ b/data/tests/tech/html/html_figure/test_10.json
@@ -11,10 +11,6 @@
         "jaws": {
           "browsers": {
             "ie": {
-              "at_version": "2019",
-              "browser_version": "11",
-              "os_version": "1809",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -24,10 +20,6 @@
               ]
             },
             "firefox": {
-              "at_version": "2019",
-              "browser_version": "64.0.2",
-              "os_version": "1809",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -37,10 +29,6 @@
               ]
             },
             "chrome": {
-              "at_version": "2019",
-              "browser_version": "71",
-              "os_version": "1809",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -50,10 +38,6 @@
               ]
             },
             "edge": {
-              "at_version": "2019",
-              "browser_version": "42",
-              "os_version": "1809",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -67,10 +51,6 @@
         "narrator": {
           "browsers": {
             "edge": {
-              "at_version": "1804",
-              "browser_version": "42",
-              "os_version": "1804",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -85,10 +65,6 @@
         "nvda": {
           "browsers": {
             "firefox": {
-              "at_version": "2018.4.1",
-              "browser_version": "64.0.2",
-              "os_version": "1809",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -98,10 +74,6 @@
               ]
             },
             "ie": {
-              "at_version": "2018.4.1",
-              "browser_version": "11",
-              "os_version": "1809",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -111,10 +83,6 @@
               ]
             },
             "chrome": {
-              "at_version": "2018.4.1",
-              "browser_version": "72",
-              "os_version": "1809",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -124,10 +92,6 @@
               ]
             },
             "edge": {
-              "at_version": "2018.4.1",
-              "browser_version": "42",
-              "os_version": "1809",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -141,10 +105,6 @@
         "vo_macos": {
           "browsers": {
             "safari": {
-              "at_version": "10.14.2",
-              "browser_version": "12.0.2",
-              "os_version": "10.14.2",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -154,10 +114,6 @@
               ]
             },
             "chrome": {
-              "at_version": "10.14.2",
-              "browser_version": "71",
-              "os_version": "10.14.2",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -171,10 +127,6 @@
         "vo_ios": {
           "browsers": {
             "ios_saf": {
-              "at_version": "12.1",
-              "browser_version": "12.1.2",
-              "os_version": "12.1",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -184,10 +136,6 @@
               ]
             },
             "ios_chr": {
-              "at_version": "12.1",
-              "browser_version": "71",
-              "os_version": "12.1",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -201,10 +149,6 @@
         "talkback": {
           "browsers": {
             "and_chr": {
-              "at_version": "7.2",
-              "browser_version": "70",
-              "os_version": "8.1",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -236,5 +180,115 @@
       "date": "2019-01-22",
       "message": "Test created. Thank you @scottaohara."
     }
-  ]
+  ],
+  "versions": {
+    "jaws": {
+      "browsers": {
+        "chrome": {
+          "at_version": "2019",
+          "browser_version": "71",
+          "os_version": "1809",
+          "date": "2019-01-22"
+        },
+        "ie": {
+          "at_version": "2019",
+          "browser_version": "11",
+          "os_version": "1809",
+          "date": "2019-01-22"
+        },
+        "firefox": {
+          "at_version": "2019",
+          "browser_version": "64.0.2",
+          "os_version": "1809",
+          "date": "2019-01-22"
+        },
+        "edge": {
+          "at_version": "2019",
+          "browser_version": "42",
+          "os_version": "1809",
+          "date": "2019-01-22"
+        }
+      }
+    },
+    "narrator": {
+      "browsers": {
+        "edge": {
+          "at_version": "1804",
+          "browser_version": "42",
+          "os_version": "1804",
+          "date": "2019-01-22"
+        }
+      }
+    },
+    "nvda": {
+      "browsers": {
+        "chrome": {
+          "at_version": "2018.4.1",
+          "browser_version": "72",
+          "os_version": "1809",
+          "date": "2019-01-22"
+        },
+        "firefox": {
+          "at_version": "2018.4.1",
+          "browser_version": "64.0.2",
+          "os_version": "1809",
+          "date": "2019-01-22"
+        },
+        "ie": {
+          "at_version": "2018.4.1",
+          "browser_version": "11",
+          "os_version": "1809",
+          "date": "2019-01-22"
+        },
+        "edge": {
+          "at_version": "2018.4.1",
+          "browser_version": "42",
+          "os_version": "1809",
+          "date": "2019-01-22"
+        }
+      }
+    },
+    "talkback": {
+      "browsers": {
+        "and_chr": {
+          "at_version": "7.2",
+          "browser_version": "70",
+          "os_version": "8.1",
+          "date": "2019-01-22"
+        }
+      }
+    },
+    "vo_ios": {
+      "browsers": {
+        "ios_saf": {
+          "at_version": "12.1",
+          "browser_version": "12.1.2",
+          "os_version": "12.1",
+          "date": "2019-01-22"
+        },
+        "ios_chr": {
+          "at_version": "12.1",
+          "browser_version": "71",
+          "os_version": "12.1",
+          "date": "2019-01-22"
+        }
+      }
+    },
+    "vo_macos": {
+      "browsers": {
+        "safari": {
+          "at_version": "10.14.2",
+          "browser_version": "12.0.2",
+          "os_version": "10.14.2",
+          "date": "2019-01-22"
+        },
+        "chrome": {
+          "at_version": "10.14.2",
+          "browser_version": "71",
+          "os_version": "10.14.2",
+          "date": "2019-01-22"
+        }
+      }
+    }
+  }
 }

--- a/data/tests/tech/html/html_figure/test_11.json
+++ b/data/tests/tech/html/html_figure/test_11.json
@@ -158,10 +158,6 @@
               ]
             },
             "and_ff": {
-              "at_version": "7.2",
-              "browser_version": "63.0.2",
-              "os_version": "8.1",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -253,6 +249,12 @@
         "and_chr": {
           "at_version": "7.2",
           "browser_version": "70",
+          "os_version": "8.1",
+          "date": "2019-01-22"
+        },
+        "and_ff": {
+          "at_version": "7.2",
+          "browser_version": "63.0.2",
           "os_version": "8.1",
           "date": "2019-01-22"
         }

--- a/data/tests/tech/html/html_figure/test_11.json
+++ b/data/tests/tech/html/html_figure/test_11.json
@@ -11,10 +11,6 @@
         "jaws": {
           "browsers": {
             "ie": {
-              "at_version": "2019",
-              "browser_version": "11",
-              "os_version": "1809",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -24,10 +20,6 @@
               ]
             },
             "firefox": {
-              "at_version": "2019",
-              "browser_version": "64.0.2",
-              "os_version": "1809",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -37,10 +29,6 @@
               ]
             },
             "chrome": {
-              "at_version": "2019",
-              "browser_version": "71",
-              "os_version": "1809",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -50,10 +38,6 @@
               ]
             },
             "edge": {
-              "at_version": "2019",
-              "browser_version": "42",
-              "os_version": "1809",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -67,10 +51,6 @@
         "narrator": {
           "browsers": {
             "edge": {
-              "at_version": "1804",
-              "browser_version": "42",
-              "os_version": "1804",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -85,10 +65,6 @@
         "nvda": {
           "browsers": {
             "firefox": {
-              "at_version": "2018.4.1",
-              "browser_version": "64.0.2",
-              "os_version": "1809",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -98,10 +74,6 @@
               ]
             },
             "ie": {
-              "at_version": "2018.4.1",
-              "browser_version": "11",
-              "os_version": "1809",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -111,10 +83,6 @@
               ]
             },
             "chrome": {
-              "at_version": "2018.4.1",
-              "browser_version": "72",
-              "os_version": "1809",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -124,10 +92,6 @@
               ]
             },
             "edge": {
-              "at_version": "2018.4.1",
-              "browser_version": "42",
-              "os_version": "1809",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -141,10 +105,6 @@
         "vo_macos": {
           "browsers": {
             "safari": {
-              "at_version": "10.14.2",
-              "browser_version": "12.0.2",
-              "os_version": "10.14.2",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -154,10 +114,6 @@
               ]
             },
             "chrome": {
-              "at_version": "10.14.2",
-              "browser_version": "71",
-              "os_version": "10.14.2",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -171,10 +127,6 @@
         "vo_ios": {
           "browsers": {
             "ios_saf": {
-              "at_version": "12.1",
-              "browser_version": "12.1.2",
-              "os_version": "12.1",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -184,10 +136,6 @@
               ]
             },
             "ios_chr": {
-              "at_version": "12.1",
-              "browser_version": "71",
-              "os_version": "12.1",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -201,10 +149,6 @@
         "talkback": {
           "browsers": {
             "and_chr": {
-              "at_version": "7.2",
-              "browser_version": "70",
-              "os_version": "8.1",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -236,5 +180,115 @@
       "date": "2019-01-22",
       "message": "Test created. Thank you @scottaohara."
     }
-  ]
+  ],
+  "versions": {
+    "jaws": {
+      "browsers": {
+        "chrome": {
+          "at_version": "2019",
+          "browser_version": "71",
+          "os_version": "1809",
+          "date": "2019-01-22"
+        },
+        "ie": {
+          "at_version": "2019",
+          "browser_version": "11",
+          "os_version": "1809",
+          "date": "2019-01-22"
+        },
+        "firefox": {
+          "at_version": "2019",
+          "browser_version": "64.0.2",
+          "os_version": "1809",
+          "date": "2019-01-22"
+        },
+        "edge": {
+          "at_version": "2019",
+          "browser_version": "42",
+          "os_version": "1809",
+          "date": "2019-01-22"
+        }
+      }
+    },
+    "narrator": {
+      "browsers": {
+        "edge": {
+          "at_version": "1804",
+          "browser_version": "42",
+          "os_version": "1804",
+          "date": "2019-01-22"
+        }
+      }
+    },
+    "nvda": {
+      "browsers": {
+        "chrome": {
+          "at_version": "2018.4.1",
+          "browser_version": "72",
+          "os_version": "1809",
+          "date": "2019-01-22"
+        },
+        "firefox": {
+          "at_version": "2018.4.1",
+          "browser_version": "64.0.2",
+          "os_version": "1809",
+          "date": "2019-01-22"
+        },
+        "ie": {
+          "at_version": "2018.4.1",
+          "browser_version": "11",
+          "os_version": "1809",
+          "date": "2019-01-22"
+        },
+        "edge": {
+          "at_version": "2018.4.1",
+          "browser_version": "42",
+          "os_version": "1809",
+          "date": "2019-01-22"
+        }
+      }
+    },
+    "talkback": {
+      "browsers": {
+        "and_chr": {
+          "at_version": "7.2",
+          "browser_version": "70",
+          "os_version": "8.1",
+          "date": "2019-01-22"
+        }
+      }
+    },
+    "vo_ios": {
+      "browsers": {
+        "ios_saf": {
+          "at_version": "12.1",
+          "browser_version": "12.1.2",
+          "os_version": "12.1",
+          "date": "2019-01-22"
+        },
+        "ios_chr": {
+          "at_version": "12.1",
+          "browser_version": "71",
+          "os_version": "12.1",
+          "date": "2019-01-22"
+        }
+      }
+    },
+    "vo_macos": {
+      "browsers": {
+        "safari": {
+          "at_version": "10.14.2",
+          "browser_version": "12.0.2",
+          "os_version": "10.14.2",
+          "date": "2019-01-22"
+        },
+        "chrome": {
+          "at_version": "10.14.2",
+          "browser_version": "71",
+          "os_version": "10.14.2",
+          "date": "2019-01-22"
+        }
+      }
+    }
+  }
 }

--- a/data/tests/tech/html/html_figure/test_12.json
+++ b/data/tests/tech/html/html_figure/test_12.json
@@ -157,10 +157,6 @@
               ]
             },
             "and_ff": {
-              "at_version": "7.2",
-              "browser_version": "63.0.2",
-              "os_version": "8.1",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -252,6 +248,12 @@
         "and_chr": {
           "at_version": "7.2",
           "browser_version": "70",
+          "os_version": "8.1",
+          "date": "2019-01-22"
+        },
+        "and_ff": {
+          "at_version": "7.2",
+          "browser_version": "63.0.2",
           "os_version": "8.1",
           "date": "2019-01-22"
         }

--- a/data/tests/tech/html/html_figure/test_12.json
+++ b/data/tests/tech/html/html_figure/test_12.json
@@ -11,10 +11,6 @@
         "jaws": {
           "browsers": {
             "ie": {
-              "at_version": "2019",
-              "browser_version": "11",
-              "os_version": "1809",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -24,10 +20,6 @@
               ]
             },
             "firefox": {
-              "at_version": "2019",
-              "browser_version": "64.0.2",
-              "os_version": "1809",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -37,10 +29,6 @@
               ]
             },
             "chrome": {
-              "at_version": "2019",
-              "browser_version": "71",
-              "os_version": "1809",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -50,10 +38,6 @@
               ]
             },
             "edge": {
-              "at_version": "2019",
-              "browser_version": "42",
-              "os_version": "1809",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -67,10 +51,6 @@
         "narrator": {
           "browsers": {
             "edge": {
-              "at_version": "1804",
-              "browser_version": "42",
-              "os_version": "1804",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -84,10 +64,6 @@
         "nvda": {
           "browsers": {
             "firefox": {
-              "at_version": "2018.4.1",
-              "browser_version": "64.0.2",
-              "os_version": "1809",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -97,10 +73,6 @@
               ]
             },
             "ie": {
-              "at_version": "2018.4.1",
-              "browser_version": "11",
-              "os_version": "1809",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -110,10 +82,6 @@
               ]
             },
             "chrome": {
-              "at_version": "2018.4.1",
-              "browser_version": "72",
-              "os_version": "1809",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -123,10 +91,6 @@
               ]
             },
             "edge": {
-              "at_version": "2018.4.1",
-              "browser_version": "42",
-              "os_version": "1809",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -140,10 +104,6 @@
         "vo_macos": {
           "browsers": {
             "safari": {
-              "at_version": "10.14.2",
-              "browser_version": "12.0.2",
-              "os_version": "10.14.2",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -153,10 +113,6 @@
               ]
             },
             "chrome": {
-              "at_version": "10.14.2",
-              "browser_version": "71",
-              "os_version": "10.14.2",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -170,10 +126,6 @@
         "vo_ios": {
           "browsers": {
             "ios_saf": {
-              "at_version": "12.1",
-              "browser_version": "12.1.2",
-              "os_version": "12.1",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -183,10 +135,6 @@
               ]
             },
             "ios_chr": {
-              "at_version": "12.1",
-              "browser_version": "71",
-              "os_version": "12.1",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -200,10 +148,6 @@
         "talkback": {
           "browsers": {
             "and_chr": {
-              "at_version": "7.2",
-              "browser_version": "70",
-              "os_version": "8.1",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -235,5 +179,115 @@
       "date": "2019-01-22",
       "message": "Test created. Thank you @scottaohara."
     }
-  ]
+  ],
+  "versions": {
+    "jaws": {
+      "browsers": {
+        "chrome": {
+          "at_version": "2019",
+          "browser_version": "71",
+          "os_version": "1809",
+          "date": "2019-01-22"
+        },
+        "ie": {
+          "at_version": "2019",
+          "browser_version": "11",
+          "os_version": "1809",
+          "date": "2019-01-22"
+        },
+        "firefox": {
+          "at_version": "2019",
+          "browser_version": "64.0.2",
+          "os_version": "1809",
+          "date": "2019-01-22"
+        },
+        "edge": {
+          "at_version": "2019",
+          "browser_version": "42",
+          "os_version": "1809",
+          "date": "2019-01-22"
+        }
+      }
+    },
+    "narrator": {
+      "browsers": {
+        "edge": {
+          "at_version": "1804",
+          "browser_version": "42",
+          "os_version": "1804",
+          "date": "2019-01-22"
+        }
+      }
+    },
+    "nvda": {
+      "browsers": {
+        "chrome": {
+          "at_version": "2018.4.1",
+          "browser_version": "72",
+          "os_version": "1809",
+          "date": "2019-01-22"
+        },
+        "firefox": {
+          "at_version": "2018.4.1",
+          "browser_version": "64.0.2",
+          "os_version": "1809",
+          "date": "2019-01-22"
+        },
+        "ie": {
+          "at_version": "2018.4.1",
+          "browser_version": "11",
+          "os_version": "1809",
+          "date": "2019-01-22"
+        },
+        "edge": {
+          "at_version": "2018.4.1",
+          "browser_version": "42",
+          "os_version": "1809",
+          "date": "2019-01-22"
+        }
+      }
+    },
+    "talkback": {
+      "browsers": {
+        "and_chr": {
+          "at_version": "7.2",
+          "browser_version": "70",
+          "os_version": "8.1",
+          "date": "2019-01-22"
+        }
+      }
+    },
+    "vo_ios": {
+      "browsers": {
+        "ios_saf": {
+          "at_version": "12.1",
+          "browser_version": "12.1.2",
+          "os_version": "12.1",
+          "date": "2019-01-22"
+        },
+        "ios_chr": {
+          "at_version": "12.1",
+          "browser_version": "71",
+          "os_version": "12.1",
+          "date": "2019-01-22"
+        }
+      }
+    },
+    "vo_macos": {
+      "browsers": {
+        "safari": {
+          "at_version": "10.14.2",
+          "browser_version": "12.0.2",
+          "os_version": "10.14.2",
+          "date": "2019-01-22"
+        },
+        "chrome": {
+          "at_version": "10.14.2",
+          "browser_version": "71",
+          "os_version": "10.14.2",
+          "date": "2019-01-22"
+        }
+      }
+    }
+  }
 }

--- a/data/tests/tech/html/html_figure/test_13.json
+++ b/data/tests/tech/html/html_figure/test_13.json
@@ -158,10 +158,6 @@
               ]
             },
             "and_ff": {
-              "at_version": "7.2",
-              "browser_version": "63.0.2",
-              "os_version": "8.1",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -253,6 +249,12 @@
         "and_chr": {
           "at_version": "7.2",
           "browser_version": "70",
+          "os_version": "8.1",
+          "date": "2019-01-22"
+        },
+        "and_ff": {
+          "at_version": "7.2",
+          "browser_version": "63.0.2",
           "os_version": "8.1",
           "date": "2019-01-22"
         }

--- a/data/tests/tech/html/html_figure/test_13.json
+++ b/data/tests/tech/html/html_figure/test_13.json
@@ -11,10 +11,6 @@
         "jaws": {
           "browsers": {
             "ie": {
-              "at_version": "2019",
-              "browser_version": "11",
-              "os_version": "1809",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -24,10 +20,6 @@
               ]
             },
             "firefox": {
-              "at_version": "2019",
-              "browser_version": "64.0.2",
-              "os_version": "1809",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -37,10 +29,6 @@
               ]
             },
             "chrome": {
-              "at_version": "2019",
-              "browser_version": "71",
-              "os_version": "1809",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -50,10 +38,6 @@
               ]
             },
             "edge": {
-              "at_version": "2019",
-              "browser_version": "42",
-              "os_version": "1809",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -67,10 +51,6 @@
         "narrator": {
           "browsers": {
             "edge": {
-              "at_version": "1804",
-              "browser_version": "42",
-              "os_version": "1804",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -85,10 +65,6 @@
         "nvda": {
           "browsers": {
             "firefox": {
-              "at_version": "2018.4.1",
-              "browser_version": "64.0.2",
-              "os_version": "1809",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -98,10 +74,6 @@
               ]
             },
             "ie": {
-              "at_version": "2018.4.1",
-              "browser_version": "11",
-              "os_version": "1809",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -111,10 +83,6 @@
               ]
             },
             "chrome": {
-              "at_version": "2018.4.1",
-              "browser_version": "72",
-              "os_version": "1809",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -124,10 +92,6 @@
               ]
             },
             "edge": {
-              "at_version": "2018.4.1",
-              "browser_version": "42",
-              "os_version": "1809",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -141,10 +105,6 @@
         "vo_macos": {
           "browsers": {
             "safari": {
-              "at_version": "10.14.2",
-              "browser_version": "12.0.2",
-              "os_version": "10.14.2",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -154,10 +114,6 @@
               ]
             },
             "chrome": {
-              "at_version": "10.14.2",
-              "browser_version": "71",
-              "os_version": "10.14.2",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -171,10 +127,6 @@
         "vo_ios": {
           "browsers": {
             "ios_saf": {
-              "at_version": "12.1",
-              "browser_version": "12.1.2",
-              "os_version": "12.1",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -184,10 +136,6 @@
               ]
             },
             "ios_chr": {
-              "at_version": "12.1",
-              "browser_version": "71",
-              "os_version": "12.1",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -201,10 +149,6 @@
         "talkback": {
           "browsers": {
             "and_chr": {
-              "at_version": "7.2",
-              "browser_version": "70",
-              "os_version": "8.1",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -236,5 +180,115 @@
       "date": "2019-01-22",
       "message": "Test created. Thank you @scottaohara."
     }
-  ]
+  ],
+  "versions": {
+    "jaws": {
+      "browsers": {
+        "chrome": {
+          "at_version": "2019",
+          "browser_version": "71",
+          "os_version": "1809",
+          "date": "2019-01-22"
+        },
+        "ie": {
+          "at_version": "2019",
+          "browser_version": "11",
+          "os_version": "1809",
+          "date": "2019-01-22"
+        },
+        "firefox": {
+          "at_version": "2019",
+          "browser_version": "64.0.2",
+          "os_version": "1809",
+          "date": "2019-01-22"
+        },
+        "edge": {
+          "at_version": "2019",
+          "browser_version": "42",
+          "os_version": "1809",
+          "date": "2019-01-22"
+        }
+      }
+    },
+    "narrator": {
+      "browsers": {
+        "edge": {
+          "at_version": "1804",
+          "browser_version": "42",
+          "os_version": "1804",
+          "date": "2019-01-22"
+        }
+      }
+    },
+    "nvda": {
+      "browsers": {
+        "chrome": {
+          "at_version": "2018.4.1",
+          "browser_version": "72",
+          "os_version": "1809",
+          "date": "2019-01-22"
+        },
+        "firefox": {
+          "at_version": "2018.4.1",
+          "browser_version": "64.0.2",
+          "os_version": "1809",
+          "date": "2019-01-22"
+        },
+        "ie": {
+          "at_version": "2018.4.1",
+          "browser_version": "11",
+          "os_version": "1809",
+          "date": "2019-01-22"
+        },
+        "edge": {
+          "at_version": "2018.4.1",
+          "browser_version": "42",
+          "os_version": "1809",
+          "date": "2019-01-22"
+        }
+      }
+    },
+    "talkback": {
+      "browsers": {
+        "and_chr": {
+          "at_version": "7.2",
+          "browser_version": "70",
+          "os_version": "8.1",
+          "date": "2019-01-22"
+        }
+      }
+    },
+    "vo_ios": {
+      "browsers": {
+        "ios_saf": {
+          "at_version": "12.1",
+          "browser_version": "12.1.2",
+          "os_version": "12.1",
+          "date": "2019-01-22"
+        },
+        "ios_chr": {
+          "at_version": "12.1",
+          "browser_version": "71",
+          "os_version": "12.1",
+          "date": "2019-01-22"
+        }
+      }
+    },
+    "vo_macos": {
+      "browsers": {
+        "safari": {
+          "at_version": "10.14.2",
+          "browser_version": "12.0.2",
+          "os_version": "10.14.2",
+          "date": "2019-01-22"
+        },
+        "chrome": {
+          "at_version": "10.14.2",
+          "browser_version": "71",
+          "os_version": "10.14.2",
+          "date": "2019-01-22"
+        }
+      }
+    }
+  }
 }

--- a/data/tests/tech/html/html_figure/test_2.json
+++ b/data/tests/tech/html/html_figure/test_2.json
@@ -11,10 +11,6 @@
         "jaws": {
           "browsers": {
             "ie": {
-              "at_version": "2019",
-              "browser_version": "11",
-              "os_version": "1809",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -24,10 +20,6 @@
               ]
             },
             "firefox": {
-              "at_version": "2019",
-              "browser_version": "64.0.2",
-              "os_version": "1809",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -37,10 +29,6 @@
               ]
             },
             "chrome": {
-              "at_version": "2019",
-              "browser_version": "71",
-              "os_version": "1809",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -51,10 +39,6 @@
               "notes": "fail (all content ignored!)"
             },
             "edge": {
-              "at_version": "2019",
-              "browser_version": "42",
-              "os_version": "1809",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -68,10 +52,6 @@
         "narrator": {
           "browsers": {
             "edge": {
-              "at_version": "1804",
-              "browser_version": "42",
-              "os_version": "1804",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -86,10 +66,6 @@
         "nvda": {
           "browsers": {
             "firefox": {
-              "at_version": "2018.4.1",
-              "browser_version": "64.0.2",
-              "os_version": "1809",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -99,10 +75,6 @@
               ]
             },
             "ie": {
-              "at_version": "2018.4.1",
-              "browser_version": "11",
-              "os_version": "1809",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -112,10 +84,6 @@
               ]
             },
             "chrome": {
-              "at_version": "2018.4.1",
-              "browser_version": "72",
-              "os_version": "1809",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -125,10 +93,6 @@
               ]
             },
             "edge": {
-              "at_version": "2018.4.1",
-              "browser_version": "42",
-              "os_version": "1809",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -142,10 +106,6 @@
         "vo_macos": {
           "browsers": {
             "safari": {
-              "at_version": "10.14.2",
-              "browser_version": "12.0.2",
-              "os_version": "10.14.2",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -155,10 +115,6 @@
               ]
             },
             "chrome": {
-              "at_version": "10.14.2",
-              "browser_version": "71",
-              "os_version": "10.14.2",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -172,10 +128,6 @@
         "vo_ios": {
           "browsers": {
             "ios_saf": {
-              "at_version": "12.1",
-              "browser_version": "12.1.2",
-              "os_version": "12.1",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -185,10 +137,6 @@
               ]
             },
             "ios_chr": {
-              "at_version": "12.1",
-              "browser_version": "71",
-              "os_version": "12.1",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -202,10 +150,6 @@
         "talkback": {
           "browsers": {
             "and_chr": {
-              "at_version": "7.2",
-              "browser_version": "70",
-              "os_version": "8.1",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -237,5 +181,115 @@
       "date": "2019-01-22",
       "message": "Test created. Thank you @scottaohara."
     }
-  ]
+  ],
+  "versions": {
+    "jaws": {
+      "browsers": {
+        "chrome": {
+          "at_version": "2019",
+          "browser_version": "71",
+          "os_version": "1809",
+          "date": "2019-01-22"
+        },
+        "ie": {
+          "at_version": "2019",
+          "browser_version": "11",
+          "os_version": "1809",
+          "date": "2019-01-22"
+        },
+        "firefox": {
+          "at_version": "2019",
+          "browser_version": "64.0.2",
+          "os_version": "1809",
+          "date": "2019-01-22"
+        },
+        "edge": {
+          "at_version": "2019",
+          "browser_version": "42",
+          "os_version": "1809",
+          "date": "2019-01-22"
+        }
+      }
+    },
+    "narrator": {
+      "browsers": {
+        "edge": {
+          "at_version": "1804",
+          "browser_version": "42",
+          "os_version": "1804",
+          "date": "2019-01-22"
+        }
+      }
+    },
+    "nvda": {
+      "browsers": {
+        "chrome": {
+          "at_version": "2018.4.1",
+          "browser_version": "72",
+          "os_version": "1809",
+          "date": "2019-01-22"
+        },
+        "firefox": {
+          "at_version": "2018.4.1",
+          "browser_version": "64.0.2",
+          "os_version": "1809",
+          "date": "2019-01-22"
+        },
+        "ie": {
+          "at_version": "2018.4.1",
+          "browser_version": "11",
+          "os_version": "1809",
+          "date": "2019-01-22"
+        },
+        "edge": {
+          "at_version": "2018.4.1",
+          "browser_version": "42",
+          "os_version": "1809",
+          "date": "2019-01-22"
+        }
+      }
+    },
+    "talkback": {
+      "browsers": {
+        "and_chr": {
+          "at_version": "7.2",
+          "browser_version": "70",
+          "os_version": "8.1",
+          "date": "2019-01-22"
+        }
+      }
+    },
+    "vo_ios": {
+      "browsers": {
+        "ios_saf": {
+          "at_version": "12.1",
+          "browser_version": "12.1.2",
+          "os_version": "12.1",
+          "date": "2019-01-22"
+        },
+        "ios_chr": {
+          "at_version": "12.1",
+          "browser_version": "71",
+          "os_version": "12.1",
+          "date": "2019-01-22"
+        }
+      }
+    },
+    "vo_macos": {
+      "browsers": {
+        "safari": {
+          "at_version": "10.14.2",
+          "browser_version": "12.0.2",
+          "os_version": "10.14.2",
+          "date": "2019-01-22"
+        },
+        "chrome": {
+          "at_version": "10.14.2",
+          "browser_version": "71",
+          "os_version": "10.14.2",
+          "date": "2019-01-22"
+        }
+      }
+    }
+  }
 }

--- a/data/tests/tech/html/html_figure/test_2.json
+++ b/data/tests/tech/html/html_figure/test_2.json
@@ -159,10 +159,6 @@
               ]
             },
             "and_ff": {
-              "at_version": "7.2",
-              "browser_version": "63.0.2",
-              "os_version": "8.1",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -254,6 +250,12 @@
         "and_chr": {
           "at_version": "7.2",
           "browser_version": "70",
+          "os_version": "8.1",
+          "date": "2019-01-22"
+        },
+        "and_ff": {
+          "at_version": "7.2",
+          "browser_version": "63.0.2",
           "os_version": "8.1",
           "date": "2019-01-22"
         }

--- a/data/tests/tech/html/html_figure/test_3.json
+++ b/data/tests/tech/html/html_figure/test_3.json
@@ -11,10 +11,6 @@
         "jaws": {
           "browsers": {
             "ie": {
-              "at_version": "2019",
-              "browser_version": "11",
-              "os_version": "1809",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -24,10 +20,6 @@
               ]
             },
             "firefox": {
-              "at_version": "2019",
-              "browser_version": "64.0.2",
-              "os_version": "1809",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -37,10 +29,6 @@
               ]
             },
             "chrome": {
-              "at_version": "2019",
-              "browser_version": "71",
-              "os_version": "1809",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -51,10 +39,6 @@
               "notes": "fail (all content ignored!)"
             },
             "edge": {
-              "at_version": "2019",
-              "browser_version": "42",
-              "os_version": "1809",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -68,10 +52,6 @@
         "narrator": {
           "browsers": {
             "edge": {
-              "at_version": "1804",
-              "browser_version": "42",
-              "os_version": "1804",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -86,10 +66,6 @@
         "nvda": {
           "browsers": {
             "firefox": {
-              "at_version": "2018.4.1",
-              "browser_version": "64.0.2",
-              "os_version": "1809",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -99,10 +75,6 @@
               ]
             },
             "ie": {
-              "at_version": "2018.4.1",
-              "browser_version": "11",
-              "os_version": "1809",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -112,10 +84,6 @@
               ]
             },
             "chrome": {
-              "at_version": "2018.4.1",
-              "browser_version": "72",
-              "os_version": "1809",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -125,10 +93,6 @@
               ]
             },
             "edge": {
-              "at_version": "2018.4.1",
-              "browser_version": "42",
-              "os_version": "1809",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -142,10 +106,6 @@
         "vo_macos": {
           "browsers": {
             "safari": {
-              "at_version": "10.14.2",
-              "browser_version": "12.0.2",
-              "os_version": "10.14.2",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -155,10 +115,6 @@
               ]
             },
             "chrome": {
-              "at_version": "10.14.2",
-              "browser_version": "71",
-              "os_version": "10.14.2",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -172,10 +128,6 @@
         "vo_ios": {
           "browsers": {
             "ios_saf": {
-              "at_version": "12.1",
-              "browser_version": "12.1.2",
-              "os_version": "12.1",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -185,10 +137,6 @@
               ]
             },
             "ios_chr": {
-              "at_version": "12.1",
-              "browser_version": "71",
-              "os_version": "12.1",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -202,10 +150,6 @@
         "talkback": {
           "browsers": {
             "and_chr": {
-              "at_version": "7.2",
-              "browser_version": "70",
-              "os_version": "8.1",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -237,5 +181,115 @@
       "date": "2019-01-22",
       "message": "Test created. Thank you @scottaohara."
     }
-  ]
+  ],
+  "versions": {
+    "jaws": {
+      "browsers": {
+        "chrome": {
+          "at_version": "2019",
+          "browser_version": "71",
+          "os_version": "1809",
+          "date": "2019-01-22"
+        },
+        "ie": {
+          "at_version": "2019",
+          "browser_version": "11",
+          "os_version": "1809",
+          "date": "2019-01-22"
+        },
+        "firefox": {
+          "at_version": "2019",
+          "browser_version": "64.0.2",
+          "os_version": "1809",
+          "date": "2019-01-22"
+        },
+        "edge": {
+          "at_version": "2019",
+          "browser_version": "42",
+          "os_version": "1809",
+          "date": "2019-01-22"
+        }
+      }
+    },
+    "narrator": {
+      "browsers": {
+        "edge": {
+          "at_version": "1804",
+          "browser_version": "42",
+          "os_version": "1804",
+          "date": "2019-01-22"
+        }
+      }
+    },
+    "nvda": {
+      "browsers": {
+        "chrome": {
+          "at_version": "2018.4.1",
+          "browser_version": "72",
+          "os_version": "1809",
+          "date": "2019-01-22"
+        },
+        "firefox": {
+          "at_version": "2018.4.1",
+          "browser_version": "64.0.2",
+          "os_version": "1809",
+          "date": "2019-01-22"
+        },
+        "ie": {
+          "at_version": "2018.4.1",
+          "browser_version": "11",
+          "os_version": "1809",
+          "date": "2019-01-22"
+        },
+        "edge": {
+          "at_version": "2018.4.1",
+          "browser_version": "42",
+          "os_version": "1809",
+          "date": "2019-01-22"
+        }
+      }
+    },
+    "talkback": {
+      "browsers": {
+        "and_chr": {
+          "at_version": "7.2",
+          "browser_version": "70",
+          "os_version": "8.1",
+          "date": "2019-01-22"
+        }
+      }
+    },
+    "vo_ios": {
+      "browsers": {
+        "ios_saf": {
+          "at_version": "12.1",
+          "browser_version": "12.1.2",
+          "os_version": "12.1",
+          "date": "2019-01-22"
+        },
+        "ios_chr": {
+          "at_version": "12.1",
+          "browser_version": "71",
+          "os_version": "12.1",
+          "date": "2019-01-22"
+        }
+      }
+    },
+    "vo_macos": {
+      "browsers": {
+        "safari": {
+          "at_version": "10.14.2",
+          "browser_version": "12.0.2",
+          "os_version": "10.14.2",
+          "date": "2019-01-22"
+        },
+        "chrome": {
+          "at_version": "10.14.2",
+          "browser_version": "71",
+          "os_version": "10.14.2",
+          "date": "2019-01-22"
+        }
+      }
+    }
+  }
 }

--- a/data/tests/tech/html/html_figure/test_3.json
+++ b/data/tests/tech/html/html_figure/test_3.json
@@ -159,10 +159,6 @@
               ]
             },
             "and_ff": {
-              "at_version": "7.2",
-              "browser_version": "63.0.2",
-              "os_version": "8.1",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -254,6 +250,12 @@
         "and_chr": {
           "at_version": "7.2",
           "browser_version": "70",
+          "os_version": "8.1",
+          "date": "2019-01-22"
+        },
+        "and_ff": {
+          "at_version": "7.2",
+          "browser_version": "63.0.2",
           "os_version": "8.1",
           "date": "2019-01-22"
         }

--- a/data/tests/tech/html/html_figure/test_4.json
+++ b/data/tests/tech/html/html_figure/test_4.json
@@ -158,10 +158,6 @@
               ]
             },
             "and_ff": {
-              "at_version": "7.2",
-              "browser_version": "63.0.2",
-              "os_version": "8.1",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -253,6 +249,12 @@
         "and_chr": {
           "at_version": "7.2",
           "browser_version": "70",
+          "os_version": "8.1",
+          "date": "2019-01-22"
+        },
+        "and_ff": {
+          "at_version": "7.2",
+          "browser_version": "63.0.2",
           "os_version": "8.1",
           "date": "2019-01-22"
         }

--- a/data/tests/tech/html/html_figure/test_4.json
+++ b/data/tests/tech/html/html_figure/test_4.json
@@ -11,10 +11,6 @@
         "jaws": {
           "browsers": {
             "ie": {
-              "at_version": "2019",
-              "browser_version": "11",
-              "os_version": "1809",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -24,10 +20,6 @@
               ]
             },
             "firefox": {
-              "at_version": "2019",
-              "browser_version": "64.0.2",
-              "os_version": "1809",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -37,10 +29,6 @@
               ]
             },
             "chrome": {
-              "at_version": "2019",
-              "browser_version": "71",
-              "os_version": "1809",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -50,10 +38,6 @@
               ]
             },
             "edge": {
-              "at_version": "2019",
-              "browser_version": "42",
-              "os_version": "1809",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -67,10 +51,6 @@
         "narrator": {
           "browsers": {
             "edge": {
-              "at_version": "1804",
-              "browser_version": "42",
-              "os_version": "1804",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -85,10 +65,6 @@
         "nvda": {
           "browsers": {
             "firefox": {
-              "at_version": "2018.4.1",
-              "browser_version": "64.0.2",
-              "os_version": "1809",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -98,10 +74,6 @@
               ]
             },
             "ie": {
-              "at_version": "2018.4.1",
-              "browser_version": "11",
-              "os_version": "1809",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -111,10 +83,6 @@
               ]
             },
             "chrome": {
-              "at_version": "2018.4.1",
-              "browser_version": "72",
-              "os_version": "1809",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -124,10 +92,6 @@
               ]
             },
             "edge": {
-              "at_version": "2018.4.1",
-              "browser_version": "42",
-              "os_version": "1809",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -141,10 +105,6 @@
         "vo_macos": {
           "browsers": {
             "safari": {
-              "at_version": "10.14.2",
-              "browser_version": "12.0.2",
-              "os_version": "10.14.2",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -154,10 +114,6 @@
               ]
             },
             "chrome": {
-              "at_version": "10.14.2",
-              "browser_version": "71",
-              "os_version": "10.14.2",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -171,10 +127,6 @@
         "vo_ios": {
           "browsers": {
             "ios_saf": {
-              "at_version": "12.1",
-              "browser_version": "12.1.2",
-              "os_version": "12.1",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -184,10 +136,6 @@
               ]
             },
             "ios_chr": {
-              "at_version": "12.1",
-              "browser_version": "71",
-              "os_version": "12.1",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -201,10 +149,6 @@
         "talkback": {
           "browsers": {
             "and_chr": {
-              "at_version": "7.2",
-              "browser_version": "70",
-              "os_version": "8.1",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -236,5 +180,115 @@
       "date": "2019-01-22",
       "message": "Test created. Thank you @scottaohara."
     }
-  ]
+  ],
+  "versions": {
+    "jaws": {
+      "browsers": {
+        "chrome": {
+          "at_version": "2019",
+          "browser_version": "71",
+          "os_version": "1809",
+          "date": "2019-01-22"
+        },
+        "ie": {
+          "at_version": "2019",
+          "browser_version": "11",
+          "os_version": "1809",
+          "date": "2019-01-22"
+        },
+        "firefox": {
+          "at_version": "2019",
+          "browser_version": "64.0.2",
+          "os_version": "1809",
+          "date": "2019-01-22"
+        },
+        "edge": {
+          "at_version": "2019",
+          "browser_version": "42",
+          "os_version": "1809",
+          "date": "2019-01-22"
+        }
+      }
+    },
+    "narrator": {
+      "browsers": {
+        "edge": {
+          "at_version": "1804",
+          "browser_version": "42",
+          "os_version": "1804",
+          "date": "2019-01-22"
+        }
+      }
+    },
+    "nvda": {
+      "browsers": {
+        "chrome": {
+          "at_version": "2018.4.1",
+          "browser_version": "72",
+          "os_version": "1809",
+          "date": "2019-01-22"
+        },
+        "firefox": {
+          "at_version": "2018.4.1",
+          "browser_version": "64.0.2",
+          "os_version": "1809",
+          "date": "2019-01-22"
+        },
+        "ie": {
+          "at_version": "2018.4.1",
+          "browser_version": "11",
+          "os_version": "1809",
+          "date": "2019-01-22"
+        },
+        "edge": {
+          "at_version": "2018.4.1",
+          "browser_version": "42",
+          "os_version": "1809",
+          "date": "2019-01-22"
+        }
+      }
+    },
+    "talkback": {
+      "browsers": {
+        "and_chr": {
+          "at_version": "7.2",
+          "browser_version": "70",
+          "os_version": "8.1",
+          "date": "2019-01-22"
+        }
+      }
+    },
+    "vo_ios": {
+      "browsers": {
+        "ios_saf": {
+          "at_version": "12.1",
+          "browser_version": "12.1.2",
+          "os_version": "12.1",
+          "date": "2019-01-22"
+        },
+        "ios_chr": {
+          "at_version": "12.1",
+          "browser_version": "71",
+          "os_version": "12.1",
+          "date": "2019-01-22"
+        }
+      }
+    },
+    "vo_macos": {
+      "browsers": {
+        "safari": {
+          "at_version": "10.14.2",
+          "browser_version": "12.0.2",
+          "os_version": "10.14.2",
+          "date": "2019-01-22"
+        },
+        "chrome": {
+          "at_version": "10.14.2",
+          "browser_version": "71",
+          "os_version": "10.14.2",
+          "date": "2019-01-22"
+        }
+      }
+    }
+  }
 }

--- a/data/tests/tech/html/html_figure/test_5.json
+++ b/data/tests/tech/html/html_figure/test_5.json
@@ -158,10 +158,6 @@
               ]
             },
             "and_ff": {
-              "at_version": "7.2",
-              "browser_version": "63.0.2",
-              "os_version": "8.1",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -253,6 +249,12 @@
         "and_chr": {
           "at_version": "7.2",
           "browser_version": "70",
+          "os_version": "8.1",
+          "date": "2019-01-22"
+        },
+        "and_ff": {
+          "at_version": "7.2",
+          "browser_version": "63.0.2",
           "os_version": "8.1",
           "date": "2019-01-22"
         }

--- a/data/tests/tech/html/html_figure/test_5.json
+++ b/data/tests/tech/html/html_figure/test_5.json
@@ -11,10 +11,6 @@
         "jaws": {
           "browsers": {
             "ie": {
-              "at_version": "2019",
-              "browser_version": "11",
-              "os_version": "1809",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -24,10 +20,6 @@
               ]
             },
             "firefox": {
-              "at_version": "2019",
-              "browser_version": "64.0.2",
-              "os_version": "1809",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -37,10 +29,6 @@
               ]
             },
             "chrome": {
-              "at_version": "2019",
-              "browser_version": "71",
-              "os_version": "1809",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -50,10 +38,6 @@
               ]
             },
             "edge": {
-              "at_version": "2019",
-              "browser_version": "42",
-              "os_version": "1809",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -67,10 +51,6 @@
         "narrator": {
           "browsers": {
             "edge": {
-              "at_version": "1804",
-              "browser_version": "42",
-              "os_version": "1804",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -85,10 +65,6 @@
         "nvda": {
           "browsers": {
             "firefox": {
-              "at_version": "2018.4.1",
-              "browser_version": "64.0.2",
-              "os_version": "1809",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -98,10 +74,6 @@
               ]
             },
             "ie": {
-              "at_version": "2018.4.1",
-              "browser_version": "11",
-              "os_version": "1809",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -111,10 +83,6 @@
               ]
             },
             "chrome": {
-              "at_version": "2018.4.1",
-              "browser_version": "72",
-              "os_version": "1809",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -124,10 +92,6 @@
               ]
             },
             "edge": {
-              "at_version": "2018.4.1",
-              "browser_version": "42",
-              "os_version": "1809",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -141,10 +105,6 @@
         "vo_macos": {
           "browsers": {
             "safari": {
-              "at_version": "10.14.2",
-              "browser_version": "12.0.2",
-              "os_version": "10.14.2",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -154,10 +114,6 @@
               ]
             },
             "chrome": {
-              "at_version": "10.14.2",
-              "browser_version": "71",
-              "os_version": "10.14.2",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -171,10 +127,6 @@
         "vo_ios": {
           "browsers": {
             "ios_saf": {
-              "at_version": "12.1",
-              "browser_version": "12.1.2",
-              "os_version": "12.1",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -184,10 +136,6 @@
               ]
             },
             "ios_chr": {
-              "at_version": "12.1",
-              "browser_version": "71",
-              "os_version": "12.1",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -201,10 +149,6 @@
         "talkback": {
           "browsers": {
             "and_chr": {
-              "at_version": "7.2",
-              "browser_version": "70",
-              "os_version": "8.1",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -236,5 +180,115 @@
       "date": "2019-01-22",
       "message": "Test created. Thank you @scottaohara."
     }
-  ]
+  ],
+  "versions": {
+    "jaws": {
+      "browsers": {
+        "chrome": {
+          "at_version": "2019",
+          "browser_version": "71",
+          "os_version": "1809",
+          "date": "2019-01-22"
+        },
+        "ie": {
+          "at_version": "2019",
+          "browser_version": "11",
+          "os_version": "1809",
+          "date": "2019-01-22"
+        },
+        "firefox": {
+          "at_version": "2019",
+          "browser_version": "64.0.2",
+          "os_version": "1809",
+          "date": "2019-01-22"
+        },
+        "edge": {
+          "at_version": "2019",
+          "browser_version": "42",
+          "os_version": "1809",
+          "date": "2019-01-22"
+        }
+      }
+    },
+    "narrator": {
+      "browsers": {
+        "edge": {
+          "at_version": "1804",
+          "browser_version": "42",
+          "os_version": "1804",
+          "date": "2019-01-22"
+        }
+      }
+    },
+    "nvda": {
+      "browsers": {
+        "chrome": {
+          "at_version": "2018.4.1",
+          "browser_version": "72",
+          "os_version": "1809",
+          "date": "2019-01-22"
+        },
+        "firefox": {
+          "at_version": "2018.4.1",
+          "browser_version": "64.0.2",
+          "os_version": "1809",
+          "date": "2019-01-22"
+        },
+        "ie": {
+          "at_version": "2018.4.1",
+          "browser_version": "11",
+          "os_version": "1809",
+          "date": "2019-01-22"
+        },
+        "edge": {
+          "at_version": "2018.4.1",
+          "browser_version": "42",
+          "os_version": "1809",
+          "date": "2019-01-22"
+        }
+      }
+    },
+    "talkback": {
+      "browsers": {
+        "and_chr": {
+          "at_version": "7.2",
+          "browser_version": "70",
+          "os_version": "8.1",
+          "date": "2019-01-22"
+        }
+      }
+    },
+    "vo_ios": {
+      "browsers": {
+        "ios_saf": {
+          "at_version": "12.1",
+          "browser_version": "12.1.2",
+          "os_version": "12.1",
+          "date": "2019-01-22"
+        },
+        "ios_chr": {
+          "at_version": "12.1",
+          "browser_version": "71",
+          "os_version": "12.1",
+          "date": "2019-01-22"
+        }
+      }
+    },
+    "vo_macos": {
+      "browsers": {
+        "safari": {
+          "at_version": "10.14.2",
+          "browser_version": "12.0.2",
+          "os_version": "10.14.2",
+          "date": "2019-01-22"
+        },
+        "chrome": {
+          "at_version": "10.14.2",
+          "browser_version": "71",
+          "os_version": "10.14.2",
+          "date": "2019-01-22"
+        }
+      }
+    }
+  }
 }

--- a/data/tests/tech/html/html_figure/test_6.json
+++ b/data/tests/tech/html/html_figure/test_6.json
@@ -157,10 +157,6 @@
               ]
             },
             "and_ff": {
-              "at_version": "7.2",
-              "browser_version": "63.0.2",
-              "os_version": "8.1",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -252,6 +248,12 @@
         "and_chr": {
           "at_version": "7.2",
           "browser_version": "70",
+          "os_version": "8.1",
+          "date": "2019-01-22"
+        },
+        "and_ff": {
+          "at_version": "7.2",
+          "browser_version": "63.0.2",
           "os_version": "8.1",
           "date": "2019-01-22"
         }

--- a/data/tests/tech/html/html_figure/test_6.json
+++ b/data/tests/tech/html/html_figure/test_6.json
@@ -11,10 +11,6 @@
         "jaws": {
           "browsers": {
             "ie": {
-              "at_version": "2019",
-              "browser_version": "11",
-              "os_version": "1809",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -24,10 +20,6 @@
               ]
             },
             "firefox": {
-              "at_version": "2019",
-              "browser_version": "64.0.2",
-              "os_version": "1809",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -37,10 +29,6 @@
               ]
             },
             "chrome": {
-              "at_version": "2019",
-              "browser_version": "71",
-              "os_version": "1809",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -50,10 +38,6 @@
               ]
             },
             "edge": {
-              "at_version": "2019",
-              "browser_version": "42",
-              "os_version": "1809",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -67,10 +51,6 @@
         "narrator": {
           "browsers": {
             "edge": {
-              "at_version": "1804",
-              "browser_version": "42",
-              "os_version": "1804",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -84,10 +64,6 @@
         "nvda": {
           "browsers": {
             "firefox": {
-              "at_version": "2018.4.1",
-              "browser_version": "64.0.2",
-              "os_version": "1809",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -97,10 +73,6 @@
               ]
             },
             "ie": {
-              "at_version": "2018.4.1",
-              "browser_version": "11",
-              "os_version": "1809",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -110,10 +82,6 @@
               ]
             },
             "chrome": {
-              "at_version": "2018.4.1",
-              "browser_version": "72",
-              "os_version": "1809",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -123,10 +91,6 @@
               ]
             },
             "edge": {
-              "at_version": "2018.4.1",
-              "browser_version": "42",
-              "os_version": "1809",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -140,10 +104,6 @@
         "vo_macos": {
           "browsers": {
             "safari": {
-              "at_version": "10.14.2",
-              "browser_version": "12.0.2",
-              "os_version": "10.14.2",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -153,10 +113,6 @@
               ]
             },
             "chrome": {
-              "at_version": "10.14.2",
-              "browser_version": "71",
-              "os_version": "10.14.2",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -170,10 +126,6 @@
         "vo_ios": {
           "browsers": {
             "ios_saf": {
-              "at_version": "12.1",
-              "browser_version": "12.1.2",
-              "os_version": "12.1",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -183,10 +135,6 @@
               ]
             },
             "ios_chr": {
-              "at_version": "12.1",
-              "browser_version": "71",
-              "os_version": "12.1",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -200,10 +148,6 @@
         "talkback": {
           "browsers": {
             "and_chr": {
-              "at_version": "7.2",
-              "browser_version": "70",
-              "os_version": "8.1",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -235,5 +179,115 @@
       "date": "2019-01-22",
       "message": "Test created. Thank you @scottaohara."
     }
-  ]
+  ],
+  "versions": {
+    "jaws": {
+      "browsers": {
+        "chrome": {
+          "at_version": "2019",
+          "browser_version": "71",
+          "os_version": "1809",
+          "date": "2019-01-22"
+        },
+        "ie": {
+          "at_version": "2019",
+          "browser_version": "11",
+          "os_version": "1809",
+          "date": "2019-01-22"
+        },
+        "firefox": {
+          "at_version": "2019",
+          "browser_version": "64.0.2",
+          "os_version": "1809",
+          "date": "2019-01-22"
+        },
+        "edge": {
+          "at_version": "2019",
+          "browser_version": "42",
+          "os_version": "1809",
+          "date": "2019-01-22"
+        }
+      }
+    },
+    "narrator": {
+      "browsers": {
+        "edge": {
+          "at_version": "1804",
+          "browser_version": "42",
+          "os_version": "1804",
+          "date": "2019-01-22"
+        }
+      }
+    },
+    "nvda": {
+      "browsers": {
+        "chrome": {
+          "at_version": "2018.4.1",
+          "browser_version": "72",
+          "os_version": "1809",
+          "date": "2019-01-22"
+        },
+        "firefox": {
+          "at_version": "2018.4.1",
+          "browser_version": "64.0.2",
+          "os_version": "1809",
+          "date": "2019-01-22"
+        },
+        "ie": {
+          "at_version": "2018.4.1",
+          "browser_version": "11",
+          "os_version": "1809",
+          "date": "2019-01-22"
+        },
+        "edge": {
+          "at_version": "2018.4.1",
+          "browser_version": "42",
+          "os_version": "1809",
+          "date": "2019-01-22"
+        }
+      }
+    },
+    "talkback": {
+      "browsers": {
+        "and_chr": {
+          "at_version": "7.2",
+          "browser_version": "70",
+          "os_version": "8.1",
+          "date": "2019-01-22"
+        }
+      }
+    },
+    "vo_ios": {
+      "browsers": {
+        "ios_saf": {
+          "at_version": "12.1",
+          "browser_version": "12.1.2",
+          "os_version": "12.1",
+          "date": "2019-01-22"
+        },
+        "ios_chr": {
+          "at_version": "12.1",
+          "browser_version": "71",
+          "os_version": "12.1",
+          "date": "2019-01-22"
+        }
+      }
+    },
+    "vo_macos": {
+      "browsers": {
+        "safari": {
+          "at_version": "10.14.2",
+          "browser_version": "12.0.2",
+          "os_version": "10.14.2",
+          "date": "2019-01-22"
+        },
+        "chrome": {
+          "at_version": "10.14.2",
+          "browser_version": "71",
+          "os_version": "10.14.2",
+          "date": "2019-01-22"
+        }
+      }
+    }
+  }
 }

--- a/data/tests/tech/html/html_figure/test_7.json
+++ b/data/tests/tech/html/html_figure/test_7.json
@@ -158,10 +158,6 @@
               ]
             },
             "and_ff": {
-              "at_version": "7.2",
-              "browser_version": "63.0.2",
-              "os_version": "8.1",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -253,6 +249,12 @@
         "and_chr": {
           "at_version": "7.2",
           "browser_version": "70",
+          "os_version": "8.1",
+          "date": "2019-01-22"
+        },
+        "and_ff": {
+          "at_version": "7.2",
+          "browser_version": "63.0.2",
           "os_version": "8.1",
           "date": "2019-01-22"
         }

--- a/data/tests/tech/html/html_figure/test_7.json
+++ b/data/tests/tech/html/html_figure/test_7.json
@@ -11,10 +11,6 @@
         "jaws": {
           "browsers": {
             "ie": {
-              "at_version": "2019",
-              "browser_version": "11",
-              "os_version": "1809",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -24,10 +20,6 @@
               ]
             },
             "firefox": {
-              "at_version": "2019",
-              "browser_version": "64.0.2",
-              "os_version": "1809",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -37,10 +29,6 @@
               ]
             },
             "chrome": {
-              "at_version": "2019",
-              "browser_version": "71",
-              "os_version": "1809",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -50,10 +38,6 @@
               ]
             },
             "edge": {
-              "at_version": "2019",
-              "browser_version": "42",
-              "os_version": "1809",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -67,10 +51,6 @@
         "narrator": {
           "browsers": {
             "edge": {
-              "at_version": "1804",
-              "browser_version": "42",
-              "os_version": "1804",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -85,10 +65,6 @@
         "nvda": {
           "browsers": {
             "firefox": {
-              "at_version": "2018.4.1",
-              "browser_version": "64.0.2",
-              "os_version": "1809",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -98,10 +74,6 @@
               ]
             },
             "ie": {
-              "at_version": "2018.4.1",
-              "browser_version": "11",
-              "os_version": "1809",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -111,10 +83,6 @@
               ]
             },
             "chrome": {
-              "at_version": "2018.4.1",
-              "browser_version": "72",
-              "os_version": "1809",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -124,10 +92,6 @@
               ]
             },
             "edge": {
-              "at_version": "2018.4.1",
-              "browser_version": "42",
-              "os_version": "1809",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -141,10 +105,6 @@
         "vo_macos": {
           "browsers": {
             "safari": {
-              "at_version": "10.14.2",
-              "browser_version": "12.0.2",
-              "os_version": "10.14.2",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -154,10 +114,6 @@
               ]
             },
             "chrome": {
-              "at_version": "10.14.2",
-              "browser_version": "71",
-              "os_version": "10.14.2",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -171,10 +127,6 @@
         "vo_ios": {
           "browsers": {
             "ios_saf": {
-              "at_version": "12.1",
-              "browser_version": "12.1.2",
-              "os_version": "12.1",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -184,10 +136,6 @@
               ]
             },
             "ios_chr": {
-              "at_version": "12.1",
-              "browser_version": "71",
-              "os_version": "12.1",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -201,10 +149,6 @@
         "talkback": {
           "browsers": {
             "and_chr": {
-              "at_version": "7.2",
-              "browser_version": "70",
-              "os_version": "8.1",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -236,5 +180,115 @@
       "date": "2019-01-22",
       "message": "Test created. Thank you @scottaohara."
     }
-  ]
+  ],
+  "versions": {
+    "jaws": {
+      "browsers": {
+        "chrome": {
+          "at_version": "2019",
+          "browser_version": "71",
+          "os_version": "1809",
+          "date": "2019-01-22"
+        },
+        "ie": {
+          "at_version": "2019",
+          "browser_version": "11",
+          "os_version": "1809",
+          "date": "2019-01-22"
+        },
+        "firefox": {
+          "at_version": "2019",
+          "browser_version": "64.0.2",
+          "os_version": "1809",
+          "date": "2019-01-22"
+        },
+        "edge": {
+          "at_version": "2019",
+          "browser_version": "42",
+          "os_version": "1809",
+          "date": "2019-01-22"
+        }
+      }
+    },
+    "narrator": {
+      "browsers": {
+        "edge": {
+          "at_version": "1804",
+          "browser_version": "42",
+          "os_version": "1804",
+          "date": "2019-01-22"
+        }
+      }
+    },
+    "nvda": {
+      "browsers": {
+        "chrome": {
+          "at_version": "2018.4.1",
+          "browser_version": "72",
+          "os_version": "1809",
+          "date": "2019-01-22"
+        },
+        "firefox": {
+          "at_version": "2018.4.1",
+          "browser_version": "64.0.2",
+          "os_version": "1809",
+          "date": "2019-01-22"
+        },
+        "ie": {
+          "at_version": "2018.4.1",
+          "browser_version": "11",
+          "os_version": "1809",
+          "date": "2019-01-22"
+        },
+        "edge": {
+          "at_version": "2018.4.1",
+          "browser_version": "42",
+          "os_version": "1809",
+          "date": "2019-01-22"
+        }
+      }
+    },
+    "talkback": {
+      "browsers": {
+        "and_chr": {
+          "at_version": "7.2",
+          "browser_version": "70",
+          "os_version": "8.1",
+          "date": "2019-01-22"
+        }
+      }
+    },
+    "vo_ios": {
+      "browsers": {
+        "ios_saf": {
+          "at_version": "12.1",
+          "browser_version": "12.1.2",
+          "os_version": "12.1",
+          "date": "2019-01-22"
+        },
+        "ios_chr": {
+          "at_version": "12.1",
+          "browser_version": "71",
+          "os_version": "12.1",
+          "date": "2019-01-22"
+        }
+      }
+    },
+    "vo_macos": {
+      "browsers": {
+        "safari": {
+          "at_version": "10.14.2",
+          "browser_version": "12.0.2",
+          "os_version": "10.14.2",
+          "date": "2019-01-22"
+        },
+        "chrome": {
+          "at_version": "10.14.2",
+          "browser_version": "71",
+          "os_version": "10.14.2",
+          "date": "2019-01-22"
+        }
+      }
+    }
+  }
 }

--- a/data/tests/tech/html/html_figure/test_8.json
+++ b/data/tests/tech/html/html_figure/test_8.json
@@ -11,10 +11,6 @@
         "jaws": {
           "browsers": {
             "ie": {
-              "at_version": "2019",
-              "browser_version": "11",
-              "os_version": "1809",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -25,10 +21,6 @@
               "notes": "fail (figure exposed but no accessible name)"
             },
             "firefox": {
-              "at_version": "2019",
-              "browser_version": "64.0.2",
-              "os_version": "1809",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -38,10 +30,6 @@
               ]
             },
             "chrome": {
-              "at_version": "2019",
-              "browser_version": "71",
-              "os_version": "1809",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -51,10 +39,6 @@
               ]
             },
             "edge": {
-              "at_version": "2019",
-              "browser_version": "42",
-              "os_version": "1809",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -68,10 +52,6 @@
         "narrator": {
           "browsers": {
             "edge": {
-              "at_version": "1804",
-              "browser_version": "42",
-              "os_version": "1804",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -86,10 +66,6 @@
         "nvda": {
           "browsers": {
             "firefox": {
-              "at_version": "2018.4.1",
-              "browser_version": "64.0.2",
-              "os_version": "1809",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -99,10 +75,6 @@
               ]
             },
             "ie": {
-              "at_version": "2018.4.1",
-              "browser_version": "11",
-              "os_version": "1809",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -112,10 +84,6 @@
               ]
             },
             "chrome": {
-              "at_version": "2018.4.1",
-              "browser_version": "72",
-              "os_version": "1809",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -125,10 +93,6 @@
               ]
             },
             "edge": {
-              "at_version": "2018.4.1",
-              "browser_version": "42",
-              "os_version": "1809",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -142,10 +106,6 @@
         "vo_macos": {
           "browsers": {
             "safari": {
-              "at_version": "10.14.2",
-              "browser_version": "12.0.2",
-              "os_version": "10.14.2",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -155,10 +115,6 @@
               ]
             },
             "chrome": {
-              "at_version": "10.14.2",
-              "browser_version": "71",
-              "os_version": "10.14.2",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -172,10 +128,6 @@
         "vo_ios": {
           "browsers": {
             "ios_saf": {
-              "at_version": "12.1",
-              "browser_version": "12.1.2",
-              "os_version": "12.1",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -185,10 +137,6 @@
               ]
             },
             "ios_chr": {
-              "at_version": "12.1",
-              "browser_version": "71",
-              "os_version": "12.1",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -202,10 +150,6 @@
         "talkback": {
           "browsers": {
             "and_chr": {
-              "at_version": "7.2",
-              "browser_version": "70",
-              "os_version": "8.1",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -237,5 +181,115 @@
       "date": "2019-01-22",
       "message": "Test created. Thank you @scottaohara."
     }
-  ]
+  ],
+  "versions": {
+    "jaws": {
+      "browsers": {
+        "chrome": {
+          "at_version": "2019",
+          "browser_version": "71",
+          "os_version": "1809",
+          "date": "2019-01-22"
+        },
+        "ie": {
+          "at_version": "2019",
+          "browser_version": "11",
+          "os_version": "1809",
+          "date": "2019-01-22"
+        },
+        "firefox": {
+          "at_version": "2019",
+          "browser_version": "64.0.2",
+          "os_version": "1809",
+          "date": "2019-01-22"
+        },
+        "edge": {
+          "at_version": "2019",
+          "browser_version": "42",
+          "os_version": "1809",
+          "date": "2019-01-22"
+        }
+      }
+    },
+    "narrator": {
+      "browsers": {
+        "edge": {
+          "at_version": "1804",
+          "browser_version": "42",
+          "os_version": "1804",
+          "date": "2019-01-22"
+        }
+      }
+    },
+    "nvda": {
+      "browsers": {
+        "chrome": {
+          "at_version": "2018.4.1",
+          "browser_version": "72",
+          "os_version": "1809",
+          "date": "2019-01-22"
+        },
+        "firefox": {
+          "at_version": "2018.4.1",
+          "browser_version": "64.0.2",
+          "os_version": "1809",
+          "date": "2019-01-22"
+        },
+        "ie": {
+          "at_version": "2018.4.1",
+          "browser_version": "11",
+          "os_version": "1809",
+          "date": "2019-01-22"
+        },
+        "edge": {
+          "at_version": "2018.4.1",
+          "browser_version": "42",
+          "os_version": "1809",
+          "date": "2019-01-22"
+        }
+      }
+    },
+    "talkback": {
+      "browsers": {
+        "and_chr": {
+          "at_version": "7.2",
+          "browser_version": "70",
+          "os_version": "8.1",
+          "date": "2019-01-22"
+        }
+      }
+    },
+    "vo_ios": {
+      "browsers": {
+        "ios_saf": {
+          "at_version": "12.1",
+          "browser_version": "12.1.2",
+          "os_version": "12.1",
+          "date": "2019-01-22"
+        },
+        "ios_chr": {
+          "at_version": "12.1",
+          "browser_version": "71",
+          "os_version": "12.1",
+          "date": "2019-01-22"
+        }
+      }
+    },
+    "vo_macos": {
+      "browsers": {
+        "safari": {
+          "at_version": "10.14.2",
+          "browser_version": "12.0.2",
+          "os_version": "10.14.2",
+          "date": "2019-01-22"
+        },
+        "chrome": {
+          "at_version": "10.14.2",
+          "browser_version": "71",
+          "os_version": "10.14.2",
+          "date": "2019-01-22"
+        }
+      }
+    }
+  }
 }

--- a/data/tests/tech/html/html_figure/test_8.json
+++ b/data/tests/tech/html/html_figure/test_8.json
@@ -159,10 +159,6 @@
               ]
             },
             "and_ff": {
-              "at_version": "7.2",
-              "browser_version": "63.0.2",
-              "os_version": "8.1",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -254,6 +250,12 @@
         "and_chr": {
           "at_version": "7.2",
           "browser_version": "70",
+          "os_version": "8.1",
+          "date": "2019-01-22"
+        },
+        "and_ff": {
+          "at_version": "7.2",
+          "browser_version": "63.0.2",
           "os_version": "8.1",
           "date": "2019-01-22"
         }

--- a/data/tests/tech/html/html_figure/test_9.json
+++ b/data/tests/tech/html/html_figure/test_9.json
@@ -158,10 +158,6 @@
               ]
             },
             "and_ff": {
-              "at_version": "7.2",
-              "browser_version": "63.0.2",
-              "os_version": "8.1",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -253,6 +249,12 @@
         "and_chr": {
           "at_version": "7.2",
           "browser_version": "70",
+          "os_version": "8.1",
+          "date": "2019-01-22"
+        },
+        "and_ff": {
+          "at_version": "7.2",
+          "browser_version": "63.0.2",
           "os_version": "8.1",
           "date": "2019-01-22"
         }

--- a/data/tests/tech/html/html_figure/test_9.json
+++ b/data/tests/tech/html/html_figure/test_9.json
@@ -11,10 +11,6 @@
         "jaws": {
           "browsers": {
             "ie": {
-              "at_version": "2019",
-              "browser_version": "11",
-              "os_version": "1809",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -24,10 +20,6 @@
               ]
             },
             "firefox": {
-              "at_version": "2019",
-              "browser_version": "64.0.2",
-              "os_version": "1809",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -37,10 +29,6 @@
               ]
             },
             "chrome": {
-              "at_version": "2019",
-              "browser_version": "71",
-              "os_version": "1809",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -50,10 +38,6 @@
               ]
             },
             "edge": {
-              "at_version": "2019",
-              "browser_version": "42",
-              "os_version": "1809",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -67,10 +51,6 @@
         "narrator": {
           "browsers": {
             "edge": {
-              "at_version": "1804",
-              "browser_version": "42",
-              "os_version": "1804",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -85,10 +65,6 @@
         "nvda": {
           "browsers": {
             "firefox": {
-              "at_version": "2018.4.1",
-              "browser_version": "64.0.2",
-              "os_version": "1809",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -98,10 +74,6 @@
               ]
             },
             "ie": {
-              "at_version": "2018.4.1",
-              "browser_version": "11",
-              "os_version": "1809",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -111,10 +83,6 @@
               ]
             },
             "chrome": {
-              "at_version": "2018.4.1",
-              "browser_version": "72",
-              "os_version": "1809",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -124,10 +92,6 @@
               ]
             },
             "edge": {
-              "at_version": "2018.4.1",
-              "browser_version": "42",
-              "os_version": "1809",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -141,10 +105,6 @@
         "vo_macos": {
           "browsers": {
             "safari": {
-              "at_version": "10.14.2",
-              "browser_version": "12.0.2",
-              "os_version": "10.14.2",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -154,10 +114,6 @@
               ]
             },
             "chrome": {
-              "at_version": "10.14.2",
-              "browser_version": "71",
-              "os_version": "10.14.2",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -171,10 +127,6 @@
         "vo_ios": {
           "browsers": {
             "ios_saf": {
-              "at_version": "12.1",
-              "browser_version": "12.1.2",
-              "os_version": "12.1",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -184,10 +136,6 @@
               ]
             },
             "ios_chr": {
-              "at_version": "12.1",
-              "browser_version": "71",
-              "os_version": "12.1",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -201,10 +149,6 @@
         "talkback": {
           "browsers": {
             "and_chr": {
-              "at_version": "7.2",
-              "browser_version": "70",
-              "os_version": "8.1",
-              "date": "2019-01-22",
               "output": [
                 {
                   "command": "next_item",
@@ -236,5 +180,115 @@
       "date": "2019-01-22",
       "message": "Test created. Thank you @scottaohara."
     }
-  ]
+  ],
+  "versions": {
+    "jaws": {
+      "browsers": {
+        "chrome": {
+          "at_version": "2019",
+          "browser_version": "71",
+          "os_version": "1809",
+          "date": "2019-01-22"
+        },
+        "ie": {
+          "at_version": "2019",
+          "browser_version": "11",
+          "os_version": "1809",
+          "date": "2019-01-22"
+        },
+        "firefox": {
+          "at_version": "2019",
+          "browser_version": "64.0.2",
+          "os_version": "1809",
+          "date": "2019-01-22"
+        },
+        "edge": {
+          "at_version": "2019",
+          "browser_version": "42",
+          "os_version": "1809",
+          "date": "2019-01-22"
+        }
+      }
+    },
+    "narrator": {
+      "browsers": {
+        "edge": {
+          "at_version": "1804",
+          "browser_version": "42",
+          "os_version": "1804",
+          "date": "2019-01-22"
+        }
+      }
+    },
+    "nvda": {
+      "browsers": {
+        "chrome": {
+          "at_version": "2018.4.1",
+          "browser_version": "72",
+          "os_version": "1809",
+          "date": "2019-01-22"
+        },
+        "firefox": {
+          "at_version": "2018.4.1",
+          "browser_version": "64.0.2",
+          "os_version": "1809",
+          "date": "2019-01-22"
+        },
+        "ie": {
+          "at_version": "2018.4.1",
+          "browser_version": "11",
+          "os_version": "1809",
+          "date": "2019-01-22"
+        },
+        "edge": {
+          "at_version": "2018.4.1",
+          "browser_version": "42",
+          "os_version": "1809",
+          "date": "2019-01-22"
+        }
+      }
+    },
+    "talkback": {
+      "browsers": {
+        "and_chr": {
+          "at_version": "7.2",
+          "browser_version": "70",
+          "os_version": "8.1",
+          "date": "2019-01-22"
+        }
+      }
+    },
+    "vo_ios": {
+      "browsers": {
+        "ios_saf": {
+          "at_version": "12.1",
+          "browser_version": "12.1.2",
+          "os_version": "12.1",
+          "date": "2019-01-22"
+        },
+        "ios_chr": {
+          "at_version": "12.1",
+          "browser_version": "71",
+          "os_version": "12.1",
+          "date": "2019-01-22"
+        }
+      }
+    },
+    "vo_macos": {
+      "browsers": {
+        "safari": {
+          "at_version": "10.14.2",
+          "browser_version": "12.0.2",
+          "os_version": "10.14.2",
+          "date": "2019-01-22"
+        },
+        "chrome": {
+          "at_version": "10.14.2",
+          "browser_version": "71",
+          "os_version": "10.14.2",
+          "date": "2019-01-22"
+        }
+      }
+    }
+  }
 }

--- a/data/tests/tech/html/table/example_1.json
+++ b/data/tests/tech/html/table/example_1.json
@@ -10,10 +10,6 @@
         "narrator": {
           "browsers": {
             "edge": {
-              "at_version": "1809",
-              "browser_version": "44.17763",
-              "os_version": "1809",
-              "date": "2019-05-03",
               "output": [
                 {
                   "command": "next_item",
@@ -27,10 +23,6 @@
         "nvda": {
           "browsers": {
             "firefox": {
-              "at_version": "2018.2.1",
-              "browser_version": "61.0.1",
-              "os_version": "1803",
-              "date": "2018-07-30",
               "output": [
                 {
                   "command": "next_item",
@@ -40,10 +32,6 @@
               ]
             },
             "chrome": {
-              "at_version": "2018.1808.10",
-              "browser_version": "74",
-              "os_version": "1809",
-              "date": "2019-05-03",
               "output": [
                 {
                   "command": "next_item",
@@ -57,10 +45,6 @@
         "jaws": {
           "browsers": {
             "ie": {
-              "at_version": "2018.1811.2",
-              "browser_version": "11.134",
-              "os_version": "1809",
-              "date": "2019-05-03",
               "output": [
                 {
                   "command": "next_item",
@@ -76,10 +60,6 @@
               "notes": ""
             },
             "firefox": {
-              "at_version": "2018.1811.2",
-              "browser_version": "66",
-              "os_version": "1809",
-              "date": "2019-05-03",
               "output": [
                 {
                   "command": "next_item",
@@ -95,10 +75,6 @@
               "notes": ""
             },
             "chrome": {
-              "at_version": "2018.1811.2",
-              "browser_version": "74",
-              "os_version": "1809",
-              "date": "2019-05-03",
               "output": [
                 {
                   "command": "next_item",
@@ -118,10 +94,6 @@
         "vo_macos": {
           "browsers": {
             "safari": {
-              "at_version": "10.14.4",
-              "browser_version": "12.1",
-              "os_version": "10.14.4",
-              "date": "2019-05-03",
               "output": [
                 {
                   "command": "next_item",
@@ -140,10 +112,6 @@
         "vo_ios": {
           "browsers": {
             "ios_saf": {
-              "at_version": "12.2",
-              "browser_version": "12.2",
-              "os_version": "12.2",
-              "date": "2019-05-01",
               "output": [
                 {
                   "command": "next_item",
@@ -169,10 +137,6 @@
         "narrator": {
           "browsers": {
             "edge": {
-              "at_version": "1809",
-              "browser_version": "44.17763",
-              "os_version": "1809",
-              "date": "2019-05-03",
               "output": [
                 {
                   "command": "next_item",
@@ -211,10 +175,6 @@
         "nvda": {
           "browsers": {
             "firefox": {
-              "at_version": "2018.2.1",
-              "browser_version": "61.0.1",
-              "os_version": "1803",
-              "date": "2018-07-30",
               "output": [
                 {
                   "command": "next_item",
@@ -249,10 +209,6 @@
               ]
             },
             "chrome": {
-              "at_version": "2018.1808.10",
-              "browser_version": "74",
-              "os_version": "1809",
-              "date": "2019-05-03",
               "output": [
                 {
                   "command": "next_item",
@@ -291,10 +247,6 @@
         "jaws": {
           "browsers": {
             "ie": {
-              "at_version": "2018.1811.2",
-              "browser_version": "11.134",
-              "os_version": "1809",
-              "date": "2019-05-03",
               "output": [
                 {
                   "command": "next_item",
@@ -310,10 +262,6 @@
               "notes": ""
             },
             "firefox": {
-              "at_version": "2018.1811.2",
-              "browser_version": "66",
-              "os_version": "1809",
-              "date": "2019-05-03",
               "output": [
                 {
                   "command": "next_item",
@@ -329,10 +277,6 @@
               "notes": ""
             },
             "chrome": {
-              "at_version": "2018.1811.2",
-              "browser_version": "74",
-              "os_version": "1809",
-              "date": "2019-05-03",
               "output": [
                 {
                   "command": "next_item",
@@ -352,10 +296,6 @@
         "vo_macos": {
           "browsers": {
             "safari": {
-              "at_version": "10.14.4",
-              "browser_version": "12.1",
-              "os_version": "10.14.4",
-              "date": "2019-05-03",
               "output": [
                 {
                   "command": "next_item",
@@ -374,10 +314,6 @@
         "vo_ios": {
           "browsers": {
             "ios_saf": {
-              "at_version": "12.2",
-              "browser_version": "12.2",
-              "os_version": "12.2",
-              "date": "2019-05-01",
               "output": [
                 {
                   "command": "next_item",
@@ -404,10 +340,6 @@
         "narrator": {
           "browsers": {
             "edge": {
-              "at_version": "1809",
-              "browser_version": "44.17763",
-              "os_version": "1809",
-              "date": "2019-05-03",
               "output": [
                 {
                   "command": "table_move_to_next_column",
@@ -426,10 +358,6 @@
         "nvda": {
           "browsers": {
             "firefox": {
-              "at_version": "2018.2.1",
-              "browser_version": "61.0.1",
-              "os_version": "1803",
-              "date": "2018-07-30",
               "output": [
                 {
                   "command": "table_move_to_next_column",
@@ -444,10 +372,6 @@
               ]
             },
             "chrome": {
-              "at_version": "2018.1808.10",
-              "browser_version": "74",
-              "os_version": "1809",
-              "date": "2019-05-03",
               "output": [
                 {
                   "command": "table_move_to_next_column",
@@ -466,10 +390,6 @@
         "jaws": {
           "browsers": {
             "ie": {
-              "at_version": "2018.1811.2",
-              "browser_version": "11.134",
-              "os_version": "1809",
-              "date": "2019-05-03",
               "output": [
                 {
                   "command": "table_move_to_next_column",
@@ -485,10 +405,6 @@
               "notes": ""
             },
             "firefox": {
-              "at_version": "2018.1811.2",
-              "browser_version": "66",
-              "os_version": "1809",
-              "date": "2019-05-03",
               "output": [
                 {
                   "command": "table_move_to_next_column",
@@ -504,10 +420,6 @@
               "notes": ""
             },
             "chrome": {
-              "at_version": "2018.1811.2",
-              "browser_version": "74",
-              "os_version": "1809",
-              "date": "2019-05-03",
               "output": [
                 {
                   "command": "table_move_to_next_column",
@@ -527,10 +439,6 @@
         "vo_macos": {
           "browsers": {
             "safari": {
-              "at_version": "10.14.4",
-              "browser_version": "12.1",
-              "os_version": "10.14.4",
-              "date": "2019-05-03",
               "output": [
                 {
                   "command": "table_move_to_next_column",
@@ -549,10 +457,6 @@
         "vo_ios": {
           "browsers": {
             "ios_saf": {
-              "at_version": "12.2",
-              "browser_version": "12.2",
-              "os_version": "12.2",
-              "date": "2019-05-01",
               "output": [
                 {
                   "command": "next_item",
@@ -588,10 +492,6 @@
         "narrator": {
           "browsers": {
             "edge": {
-              "at_version": "1809",
-              "browser_version": "44.17763",
-              "os_version": "1809",
-              "date": "2019-05-03",
               "output": [
                 {
                   "command": "table_move_to_next_row",
@@ -620,10 +520,6 @@
         "nvda": {
           "browsers": {
             "firefox": {
-              "at_version": "2018.2.1",
-              "browser_version": "61.0.1",
-              "os_version": "1803",
-              "date": "2018-07-30",
               "output": [
                 {
                   "command": "table_move_to_next_row",
@@ -648,10 +544,6 @@
               ]
             },
             "chrome": {
-              "at_version": "2018.1808.10",
-              "browser_version": "74",
-              "os_version": "1809",
-              "date": "2019-05-03",
               "output": [
                 {
                   "command": "table_move_to_next_row",
@@ -680,10 +572,6 @@
         "jaws": {
           "browsers": {
             "ie": {
-              "at_version": "2018.1811.2",
-              "browser_version": "11.134",
-              "os_version": "1809",
-              "date": "2019-05-03",
               "output": [
                 {
                   "command": "table_move_to_next_row",
@@ -709,10 +597,6 @@
               "notes": ""
             },
             "firefox": {
-              "at_version": "2018.1811.2",
-              "browser_version": "66",
-              "os_version": "1809",
-              "date": "2019-05-03",
               "output": [
                 {
                   "command": "table_move_to_next_row",
@@ -738,10 +622,6 @@
               "notes": ""
             },
             "chrome": {
-              "at_version": "2018.1811.2",
-              "browser_version": "74",
-              "os_version": "1809",
-              "date": "2019-05-03",
               "output": [
                 {
                   "command": "table_move_to_next_row",
@@ -771,10 +651,6 @@
         "vo_macos": {
           "browsers": {
             "safari": {
-              "at_version": "10.14.4",
-              "browser_version": "12.1",
-              "os_version": "10.14.4",
-              "date": "2019-05-03",
               "output": [
                 {
                   "command": "table_move_to_next_column",
@@ -793,10 +669,6 @@
         "vo_ios": {
           "browsers": {
             "ios_saf": {
-              "at_version": "12.2",
-              "browser_version": "12.2",
-              "os_version": "12.2",
-              "date": "2019-05-01",
               "output": [
                 {
                   "command": "next_item",
@@ -822,10 +694,6 @@
         "narrator": {
           "browsers": {
             "edge": {
-              "at_version": "1809",
-              "browser_version": "44.17763",
-              "os_version": "1809",
-              "date": "2019-05-03",
               "output": [
                 {
                   "command": "table_move_to_next_column",
@@ -854,10 +722,6 @@
         "nvda": {
           "browsers": {
             "firefox": {
-              "at_version": "2018.2.1",
-              "browser_version": "61.0.1",
-              "os_version": "1803",
-              "date": "2018-07-30",
               "output": [
                 {
                   "command": "table_move_to_next_column",
@@ -882,10 +746,6 @@
               ]
             },
             "chrome": {
-              "at_version": "2018.1808.10",
-              "browser_version": "74",
-              "os_version": "1809",
-              "date": "2019-05-03",
               "output": [
                 {
                   "command": "table_move_to_next_column",
@@ -914,10 +774,6 @@
         "jaws": {
           "browsers": {
             "ie": {
-              "at_version": "2018.1811.2",
-              "browser_version": "11.134",
-              "os_version": "1809",
-              "date": "2019-05-03",
               "output": [
                 {
                   "command": "table_move_to_next_column",
@@ -943,10 +799,6 @@
               "notes": ""
             },
             "firefox": {
-              "at_version": "2018.1811.2",
-              "browser_version": "66",
-              "os_version": "1809",
-              "date": "2019-05-03",
               "output": [
                 {
                   "command": "table_move_to_next_column",
@@ -972,10 +824,6 @@
               "notes": ""
             },
             "chrome": {
-              "at_version": "2018.1811.2",
-              "browser_version": "74",
-              "os_version": "1809",
-              "date": "2019-05-03",
               "output": [
                 {
                   "command": "table_move_to_next_column",
@@ -1005,10 +853,6 @@
         "vo_macos": {
           "browsers": {
             "safari": {
-              "at_version": "10.14.4",
-              "browser_version": "12.1",
-              "os_version": "10.14.4",
-              "date": "2019-05-03",
               "output": [
                 {
                   "command": "table_move_to_next_column",
@@ -1037,10 +881,6 @@
         "vo_ios": {
           "browsers": {
             "ios_saf": {
-              "at_version": "12.2",
-              "browser_version": "12.2",
-              "os_version": "12.2",
-              "date": "2019-05-01",
               "output": [
                 {
                   "command": "table_move_to_next_column",
@@ -1076,10 +916,6 @@
         "narrator": {
           "browsers": {
             "edge": {
-              "at_version": "1809",
-              "browser_version": "44.17763",
-              "os_version": "1809",
-              "date": "2019-05-03",
               "output": [
                 {
                   "command": "previous_item",
@@ -1103,10 +939,6 @@
         "nvda": {
           "browsers": {
             "firefox": {
-              "at_version": "2018.2.1",
-              "browser_version": "61.0.1",
-              "os_version": "1803",
-              "date": "2018-07-30",
               "output": [
                 {
                   "command": "previous_item",
@@ -1126,10 +958,6 @@
               ]
             },
             "chrome": {
-              "at_version": "2018.1808.10",
-              "browser_version": "74",
-              "os_version": "1809",
-              "date": "2019-05-03",
               "output": [
                 {
                   "command": "previous_item",
@@ -1153,10 +981,6 @@
         "jaws": {
           "browsers": {
             "ie": {
-              "at_version": "2018.1811.2",
-              "browser_version": "11.134",
-              "os_version": "1809",
-              "date": "2019-05-03",
               "output": [
                 {
                   "command": "previous_item",
@@ -1177,10 +1001,6 @@
               "notes": ""
             },
             "firefox": {
-              "at_version": "2018.1811.2",
-              "browser_version": "66",
-              "os_version": "1809",
-              "date": "2019-05-03",
               "output": [
                 {
                   "command": "previous_item",
@@ -1201,10 +1021,6 @@
               "notes": ""
             },
             "chrome": {
-              "at_version": "2018.1811.2",
-              "browser_version": "74",
-              "os_version": "1809",
-              "date": "2019-05-03",
               "output": [
                 {
                   "command": "previous_item",
@@ -1229,10 +1045,6 @@
         "vo_macos": {
           "browsers": {
             "safari": {
-              "at_version": "10.14.4",
-              "browser_version": "12.1",
-              "os_version": "10.14.4",
-              "date": "2019-05-03",
               "output": [
                 {
                   "command": "previous_item",
@@ -1256,10 +1068,6 @@
         "vo_ios": {
           "browsers": {
             "ios_saf": {
-              "at_version": "12.2",
-              "browser_version": "12.2",
-              "os_version": "12.2",
-              "date": "2019-05-01",
               "output": [
                 {
                   "command": "previous_item",
@@ -1290,10 +1098,6 @@
         "narrator": {
           "browsers": {
             "edge": {
-              "at_version": "1809",
-              "browser_version": "44.17763",
-              "os_version": "1809",
-              "date": "2019-05-03",
               "output": [
                 {
                   "command": "table_move_to_next_column",
@@ -1322,10 +1126,6 @@
         "nvda": {
           "browsers": {
             "firefox": {
-              "at_version": "2018.2.1",
-              "browser_version": "61.0.1",
-              "os_version": "1803",
-              "date": "2018-07-30",
               "output": [
                 {
                   "command": "table_move_to_next_column",
@@ -1350,10 +1150,6 @@
               ]
             },
             "chrome": {
-              "at_version": "2018.1808.10",
-              "browser_version": "74",
-              "os_version": "1809",
-              "date": "2019-05-03",
               "output": [
                 {
                   "command": "table_move_to_next_column",
@@ -1382,10 +1178,6 @@
         "jaws": {
           "browsers": {
             "ie": {
-              "at_version": "2018.1811.2",
-              "browser_version": "11.134",
-              "os_version": "1809",
-              "date": "2019-05-03",
               "output": [
                 {
                   "command": "table_move_to_next_column",
@@ -1411,10 +1203,6 @@
               "notes": ""
             },
             "firefox": {
-              "at_version": "2018.1811.2",
-              "browser_version": "66",
-              "os_version": "1809",
-              "date": "2019-05-03",
               "output": [
                 {
                   "command": "table_move_to_next_column",
@@ -1440,10 +1228,6 @@
               "notes": ""
             },
             "chrome": {
-              "at_version": "2018.1811.2",
-              "browser_version": "74",
-              "os_version": "1809",
-              "date": "2019-05-03",
               "output": [
                 {
                   "command": "table_move_to_next_column",
@@ -1473,10 +1257,6 @@
         "vo_macos": {
           "browsers": {
             "safari": {
-              "at_version": "10.14.4",
-              "browser_version": "12.1",
-              "os_version": "10.14.4",
-              "date": "2019-05-03",
               "output": [
                 {
                   "command": "table_move_to_next_column",
@@ -1505,10 +1285,6 @@
         "vo_ios": {
           "browsers": {
             "ios_saf": {
-              "at_version": "12.2",
-              "browser_version": "12.2",
-              "os_version": "12.2",
-              "date": "2019-05-01",
               "output": [
                 {
                   "command": "next_item",
@@ -1533,5 +1309,75 @@
       "date": "2019-05-10",
       "message": "Test created"
     }
-  ]
+  ],
+  "versions": {
+    "jaws": {
+      "browsers": {
+        "chrome": {
+          "at_version": "2018.1811.2",
+          "browser_version": "74",
+          "os_version": "1809",
+          "date": "2019-05-03"
+        },
+        "ie": {
+          "at_version": "2018.1811.2",
+          "browser_version": "11.134",
+          "os_version": "1809",
+          "date": "2019-05-03"
+        },
+        "firefox": {
+          "at_version": "2018.1811.2",
+          "browser_version": "66",
+          "os_version": "1809",
+          "date": "2019-05-03"
+        }
+      }
+    },
+    "narrator": {
+      "browsers": {
+        "edge": {
+          "at_version": "1809",
+          "browser_version": "44.17763",
+          "os_version": "1809",
+          "date": "2019-05-03"
+        }
+      }
+    },
+    "nvda": {
+      "browsers": {
+        "chrome": {
+          "at_version": "2018.1808.10",
+          "browser_version": "74",
+          "os_version": "1809",
+          "date": "2019-05-03"
+        },
+        "firefox": {
+          "at_version": "2018.2.1",
+          "browser_version": "61.0.1",
+          "os_version": "1803",
+          "date": "2018-07-30"
+        }
+      }
+    },
+    "vo_ios": {
+      "browsers": {
+        "ios_saf": {
+          "at_version": "12.2",
+          "browser_version": "12.2",
+          "os_version": "12.2",
+          "date": "2019-05-01"
+        }
+      }
+    },
+    "vo_macos": {
+      "browsers": {
+        "safari": {
+          "at_version": "10.14.4",
+          "browser_version": "12.1",
+          "os_version": "10.14.4",
+          "date": "2019-05-03"
+        }
+      }
+    }
+  }
 }

--- a/data/tests/tech/html/table/example_1.json
+++ b/data/tests/tech/html/table/example_1.json
@@ -883,22 +883,12 @@
             "ios_saf": {
               "output": [
                 {
-                  "command": "table_move_to_next_column",
+                  "command": "next_item",
                   "output": "(position information is announced as column and rows are changed)",
                   "result": "pass"
                 },
                 {
-                  "command": "table_move_to_previous_column",
-                  "output": "(position information is announced as column and rows are changed)",
-                  "result": "pass"
-                },
-                {
-                  "command": "table_move_to_next_row",
-                  "output": "(position information is announced as column and rows are changed)",
-                  "result": "pass"
-                },
-                {
-                  "command": "table_move_to_previous_row",
+                  "command": "previous_item",
                   "output": "(position information is announced as column and rows are changed)",
                   "result": "pass"
                 }
@@ -1070,17 +1060,12 @@
             "ios_saf": {
               "output": [
                 {
+                  "command": "next_item",
+                  "output": "(no header semantics surfaced, which implies that this is a cell)",
+                  "result": "pass"
+                },
+                {
                   "command": "previous_item",
-                  "output": "(no header semantics surfaced, which implies that this is a cell)",
-                  "result": "pass"
-                },
-                {
-                  "command": "table_move_to_next_column",
-                  "output": "(no header semantics surfaced, which implies that this is a cell)",
-                  "result": "pass"
-                },
-                {
-                  "command": "table_move_to_next_row",
                   "output": "(no header semantics surfaced, which implies that this is a cell)",
                   "result": "pass"
                 }

--- a/documentation/architecture.md
+++ b/documentation/architecture.md
@@ -30,10 +30,9 @@ Details of the grading method and a high level overview of the project include:
 * A single AT/browser combination can have many output results.
 * During the build process, output results are bubbled to:
     * The browser object `test.assertions[0].results.nvda.browsers.firefox.support`. Values are mapped to one of `y` (support='yes'), `n` (support='no'), or `p` (support='partial').
-        * If all output results were `pass`, then output maps to `y`.
-        * If all output results were `partial`, then output maps to `p`.
-        * If no output results passed, then output maps to `n`.
-        * If there was a mix of values, map to `parital`.
+        * If one output results were `pass`, then support maps to `y`.
+        * If some output results were `partial`, then support maps to `p`.
+        * If no output results passed, then support maps to `n`.
     * The AT object `test.assertions[0].results.nvda.core_support` and `test.assertions[0].results.nvda.extended_support` (which includes unique support values for all browsers)
     * The test assertion `test.assertions[0].core_support` and `test.assertions[0].extended_support`, 
     * The test object `test.core_support` and `test.extended_support` which include unique support values for all at
@@ -207,6 +206,15 @@ The `output` object contains the following properties which can be provided by t
 * `command` (string|required): The ID of the command used to navigate or trigger the element that matches the css target. These IDs match those found in the [/data/ATBrowsers.json](https://github.com/accessibilitysupported/a11ysupport.io/blob/master/data/ATBrowsers.json) array of commands for the current AT.
 * `output` (string|required): the output of the result.
 * `result` (enum|required): One of `pass`, `fail`, or `partial`.
+
+#### the `versions` object (`at_version` and `browser_version`)
+
+The `versions` object defines the AT, browser, os and date values used while testing. The structure of the object replicates the general structure of the `results` object to simplify programmatic access. For example, the version information for NVDA/Firefox can be found at `test.versions.nvda.browsers.firefox`. Every time a test is tested, all assertions for the at/browser combination must be tested and updated.
+
+* `at_version` (string|required): the version of the AT used during the test
+* `browser_version` (string|required): the version of the browser used during the test
+* `os_version` (string|required): the version of the OS used during the test. The OS name can be inferred.
+* `date` (string|required): the date that this at/browser combination was last tested.
 
 ## Build process
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "start": "node ./bin/www",
-    "test": "mocha",
+    "test": "mocha --reporter progress",
     "build": "node ./build.js"
   },
   "dependencies": {

--- a/test.js
+++ b/test.js
@@ -165,7 +165,7 @@ describe('spMdToObject()', function() {
 		"== end notes ==";
 
 	let spMdToObject = require(__dirname+'/src/sp-md-to-obj.js');
-console.log(body);
+
 	let result = spMdToObject(body);
 	let moment = require('moment');
 	let currentDateString = moment().format('YYYY-MM-DD');

--- a/test.js
+++ b/test.js
@@ -1,5 +1,6 @@
 let expect = require('chai').expect;
 let fs = require('fs');
+let glob = require('glob');
 const Ajv = require('ajv');
 let ajv = new Ajv({
 	useDefaults: true,
@@ -16,19 +17,16 @@ let tech = require(buildDir+"/tech.json");
 let ATBrowsers = require(devDir+'/ATBrowsers.json');
 
 describe('Development tests', function () {
-	let testFiles = fs.readdirSync(devDir+'/tests');
+	let testFiles = glob.sync(devDir+'/tests/**/*.json');
 
-	testFiles.forEach(function (file) {
-
-		if (!file.endsWith('aria-haspopup_attribute.json')) {
-			return;
-		}
-
+	testFiles.forEach(function(file) {
 		if (!file.endsWith('.json')) {
 			return;
 		}
 
-        let test = require(devDir + '/tests/' + file);
+		// load the test
+		let test = require(file);
+
 		it(file + ' should conform to the dev-test schema', function () {
 			let valid = ajv.validate('http://accessibilitysupported.com/dev-test.json', test);
 			if (!valid) {
@@ -37,30 +35,35 @@ describe('Development tests', function () {
 			expect(valid).to.be.equal(true);
 		});
 
-		describe(file + ' features', function() {
-			for (let i=0; i < test.features.length; i++) {
-				it(devDir+'/tech/'+test.features[i] + '.json should exist', function () {
-					let exists = fs.existsSync(devDir+'/tech/'+test.features[i]+'.json');
-					expect(exists).to.be.equal(true);
-				});
-			}
-		});
+		test.assertions.forEach(assertion => {
+			it(devDir+'/tech/'+assertion.feature_id + '.json should exist', function () {
+				let exists = fs.existsSync(devDir+'/tech/'+assertion.feature_id+'.json');
+				expect(exists).to.be.equal(true);
+			});
 
-		let at_keys = Object.getOwnPropertyNames(test.results);
-		at_keys.forEach(function(at_id) {
-			let browser_keys = Object.getOwnPropertyNames(test.results[at_id].browsers);
-			browser_keys.forEach(function(browser_key) {
-				if (!test.results[at_id].browsers[browser_key].output) {
-					return;
-				}
-				test.results[at_id].browsers[browser_key].output.forEach(function(output, index) {
-					it(at_id + '.' + browser_key + '.output['+index+'].command should be valid', function() {
-                        expect(ATBrowsers.at[at_id].commands[output.command]).to.be.not.undefined;
-					})
+			if (!assertion.results) {
+				return;
+			}
+
+			let at_keys = Object.getOwnPropertyNames(assertion.results);
+			at_keys.forEach(function(at_id) {
+				let browser_keys = Object.getOwnPropertyNames(assertion.results[at_id].browsers);
+				browser_keys.forEach(function(browser_key) {
+					if (!assertion.results[at_id].browsers[browser_key].output) {
+						return;
+					}
+					assertion.results[at_id].browsers[browser_key].output.forEach(function(output, index) {
+						it(at_id + '.' + browser_key + '.output['+index+'].command should be valid: ' + output.command, function() {
+							expect(ATBrowsers.at[at_id].commands[output.command]).to.be.not.undefined;
+						})
+
+						it(at_id + '.browsers.' + browser_key + ' must have a version object defined: ' + file, function() {
+							expect(test.versions[at_id].browsers[browser_key]).to.be.not.undefined;
+						})
+					});
 				});
 			});
 		});
-
 	});
 });
 

--- a/views/test-case-support-point.pug
+++ b/views/test-case-support-point.pug
@@ -30,16 +30,19 @@ block content
                         a(href="/learn/at/"+atId)=ATBrowsers.at[atId].title
                 tr
                     th(scope="row") AT Version
-                    td= assertion.results[atId].browsers[browserId].at_version
+                    td= test.versions[atId].browsers[browserId].at_version
                 tr
                     th(scope="row") Browser Name
                     td= ATBrowsers.browsers[browserId].title
                 tr
                     th(scope="row") Browser Version
-                    td= assertion.results[atId].browsers[browserId].browser_version
+                    td= test.versions[atId].browsers[browserId].browser_version
                 tr
                     th(scope="row") OS version
-                    td= assertion.results[atId].browsers[browserId].os_version
+                    td= test.versions[atId].browsers[browserId].os_version
+                tr
+                    th(scope="row") Date
+                    td= test.versions[atId].browsers[browserId].date
                 tr
                     th(scope="row") Notes
                     td!= assertion.results[atId].browsers[browserId].notes ? md.render(assertion.results[atId].browsers[browserId].notes) : ''

--- a/views/test-case.pug
+++ b/views/test-case.pug
@@ -103,11 +103,11 @@ block content
                             each browser in ATBrowsers.at[at].core_browsers
                                 tr
                                     td= ATBrowsers.at[at].title
-                                        if assertion.results[at].browsers[browser].at_version
-                                            span= ' ' + assertion.results[at].browsers[browser].at_version
+                                        if test.versions[at] && test.versions[at].browsers[browser] && test.versions[at].browsers[browser].at_version
+                                            span= ' ' + test.versions[at].browsers[browser].at_version
                                     td= ATBrowsers.browsers[browser].title
-                                        if assertion.results[at].browsers[browser].browser_version
-                                            span= ' ' + assertion.results[at].browsers[browser].browser_version
+                                        if test.versions[at] && test.versions[at].browsers[browser] && test.versions[at].browsers[browser].browser_version
+                                            span= ' ' + test.versions[at].browsers[browser].browser_version
                                     td(class='support-case ' + assertion.results[at].browsers[browser].support)= assertion.results[at].browsers[browser].support_string
                                     td
                                         if (assertion.results[at].browsers[browser].output)
@@ -164,11 +164,11 @@ block content
                                 each browser in browsers
                                     tr
                                         td= at.title
-                                            if assertion.results[at.id].browsers[browser].at_version
-                                                span= ' ' + assertion.results[at.id].browsers[browser].at_version
+                                            if test.versions[at.id] && test.versions[at.id].browsers[browser] && test.versions[at.id].browsers[browser].at_version
+                                                span= ' ' + test.versions[at.id].browsers[browser].at_version
                                         td= ATBrowsers.browsers[browser].title
-                                            if assertion.results[at.id].browsers[browser].browser_version
-                                                span= ' ' + assertion.results[at.id].browsers[browser].browser_version
+                                            if test.versions[at.id] && test.versions[at.id].browsers[browser] && test.versions[at.id].browsers[browser].browser_version
+                                                span= ' ' + test.versions[at.id].browsers[browser].browser_version
                                         td(class='support-case ' + assertion.results[at.id].browsers[browser].support)= assertion.results[at.id].browsers[browser].support_string
                                         td
                                             if (assertion.results[at.id].browsers[browser].output)


### PR DESCRIPTION
Before this PR, versions were tracked on every output row. This resulted in the same AT, browser, and OS versions being recorded many times for many assertions within the same test. That's lot's of redundant information that wasn't very useful. In practice, a tester would re-run an entire test against a given AT/browser combo, so it is neededless to track the information at such a granular level. It's better to just record the latest at/browser/os versions in one place for a test.

This updates the schema, documentation, unit tests, and testing data accordingly. This also fixes a few issues with unit testing.