### PR TITLE
aria-pressed attribute test

### DIFF
--- a/data/tests/tech/aria/aria-pressed.json
+++ b/data/tests/tech/aria/aria-pressed.json
@@ -176,6 +176,17 @@
                   "result": "unknown"
                 }
               ]
+            },
+            "firefox": {
+              "output": [
+                {
+                  "command": "next_item",
+                  "from": "before target",
+                  "to": "target",
+                  "output": "Action, button",
+                  "result": "fail"
+                }
+              ]
             }
           }
         },
@@ -374,6 +385,17 @@
                   "to": "target",
                   "output": "\"\"",
                   "result": "unknown"
+                }
+              ]
+            },
+            "firefox": {
+              "output": [
+                {
+                  "command": "next_item",
+                  "from": "before target",
+                  "to": "target",
+                  "output": "Action, button",
+                  "result": "fail"
                 }
               ]
             }
@@ -576,6 +598,17 @@
                   "result": "unknown"
                 }
               ]
+            },
+            "firefox": {
+              "output": [
+                {
+                  "command": "next_item",
+                  "from": "before target",
+                  "to": "target",
+                  "output": "Action, button",
+                  "result": "fail"
+                }
+              ]
             }
           }
         },
@@ -776,6 +809,17 @@
                   "result": "unknown"
                 }
               ]
+            },
+            "firefox": {
+              "output": [
+                {
+                  "command": "next_item",
+                  "from": "before target",
+                  "to": "target",
+                  "output": "Action, button",
+                  "result": "fail"
+                }
+              ]
             }
           }
         },
@@ -927,6 +971,17 @@
                   "result": "unknown"
                 }
               ]
+            },
+            "firefox": {
+              "output": [
+                {
+                  "command": "next_item",
+                  "from": "before target",
+                  "to": "target",
+                  "output": "Action, button",
+                  "result": "fail"
+                }
+              ]
             }
           }
         },
@@ -1050,6 +1105,12 @@
           "os_version": "10.15",
           "browser_version": "13.0.2",
           "date": "2019-11-11"
+        },
+        "firefox": {
+          "at_version": "9",
+          "os_version": "10.14",
+          "browser_version": "70.0.1",
+          "date": "2019-11-19"
         }
       }
     },


### PR DESCRIPTION
update aria-passed.json (all seem to fail)
1. **The name of the test**: aria-pressed attribute test

1. **The AT name**: VoiceOver (MacOS)

1. **The AT version**: 9 (VoiceOver Utility version 9 - not sure whether that's correct)

1. **The Browser Name**: Firefox

1. **The Browser version**: 70.0.1

1. **The OS version**: MacOS Mojave 10.14

1. **The specific command(s) used to access the target element with the AT (keys used, touch gestures, or voice command)**: control + option + right arrow

1. **The output announced by the screen reader for each specific command (if using a screen reader). 7 and 8 help to make the test easier to replicate.**: "Action, button"

1. **Whether or not you think the test passes or fails and why**: fail - they all only say "Action, button" -1. To see if I got this right, watch [this screen recording video](https://www.dropbox.com/s/o5rorydf25r4b5a/aria-pressed%20attribute%20test%20Screen%20Recording%202019-11-19%20at%2020.46.42.mov?dl=0). Let me know if I got this right.

## References:
- https://a11ysupport.io/contribute#add-or-modify-a-support-point
- https://a11ysupport.io/tests/tech__aria__aria-pressed#assertion-aria-aria-pressed_attribute-convey_value_false
- https://a11ysupport.io/tests/tech__aria__aria-pressed/run
