### PR TITLE
Add vc_ios as an extended at

### DIFF
--- a/data/ATBrowsers.json
+++ b/data/ATBrowsers.json
@@ -16,7 +16,7 @@
         "activate_name": {
           "command": "\"Click <text>\"",
           "name": "Activate item by name",
-          "note": "If there are multiple choices with the same text, they will be labeled by numbers. Say \"Choose <number>\" to finish.",
+          "note": "If there are multiple choices with the same text, they the first one on the screen will be clicked. To disambiguate, use the \"click <role>\" command.",
           "tags": [
             "general",
             "vc"
@@ -33,7 +33,7 @@
         "activate_role": {
           "command": "Click <role>",
           "name": "Click Type",
-          "note": "where role is \"link\", \"button\", \"text field\", \"image\", \"Check box\", \"Radio Button\", etc. Dragon will then flag each matching element with a number. Say \"choose <number>\" to finish.",
+          "note": "where role is \"link\", \"button\", \"text field\", \"image\", \"Check box\", \"Radio Button\", etc. If there are multiple instances of the role, Dragon will then flag each matching element with a number. Say \"choose <number>\" to finish.",
           "tags": [
             "general",
             "vc"

--- a/data/ATBrowsers.json
+++ b/data/ATBrowsers.json
@@ -13,9 +13,9 @@
       "url": "https://www.nuance.com/dragon.html",
       "description": "http://www.nuance.com/support/dragon-naturallyspeaking/index.htm?link_name=technical_support#dr_support_contact",
       "commands": {
-        "activate_actionable_item": {
+        "activate_name": {
           "command": "\"Click <text>\"",
-          "name": "Activate actionable item",
+          "name": "Activate item by name",
           "note": "If there are multiple choices with the same text, they will be labeled by numbers. Say \"Choose <number>\" to finish.",
           "tags": [
             "general",
@@ -30,10 +30,10 @@
             "vc"
           ]
         },
-        "click_type": {
-          "command": "Click <type>",
+        "activate_role": {
+          "command": "Click <role>",
           "name": "Click Type",
-          "note": "where type is \"link\", \"button\", \"text field\", \"image\", \"Check box\", \"Radio Button\", etc. Dragon will then flag each matching element with a number. Say \"choose <number>\" to finish.",
+          "note": "where role is \"link\", \"button\", \"text field\", \"image\", \"Check box\", \"Radio Button\", etc. Dragon will then flag each matching element with a number. Say \"choose <number>\" to finish.",
           "tags": [
             "general",
             "vc"

--- a/data/ATBrowsers.json
+++ b/data/ATBrowsers.json
@@ -1,6 +1,6 @@
 {
   "core_at": ["dragon_win", "jaws", "narrator", "nvda", "talkback", "vo_ios", "vo_macos", "orca"],
-  "extended_at": ["dragon_mac"],
+  "extended_at": ["dragon_mac", "vc_ios"],
   "at": {
     "dragon_win": {
       "id": "dragon_win",
@@ -2921,6 +2921,93 @@
           "name": "Open Orca settings",
           "tags": [
             "general"
+          ]
+        }
+      }
+    },
+    "vc_ios": {
+      "id": "vc_ios",
+      "type": "vc",
+      "title": "Voice Control for iOS",
+      "short_title": "VC iOS",
+      "os": "iOS",
+      "core_browsers": ["ios_saf"],
+      "extended_browsers": [],
+      "url": "https://support.apple.com/guide/iphone/voice-control-iph2c21a3c88/ios",
+      "description": "",
+      "commands": {
+        "activate_name": {
+          "command": "\"Tap <text>\"",
+          "name": "Activate item by name",
+          "note": "If there are multiple choices with the same text, they will be labeled by numbers. Say \"Choose <number>\" to finish.",
+          "tags": [
+            "general",
+            "vc"
+          ]
+        },
+        "choose_number": {
+          "command": "\"Choose <number>\"",
+          "name": "Activate item by number",
+          "tags": [
+            "general",
+            "vc"
+          ]
+        },
+        "show_names": {
+          "command": "\"Show names\"",
+          "name": "Turn on the names overlay",
+          "tags": [
+            "general",
+            "vc"
+          ]
+        },
+        "hide_names": {
+          "command": "\"Hide names\"",
+          "name": "Hide the names overlay",
+          "tags": [
+            "general",
+            "vc"
+          ]
+        },
+        "show_numbers": {
+          "command": "\"Show numbers\"",
+          "name": "Turn on the numbers overlay",
+          "tags": [
+            "general",
+            "vc"
+          ]
+        },
+        "hide_numbers": {
+          "command": "\"Hide numbers\"",
+          "name": "Hide the numbers overlay",
+          "tags": [
+            "general",
+            "vc"
+          ]
+        },
+        "show_grid": {
+          "command": "\"Show grid\"",
+          "name": "Turn on the grid overlay",
+          "tags": [
+            "general",
+            "vc"
+          ]
+        },
+        "hide_grid": {
+          "command": "\"Hide grid\"",
+          "name": "Hide the grid overlay",
+          "tags": [
+            "general",
+            "vc"
+          ]
+        },
+        "show_hints": {
+          "command": "Show hints",
+          "name": "Show hints",
+          "note": "See command suggestions and hints",
+          "tags": [
+            "general",
+            "vc"
           ]
         }
       }

--- a/data/latest_versions.json
+++ b/data/latest_versions.json
@@ -3,7 +3,7 @@
     "browsers": {
       "chrome": {
         "at_version": "15.30",
-        "browser_version": "76",
+        "browser_version": "77",
         "os_version": "1903",
         "date": "--enter date--"
       }
@@ -13,7 +13,7 @@
     "browsers": {
       "chrome": {
         "at_version": "2019.1907.42",
-        "browser_version": "76",
+        "browser_version": "77",
         "os_version": "1903",
         "date": "--enter date--"
       },
@@ -45,7 +45,7 @@
     "browsers": {
       "chrome": {
         "at_version": "2019.2",
-        "browser_version": "76",
+        "browser_version": "77",
         "os_version": "1903",
         "date": "--enter date--"
       },
@@ -71,7 +71,7 @@
     "browsers": {
       "and_chr": {
         "at_version": "7.3.0",
-        "browser_version": "76",
+        "browser_version": "77",
         "os_version": "9",
         "date": "--enter date--"
       }
@@ -80,9 +80,9 @@
   "vo_ios": {
     "browsers": {
       "ios_saf": {
-        "at_version": "12.4.1",
-        "browser_version": "12.4.1",
-        "os_version": "12.4.1",
+        "at_version": "13.0",
+        "browser_version": "13.0",
+        "os_version": "13.0",
         "date": "--enter date--"
       }
     }
@@ -91,7 +91,7 @@
     "browsers": {
       "safari": {
         "at_version": "10.14.6",
-        "browser_version": "12.1.2",
+        "browser_version": "13.0",
         "os_version": "10.14.6",
         "date": "--enter date--"
       }

--- a/data/latest_versions.json
+++ b/data/latest_versions.json
@@ -96,5 +96,15 @@
         "date": "--enter date--"
       }
     }
+  },
+  "vc_ios": {
+    "browsers": {
+      "ios_saf": {
+        "at_version": "13.0",
+        "browser_version": "13.0",
+        "os_version": "13.0",
+        "date": "--enter date--"
+      }
+    }
   }
 }

--- a/data/tests/html_label_element_css_content.json
+++ b/data/tests/html_label_element_css_content.json
@@ -184,7 +184,7 @@
             "chrome": {
               "output": [
                 {
-                  "command": "activate_actionable_item",
+                  "command": "activate_name",
                   "output": "(input was not focused)",
                   "result": "fail"
                 }
@@ -193,7 +193,7 @@
             "ie": {
               "output": [
                 {
-                  "command": "activate_actionable_item",
+                  "command": "activate_name",
                   "output": "(input was not focused)",
                   "result": "fail"
                 }
@@ -203,7 +203,7 @@
             "firefox": {
               "output": [
                 {
-                  "command": "activate_actionable_item",
+                  "command": "activate_name",
                   "output": "(input was not focused)",
                   "result": "fail"
                 }

--- a/data/tests/html_label_element_explicit.json
+++ b/data/tests/html_label_element_explicit.json
@@ -179,7 +179,7 @@
             "chrome": {
               "output": [
                 {
-                  "command": "activate_actionable_item",
+                  "command": "activate_name",
                   "output": "(input was focused)",
                   "result": "pass"
                 }
@@ -189,7 +189,7 @@
             "ie": {
               "output": [
                 {
-                  "command": "activate_actionable_item",
+                  "command": "activate_name",
                   "output": "(input was focused)",
                   "result": "pass"
                 }
@@ -199,7 +199,7 @@
             "firefox": {
               "output": [
                 {
-                  "command": "activate_actionable_item",
+                  "command": "activate_name",
                   "output": "(input was focused)",
                   "result": "pass"
                 }

--- a/data/tests/html_label_element_implicit.json
+++ b/data/tests/html_label_element_implicit.json
@@ -179,7 +179,7 @@
             "chrome": {
               "output": [
                 {
-                  "command": "activate_actionable_item",
+                  "command": "activate_name",
                   "output": "(input was not focused)",
                   "result": "fail"
                 }
@@ -189,7 +189,7 @@
             "ie": {
               "output": [
                 {
-                  "command": "activate_actionable_item",
+                  "command": "activate_name",
                   "output": "(input was not focused)",
                   "result": "fail"
                 }
@@ -199,7 +199,7 @@
             "firefox": {
               "output": [
                 {
-                  "command": "activate_actionable_item",
+                  "command": "activate_name",
                   "output": "(input was not focused)",
                   "result": "fail"
                 }

--- a/data/tests/tech/aria/aria-required-on-html-radio-buttons.json
+++ b/data/tests/tech/aria/aria-required-on-html-radio-buttons.json
@@ -1638,7 +1638,7 @@
             "chrome": {
               "output": [
                 {
-                  "command": "activate_actionable_item",
+                  "command": "activate_name",
                   "output": "radio was checked",
                   "result": "pass",
                   "notes": "said \"click cat\" "
@@ -1852,7 +1852,7 @@
             "chrome": {
               "output": [
                 {
-                  "command": "click_type",
+                  "command": "activate_role",
                   "output": "all radios were flagged for selection",
                   "result": "pass",
                   "notes": "said \"click radio\""

--- a/data/tests/tech/aria/role_button_name_from_inner.json
+++ b/data/tests/tech/aria/role_button_name_from_inner.json
@@ -13,7 +13,7 @@
             "ie": {
               "output": [
                 {
-                  "command": "activate_actionable_item",
+                  "command": "activate_name",
                   "output": "(target was clicked)",
                   "result": "pass"
                 }
@@ -22,7 +22,7 @@
             "chrome": {
               "output": [
                 {
-                  "command": "activate_actionable_item",
+                  "command": "activate_name",
                   "output": "(target was clicked)",
                   "result": "pass"
                 }
@@ -236,7 +236,7 @@
             "ie": {
               "output": [
                 {
-                  "command": "click_type",
+                  "command": "activate_role",
                   "output": "(all elements of type were flagged)",
                   "result": "pass"
                 }
@@ -245,7 +245,7 @@
             "chrome": {
               "output": [
                 {
-                  "command": "click_type",
+                  "command": "activate_role",
                   "output": "(all elements of type were flagged)",
                   "result": "pass"
                 }

--- a/data/tests/tech/aria/role_button_name_from_label.json
+++ b/data/tests/tech/aria/role_button_name_from_label.json
@@ -13,7 +13,7 @@
             "ie": {
               "output": [
                 {
-                  "command": "activate_actionable_item",
+                  "command": "activate_name",
                   "output": "(target was clicked)",
                   "result": "pass"
                 }
@@ -22,7 +22,7 @@
             "chrome": {
               "output": [
                 {
-                  "command": "activate_actionable_item",
+                  "command": "activate_name",
                   "output": "(target was clicked)",
                   "result": "pass"
                 }
@@ -236,7 +236,7 @@
             "ie": {
               "output": [
                 {
-                  "command": "click_type",
+                  "command": "activate_role",
                   "output": "(all elements of type were flagged)",
                   "result": "pass"
                 }
@@ -245,7 +245,7 @@
             "chrome": {
               "output": [
                 {
-                  "command": "click_type",
+                  "command": "activate_role",
                   "output": "(all elements of type were flagged)",
                   "result": "pass"
                 }

--- a/data/tests/tech/aria/role_link_name_from_inner.json
+++ b/data/tests/tech/aria/role_link_name_from_inner.json
@@ -13,7 +13,7 @@
             "ie": {
               "output": [
                 {
-                  "command": "activate_actionable_item",
+                  "command": "activate_name",
                   "output": "(target was clicked)",
                   "result": "pass"
                 }
@@ -22,7 +22,7 @@
             "chrome": {
               "output": [
                 {
-                  "command": "activate_actionable_item",
+                  "command": "activate_name",
                   "output": "(target was clicked)",
                   "result": "pass"
                 }
@@ -236,7 +236,7 @@
             "ie": {
               "output": [
                 {
-                  "command": "click_type",
+                  "command": "activate_role",
                   "output": "(all elements of type were flagged)",
                   "result": "pass"
                 }
@@ -245,7 +245,7 @@
             "chrome": {
               "output": [
                 {
-                  "command": "click_type",
+                  "command": "activate_role",
                   "output": "(all elements of type were flagged)",
                   "result": "pass"
                 }

--- a/data/tests/tech/aria/role_link_name_from_label.json
+++ b/data/tests/tech/aria/role_link_name_from_label.json
@@ -13,7 +13,7 @@
             "ie": {
               "output": [
                 {
-                  "command": "activate_actionable_item",
+                  "command": "activate_name",
                   "output": "(target was clicked)",
                   "result": "pass"
                 }
@@ -22,7 +22,7 @@
             "chrome": {
               "output": [
                 {
-                  "command": "activate_actionable_item",
+                  "command": "activate_name",
                   "output": "(target was clicked)",
                   "result": "pass"
                 }
@@ -236,7 +236,7 @@
             "ie": {
               "output": [
                 {
-                  "command": "click_type",
+                  "command": "activate_role",
                   "output": "(all elements of type were flagged)",
                   "result": "pass"
                 }
@@ -245,7 +245,7 @@
             "chrome": {
               "output": [
                 {
-                  "command": "click_type",
+                  "command": "activate_role",
                   "output": "(all elements of type were flagged)",
                   "result": "pass"
                 }

--- a/data/tests/tech/html/buttons.json
+++ b/data/tests/tech/html/buttons.json
@@ -12,7 +12,7 @@
             "chrome": {
               "output": [
                 {
-                  "command": "activate_actionable_item",
+                  "command": "activate_name",
                   "output": "button was clicked",
                   "result": "pass"
                 }
@@ -225,7 +225,7 @@
             "chrome": {
               "output": [
                 {
-                  "command": "click_type",
+                  "command": "activate_role",
                   "output": "button was clicked",
                   "result": "pass",
                   "notes": "said \"click button\""
@@ -613,7 +613,7 @@
             "chrome": {
               "output": [
                 {
-                  "command": "activate_actionable_item",
+                  "command": "activate_name",
                   "output": "button was clicked",
                   "result": "pass"
                 }
@@ -826,7 +826,7 @@
             "chrome": {
               "output": [
                 {
-                  "command": "click_type",
+                  "command": "activate_role",
                   "output": "button was clicked",
                   "result": "pass",
                   "notes": "said \"click button\""
@@ -1214,7 +1214,7 @@
             "chrome": {
               "output": [
                 {
-                  "command": "activate_actionable_item",
+                  "command": "activate_name",
                   "output": "button was clicked",
                   "result": "pass"
                 }
@@ -1427,7 +1427,7 @@
             "chrome": {
               "output": [
                 {
-                  "command": "click_type",
+                  "command": "activate_role",
                   "output": "button was clicked",
                   "result": "pass",
                   "notes": "said \"click button\""
@@ -1815,7 +1815,7 @@
             "chrome": {
               "output": [
                 {
-                  "command": "activate_actionable_item",
+                  "command": "activate_name",
                   "output": "button was not flagged or clicked",
                   "result": "fail"
                 }
@@ -2028,7 +2028,7 @@
             "chrome": {
               "output": [
                 {
-                  "command": "click_type",
+                  "command": "activate_role",
                   "output": "button was not flagged or clicked",
                   "result": "fail",
                   "notes": "said \"click button\""
@@ -2416,7 +2416,7 @@
             "chrome": {
               "output": [
                 {
-                  "command": "activate_actionable_item",
+                  "command": "activate_name",
                   "output": "button was clicked",
                   "result": "pass"
                 }
@@ -2629,7 +2629,7 @@
             "chrome": {
               "output": [
                 {
-                  "command": "click_type",
+                  "command": "activate_role",
                   "output": "button was clicked",
                   "result": "pass",
                   "notes": "said \"click button\""

--- a/data/tests/tech/html/datalist.json
+++ b/data/tests/tech/html/datalist.json
@@ -12,7 +12,7 @@
             "chrome": {
               "output": [
                 {
-                  "command": "activate_actionable_item",
+                  "command": "activate_name",
                   "output": "text input was focused",
                   "result": "pass"
                 }
@@ -225,7 +225,7 @@
             "chrome": {
               "output": [
                 {
-                  "command": "click_type",
+                  "command": "activate_role",
                   "output": "text input was focused",
                   "result": "pass"
                 }
@@ -1822,7 +1822,7 @@
             "chrome": {
               "output": [
                 {
-                  "command": "click_type",
+                  "command": "activate_role",
                   "output": "text of command was entered into the text input",
                   "result": "fail"
                 }

--- a/data/tests/tech/html/details-summary.json
+++ b/data/tests/tech/html/details-summary.json
@@ -444,7 +444,7 @@
             "chrome": {
               "output": [
                 {
-                  "command": "activate_actionable_item",
+                  "command": "activate_name",
                   "output": "command not recognized",
                   "result": "fail"
                 }
@@ -660,7 +660,7 @@
             "chrome": {
               "output": [
                 {
-                  "command": "click_type",
+                  "command": "activate_role",
                   "output": "command not recognized",
                   "result": "fail"
                 }

--- a/data/tests/tech/html/input/input-email.json
+++ b/data/tests/tech/html/input/input-email.json
@@ -12,7 +12,7 @@
             "chrome": {
               "output": [
                 {
-                  "command": "activate_actionable_item",
+                  "command": "activate_name",
                   "output": "input was focused",
                   "result": "pass",
                   "notes": "said \"click email\""
@@ -226,7 +226,7 @@
             "chrome": {
               "output": [
                 {
-                  "command": "click_type",
+                  "command": "activate_role",
                   "output": "input was flagged for disambiguation",
                   "result": "pass",
                   "notes": "said \"click text\""

--- a/data/tests/tech/html/input/input-text.json
+++ b/data/tests/tech/html/input/input-text.json
@@ -12,7 +12,7 @@
             "chrome": {
               "output": [
                 {
-                  "command": "activate_actionable_item",
+                  "command": "activate_name",
                   "output": "text input was focused",
                   "result": "pass"
                 }
@@ -225,7 +225,7 @@
             "chrome": {
               "output": [
                 {
-                  "command": "click_type",
+                  "command": "activate_role",
                   "output": "text input was focused",
                   "result": "pass"
                 }

--- a/data/tests/tech/html/links/example1.json
+++ b/data/tests/tech/html/links/example1.json
@@ -13,7 +13,7 @@
             "chrome": {
               "output": [
                 {
-                  "command": "click_type",
+                  "command": "activate_role",
                   "output": "flagged as a link to choose from",
                   "result": "pass"
                 }
@@ -227,7 +227,7 @@
             "chrome": {
               "output": [
                 {
-                  "command": "activate_actionable_item",
+                  "command": "activate_name",
                   "output": "successfully activated",
                   "result": "pass"
                 }

--- a/data/tests/tech/html/links/example2.json
+++ b/data/tests/tech/html/links/example2.json
@@ -13,7 +13,7 @@
             "chrome": {
               "output": [
                 {
-                  "command": "click_type",
+                  "command": "activate_role",
                   "output": "flagged as a link to choose from",
                   "result": "pass"
                 }
@@ -227,7 +227,7 @@
             "chrome": {
               "output": [
                 {
-                  "command": "activate_actionable_item",
+                  "command": "activate_name",
                   "output": "successfully activated",
                   "result": "pass"
                 }

--- a/data/tests/tech/html/links/example3.json
+++ b/data/tests/tech/html/links/example3.json
@@ -13,7 +13,7 @@
             "chrome": {
               "output": [
                 {
-                  "command": "click_type",
+                  "command": "activate_role",
                   "output": "flagged as a link to choose from",
                   "result": "pass"
                 }
@@ -227,7 +227,7 @@
             "chrome": {
               "output": [
                 {
-                  "command": "activate_actionable_item",
+                  "command": "activate_name",
                   "output": "successfully activated",
                   "result": "pass"
                 }

--- a/data/tests/tech/html/links/example4.json
+++ b/data/tests/tech/html/links/example4.json
@@ -13,7 +13,7 @@
             "chrome": {
               "output": [
                 {
-                  "command": "click_type",
+                  "command": "activate_role",
                   "output": "flagged as a link to choose from",
                   "result": "pass"
                 }
@@ -227,7 +227,7 @@
             "chrome": {
               "output": [
                 {
-                  "command": "activate_actionable_item",
+                  "command": "activate_name",
                   "output": "successfully activated",
                   "result": "pass"
                 }

--- a/data/tests/tech/html/links/example5.json
+++ b/data/tests/tech/html/links/example5.json
@@ -13,7 +13,7 @@
             "chrome": {
               "output": [
                 {
-                  "command": "click_type",
+                  "command": "activate_role",
                   "output": "flagged as a link to choose from",
                   "result": "pass"
                 }
@@ -230,7 +230,7 @@
             "chrome": {
               "output": [
                 {
-                  "command": "activate_actionable_item",
+                  "command": "activate_name",
                   "output": "successfully activated",
                   "result": "pass"
                 }

--- a/data/tests/tech/html/links/example6.json
+++ b/data/tests/tech/html/links/example6.json
@@ -13,7 +13,7 @@
             "chrome": {
               "output": [
                 {
-                  "command": "click_type",
+                  "command": "activate_role",
                   "output": "flagged as a link to choose from",
                   "result": "fail"
                 }
@@ -173,7 +173,7 @@
             "chrome": {
               "output": [
                 {
-                  "command": "activate_actionable_item",
+                  "command": "activate_name",
                   "output": "successfully activated",
                   "result": "fail"
                 }

--- a/data/tests/tech/html/links/example7.json
+++ b/data/tests/tech/html/links/example7.json
@@ -13,7 +13,7 @@
             "chrome": {
               "output": [
                 {
-                  "command": "click_type",
+                  "command": "activate_role",
                   "output": "flagged as a link to choose from",
                   "result": "fail"
                 }
@@ -172,7 +172,7 @@
             "chrome": {
               "output": [
                 {
-                  "command": "activate_actionable_item",
+                  "command": "activate_name",
                   "output": "successfully activated",
                   "result": "fail"
                 }

--- a/data/tests/tech/html/links/example8.json
+++ b/data/tests/tech/html/links/example8.json
@@ -13,7 +13,7 @@
             "chrome": {
               "output": [
                 {
-                  "command": "click_type",
+                  "command": "activate_role",
                   "output": "flagged as a link to choose from",
                   "result": "fail"
                 }
@@ -173,7 +173,7 @@
             "chrome": {
               "output": [
                 {
-                  "command": "activate_actionable_item",
+                  "command": "activate_name",
                   "output": "successfully activated",
                   "result": "fail"
                 }

--- a/data/tests/tech/html/required_attribute_radio_group.json
+++ b/data/tests/tech/html/required_attribute_radio_group.json
@@ -1972,7 +1972,7 @@
             "chrome": {
               "output": [
                 {
-                  "command": "activate_actionable_item",
+                  "command": "activate_name",
                   "output": "radio was checked",
                   "result": "pass",
                   "notes": "said \"click cat\" "
@@ -2186,7 +2186,7 @@
             "chrome": {
               "output": [
                 {
-                  "command": "click_type",
+                  "command": "activate_role",
                   "output": "all radios were flagged for selection",
                   "result": "pass",
                   "notes": "said \"click radio\""

--- a/data/tests/tech/html/select.json
+++ b/data/tests/tech/html/select.json
@@ -12,7 +12,7 @@
             "chrome": {
               "output": [
                 {
-                  "command": "activate_actionable_item",
+                  "command": "activate_name",
                   "output": "element was focused",
                   "result": "pass"
                 }
@@ -225,7 +225,7 @@
             "chrome": {
               "output": [
                 {
-                  "command": "click_type",
+                  "command": "activate_role",
                   "output": "element was focused",
                   "result": "pass"
                 }

--- a/documentation/at/vc_ios.md
+++ b/documentation/at/vc_ios.md
@@ -1,0 +1,11 @@
+# Voice Control for iOS
+
+Voice Control for iOS is a voice control system that can be found in iOS 13 and greater.
+
+## Install
+
+Voice Control is built in to iOS and you can enable it from your Settings app.
+
+## Guides, Documentation, and resources
+
+* [Apple documentation](https://support.apple.com/guide/iphone/voice-control-iph2c21a3c88/ios)

--- a/documentation/learn.md
+++ b/documentation/learn.md
@@ -6,7 +6,10 @@ There are many different forms of Assistive Technologies (AT). The scope of this
 
 There are many different assistive technologies, but it would be impossible for us to test them all. Therefore [we only test the most widely used ones](/faq#what-assistive-technologies-are-in-scope%3F).
 
-* [Dragon Naturally Speaking](/learn/at/dragon)
+### Screen readers
+
+Screen readers announce the content of the screen either by audio or by a braille device. People who are blind or have low vision are likely to use screen reader software to interact with computers or devices.
+
 * [JAWS](/learn/at/jaws)
 * [Narrator](/learn/at/narrator)
 * [NVDA](/learn/at/nvda)
@@ -14,3 +17,10 @@ There are many different assistive technologies, but it would be impossible for 
 * [VoiceOver for iOS](/learn/at/vo_ios)
 * [VoiceOver for macOS](/learn/at/vo_macos)
 * [Orca for Linux](/learn/at/orca)
+
+### Voice Control
+
+Voice Control software allows users to command their computers or devices by voice, bypassing the need for a mouse or keyboard. People with physical or motor disabilities are most likely to use voice control software.
+
+* [Dragon Naturally Speaking](/learn/at/dragon)
+* [Voice Control for iOS](/learn/at/vc_ios)

--- a/documentation/learn.md
+++ b/documentation/learn.md
@@ -2,6 +2,8 @@
 
 There are many different forms of Assistive Technologies (AT). The scope of this website only covers AT that must interface with the code you write as a web developer. This means that AT like screen readers or voice control software are in scope, while AT such as hearing aids and screen magnifiers are not.
 
+For a summary of similar commands across different types of AT, view the [command matrix](/learn/commands).
+
 ## AT Information
 
 There are many different assistive technologies, but it would be impossible for us to test them all. Therefore [we only test the most widely used ones](/faq#what-assistive-technologies-are-in-scope%3F).

--- a/routes/index.js
+++ b/routes/index.js
@@ -66,7 +66,7 @@ router.get('/learn/commands', function(req, res, next) {
 });
 
 router.get('/learn/at/:id', function(req, res, next) {
-	let allowed = ['dragon', 'jaws', 'narrator', 'nvda', 'talkback', 'vo_ios', 'vo_macos', 'orca'];
+	let allowed = ['dragon', 'jaws', 'narrator', 'nvda', 'talkback', 'vo_ios', 'vo_macos', 'orca', 'vc_ios'];
 
 	if (!allowed.includes(req.params.id)) {
 		next(createError(404));


### PR DESCRIPTION
This accomplishes the following tasks in #74 

- [x] Add vc_ios to the ATBrowsers.json file as an extended combination
- [x]  Add a 'learn' page for vc_ios
- [x]  Add a list of commands to the entry in ATBrowsers.json file
- [x]  Review existing commands in the Dragon entry and normalize + improve command names where it makes sense. This likely means editing existing Dragon test results with new names.

Additionally, it adds a link to the 'command matrix' that was previously unlinked.

The following must be met before merging

- [x] No spelling/grammer errors
- [x] No invalid code (JSON or HTML)
- [x] Content makes sense and is logical
- [x] All tests pass (should be run via travisCI)
