### PR TITLE
consistent references

### DIFF
--- a/data/tech/html/a(href)_element.json
+++ b/data/tech/html/a(href)_element.json
@@ -5,8 +5,12 @@
   "description": "If the a element has an href attribute, then it represents a hyperlink (a hypertext anchor) labeled by its contents.",
   "references": [
     {
-      "title": "HTML5 spec for the a element",
+      "title": "WHATWG HTML spec for the a element",
       "url": "https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-a-element"
+    },
+    {
+      "title": "HTML AAM for the a element (with href)",
+      "url": "https://w3c.github.io/html-aam/#el-a"
     }
   ],
   "assertions": [

--- a/data/tech/html/a_element.json
+++ b/data/tech/html/a_element.json
@@ -5,8 +5,12 @@
   "description": "If the a element has no href attribute, then the element represents a placeholder for where a link might otherwise have been placed, if it had been relevant, consisting of just the element's contents.",
   "references": [
     {
-      "title": "HTML5 spec for the a element",
+      "title": "WHATWG HTML spec for the a element",
       "url": "https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-a-element"
+    },
+    {
+      "title": "HTML AAM for the a element (without href)",
+      "url": "https://w3c.github.io/html-aam/#el-a-no-href"
     }
   ],
   "assertions": [

--- a/data/tech/html/button_element.json
+++ b/data/tech/html/button_element.json
@@ -5,8 +5,12 @@
   "description": "The button element represents a button labeled by its contents.",
   "references": [
     {
-      "title": "HTML5 spec for button",
+      "title": "WHATWG HTML spec for the button element",
       "url": "https://html.spec.whatwg.org/multipage/form-elements.html#the-button-element"
+    },
+    {
+      "title": "HTML AAM for the button element",
+      "url": "https://w3c.github.io/html-aam/#el-button"
     }
   ],
   "assertions": [

--- a/data/tech/html/canvas_element.json
+++ b/data/tech/html/canvas_element.json
@@ -5,12 +5,12 @@
   "description": "",
   "references": [
     {
-      "title": "HTML5 spec for canvas",
-      "url": "https://w3c.github.io/html/the-canvas-element.html#the-canvas-element"
+      "title": "WHATWG HTML spec for the canvas element",
+      "url": "https://html.spec.whatwg.org/multipage/canvas.html#the-canvas-element"
     },
     {
-      "title": "HTML AAM",
-      "url": "https://www.w3.org/TR/html-aam-1.0/#details-id-18"
+      "title": "HTML AAM for the canvas element",
+      "url": "https://w3c.github.io/html-aam/#el-canvas"
     }
   ],
   "assertions": [],

--- a/data/tech/html/datalist_element.json
+++ b/data/tech/html/datalist_element.json
@@ -11,7 +11,7 @@
   ],
   "references": [
     {
-      "title": "WHATWG HTML5 spec for datalist",
+      "title": "WHATWG HTML spec for the datalist element",
       "url": "https://html.spec.whatwg.org/#the-datalist-element"
     },
     {

--- a/data/tech/html/dd_element.json
+++ b/data/tech/html/dd_element.json
@@ -9,12 +9,12 @@
   ],
   "references": [
     {
-      "title": "W3C HTML5 spec for the dd element",
-      "url": "https://w3c.github.io/html/grouping-content.html#the-dd-element"
+      "title": "WHATWG HTML spec for the dd element",
+      "url": "https://html.spec.whatwg.org/#the-dd-element"
     },
     {
-      "title": "WHATWG HTML5 spec for the dd element",
-      "url": "https://html.spec.whatwg.org/#the-dd-element"
+      "title": "HTML AAM for the dd element",
+      "url": "https://w3c.github.io/html-aam/#el-dd"
     }
   ],
   "assertions": [

--- a/data/tech/html/details_element.json
+++ b/data/tech/html/details_element.json
@@ -8,8 +8,12 @@
   ],
   "references": [
     {
-      "title": "WHATWG HTML5 spec for the details element",
+      "title": "WHATWG HTML spec for the details element",
       "url": "https://html.spec.whatwg.org/multipage/interactive-elements.html#the-details-element"
+    },
+    {
+      "title": "HTML AAM for the details element",
+      "url": "https://w3c.github.io/html-aam/#el-details"
     }
   ],
   "assertions": [

--- a/data/tech/html/dialog_element.json
+++ b/data/tech/html/dialog_element.json
@@ -5,8 +5,12 @@
   "description": "",
   "references": [
     {
-      "title": "HTML5 spec for dialog",
-      "url": "https://w3c.github.io/html/interactive-elements.html#the-dialog-element"
+      "title": "WHATWG HTML spec for the details element",
+      "url": "https://html.spec.whatwg.org/multipage/interactive-elements.html#the-dialog-element"
+    },
+    {
+      "title": "HTML AAM for the dialog element",
+      "url": "https://w3c.github.io/html-aam/#el-dialog"
     }
   ],
   "assertions": [],

--- a/data/tech/html/dialog_element.json
+++ b/data/tech/html/dialog_element.json
@@ -5,7 +5,7 @@
   "description": "",
   "references": [
     {
-      "title": "WHATWG HTML spec for the details element",
+      "title": "WHATWG HTML spec for the dialog element",
       "url": "https://html.spec.whatwg.org/multipage/interactive-elements.html#the-dialog-element"
     },
     {

--- a/data/tech/html/disabled_attribute.json
+++ b/data/tech/html/disabled_attribute.json
@@ -4,16 +4,16 @@
   "description": "The HTML `disabled` attribute lets authors disable form controls. Note, adding the disabled attribute to form controls will generally cause them to not be focusable.",
   "references": [
     {
-      "title": "HTML5 spec for disabled attribute",
-      "url": "https://w3c.github.io/html/sec-forms.html#enabling-and-disabling-form-controls-the-disabled-attribute"
+      "title": "WHATWG HTML spec for the disabled attribute",
+      "url": "https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#enabling-and-disabling-form-controls:-the-disabled-attribute"
     },
     {
-      "title": "Disabled attribute and affect on focus in the HTML5 spec",
+      "title": "WHATWG HTML spec for how the disabled attribute affects focus",
       "url": "https://html.spec.whatwg.org/#focusable-area"
     },
     {
-      "title": "HTML AAM rules for the disabled attribute",
-      "url": "https://www.w3.org/TR/html-aam-1.0/#details-id-186"
+      "title": "HTML AAM for the disabled attribute",
+      "url": "https://w3c.github.io/html-aam/#att-disabled"
     }
   ],
   "assertions": [

--- a/data/tech/html/div_element.json
+++ b/data/tech/html/div_element.json
@@ -5,8 +5,12 @@
   "description": "",
   "references": [
     {
-      "title": "HTML5 spec for div",
+      "title": "WHATWG HTML spec for the div element",
       "url": "https://html.spec.whatwg.org/#the-div-element"
+    },
+    {
+      "title": "HTML AAM for the div element",
+      "url": "https://w3c.github.io/html-aam/#el-div"
     }
   ],
   "assertions": [],

--- a/data/tech/html/dl_element.json
+++ b/data/tech/html/dl_element.json
@@ -3,19 +3,19 @@
   "title": "dl element (description list)",
   "type": "element",
   "description": "Description list element. See the related [`dt` element](/tech/html/dt_element) and the [`dd` element](/tech/html/dd_element) for more information.",
-  "recommendation": "The `dl` element and its associated `dt` and `dd` elements have poor to non-existent support. If it is critically important to convey relationships between terms and descriptions and the values of the two can be confused with eachother (think a matching list of colors such as \"red: blue\", consider another approach such as a table or headings. It is often possible for a user to determine which text is a key and which text is a value just based upon the text alone. If this is the case for your implementation, it might be fine to use a `dl` element and hope for better support in the future.",
+  "recommendation": "The `dl` element and its associated `dt` and `dd` elements have poor to non-existent support. If it is critically important to convey relationships between terms and descriptions and the values of the two can be confused with each other (think a matching list of colors such as \"red: blue\", consider another approach such as a table or headings. It is often possible for a user to determine which text is a key and which text is a value just based upon the text alone. If this is the case for your implementation, it might be fine to use a `dl` element and hope for better support in the future.",
   "related_features": [
     "html/dt_element",
     "html/dd_element"
   ],
   "references": [
     {
-      "title": "W3C HTML5 spec for description lists",
-      "url": "https://w3c.github.io/html/grouping-content.html#the-dl-element"
+      "title": "WHATWG HTML spec for description lists",
+      "url": "https://html.spec.whatwg.org/#the-dl-element"
     },
     {
-      "title": "WHATWG HTML5 spec for description lists",
-      "url": "https://html.spec.whatwg.org/#the-dl-element"
+      "title": "HTML AAM for the dl element",
+      "url": "https://w3c.github.io/html-aam/#el-dl"
     }
   ],
   "related_issues": [

--- a/data/tech/html/dt_element.json
+++ b/data/tech/html/dt_element.json
@@ -9,12 +9,12 @@
   ],
   "references": [
     {
-      "title": "W3C HTML5 spec for the dt element",
-      "url": "https://w3c.github.io/html/grouping-content.html#the-dt-element"
+      "title": "WHATWG HTML spec for the dt element",
+      "url": "https://html.spec.whatwg.org/#the-dd-element"
     },
     {
-      "title": "WHATWG HTML5 spec for the dt element",
-      "url": "https://html.spec.whatwg.org/#the-dd-element"
+      "title": "HTML AAM for the dt element",
+      "url": "https://w3c.github.io/html-aam/#el-dt"
     }
   ],
   "assertions": [

--- a/data/tech/html/fieldset_element.json
+++ b/data/tech/html/fieldset_element.json
@@ -8,8 +8,12 @@
   ],
   "references": [
     {
-      "title": "HTML5 spec for the fieldset element",
+      "title": "WHATWG HTML spec for the fieldset element",
       "url": "https://html.spec.whatwg.org/multipage/form-elements.html#the-fieldset-element"
+    },
+    {
+      "title": "HTML AAM for the fieldset element",
+      "url": "https://w3c.github.io/html-aam/#el-fieldset"
     }
   ],
   "assertions": [

--- a/data/tech/html/figcaption_element.json
+++ b/data/tech/html/figcaption_element.json
@@ -8,16 +8,12 @@
   ],
   "references": [
     {
-      "title": "W3C HTML5 spec for figcaption",
-      "url": "https://w3c.github.io/html/grouping-content.html#the-figcaption-element"
-    },
-    {
-      "title": "WHATWG HTML5 spec for figcaption",
+      "title": "WHATWG HTML spec for the figcaption element",
       "url": "https://html.spec.whatwg.org/multipage/grouping-content.html#the-figcaption-element"
     },
     {
-      "title": "HTML AAM spec for figcaption",
-      "url": "https://www.w3.org/TR/html-aam-1.0/#figure-and-figcaption-elements"
+      "title": "HTML AAM for the figcaption element",
+      "url": "https://w3c.github.io/html-aam/#el-figcaption"
     }
   ],
   "assertions": [

--- a/data/tech/html/figure_element.json
+++ b/data/tech/html/figure_element.json
@@ -8,16 +8,12 @@
   ],
   "references": [
     {
-      "title": "HTML5 spec for figure",
-      "url": "https://w3c.github.io/html/grouping-content.html#the-figure-element"
-    },
-    {
-      "title": "WHATWG HTML5 spec for figure",
+      "title": "WHATWG HTML spec for the figure element",
       "url": "https://html.spec.whatwg.org/multipage/grouping-content.html#the-figure-element"
     },
     {
-      "title": "HTML AAM spec for figure",
-      "url": "https://www.w3.org/TR/html-aam-1.0/#figure-and-figcaption-elements"
+      "title": "HTML AAM for the figure element",
+      "url": "https://w3c.github.io/html-aam/#el-figure"
     }
   ],
   "assertions": [

--- a/data/tech/html/h1-6_elements.json
+++ b/data/tech/html/h1-6_elements.json
@@ -5,8 +5,12 @@
   "description": "",
   "references": [
     {
-      "title": "WHATWG spec for heading elements",
+      "title": "WHATWG HTML spec for heading elements",
       "url": "https://html.spec.whatwg.org/multipage/sections.html#the-h1,-h2,-h3,-h4,-h5,-and-h6-elements"
+    },
+    {
+      "title": "HTML AAM for heading elements",
+      "url": "https://w3c.github.io/html-aam/#el-h1-h6"
     }
   ],
   "assertions": [

--- a/data/tech/html/headers_attribute.json
+++ b/data/tech/html/headers_attribute.json
@@ -10,8 +10,12 @@
   ],
   "references": [
     {
-      "title": "WHATWG HTML5 spec 4.9.12.2 Forming relationships between data cells and header cells",
+      "title": "WHATWG HTML spec 4.9.12.2 Forming relationships between data cells and header cells",
       "url": "https://html.spec.whatwg.org/multipage/tables.html#header-and-data-cell-semantics:attr-tdth-headers"
+    },
+    {
+      "title": "HTML AAM for the headers attribute",
+      "url": "https://w3c.github.io/html-aam/#att-headers"
     }
   ],
   "related_issues": [

--- a/data/tech/html/img_element.json
+++ b/data/tech/html/img_element.json
@@ -7,6 +7,10 @@
     {
       "title": "HTML5 spec for img",
       "url": "https://html.spec.whatwg.org/#the-img-element"
+    },
+    {
+      "title": "HTML AAM for the img element",
+      "url": "https://w3c.github.io/html-aam/#el-img"
     }
   ],
   "assertions": [],

--- a/data/tech/html/img_element.json
+++ b/data/tech/html/img_element.json
@@ -5,7 +5,7 @@
   "description": "",
   "references": [
     {
-      "title": "HTML5 spec for img",
+      "title": "WHATWG HTML spec for the img element",
       "url": "https://html.spec.whatwg.org/#the-img-element"
     },
     {

--- a/data/tech/html/input(type-button)_element.json
+++ b/data/tech/html/input(type-button)_element.json
@@ -6,8 +6,12 @@
   "is_form_control": true,
   "references": [
     {
-      "title": "HTML5 spec for input[type=\"button\"]",
+      "title": "WHATWG HTML spec for input[type=\"button\"]",
       "url": "https://html.spec.whatwg.org/multipage/input.html#button-state-(type=button)"
+    },
+    {
+      "title": "HTML AAM for the input[type=\"button\"]",
+      "url": "https://w3c.github.io/html-aam/#el-input-button"
     }
   ],
   "assertions": [

--- a/data/tech/html/input(type-checkbox)_element.json
+++ b/data/tech/html/input(type-checkbox)_element.json
@@ -6,8 +6,12 @@
   "is_form_control": true,
   "references": [
     {
-      "title": "HTML5 spec for input[type=\"checkbox\"]",
+      "title": "WHATWG HTML spec for input[type=\"checkbox\"]",
       "url": "https://html.spec.whatwg.org/multipage/input.html#checkbox-state-(type=checkbox)"
+    },
+    {
+      "title": "HTML AAM for the input[type=\"checkbox\"]",
+      "url": "https://w3c.github.io/html-aam/#el-input-checkbox"
     }
   ],
   "assertions": [

--- a/data/tech/html/input(type-color)_element.json
+++ b/data/tech/html/input(type-color)_element.json
@@ -6,8 +6,12 @@
   "is_form_control": true,
   "references": [
     {
-      "title": "HTML5 spec for input[type=\"color\"]",
+      "title": "WHATWG HTML spec for input[type=\"color\"]",
       "url": "https://html.spec.whatwg.org/multipage/input.html#color-state-(type=color)"
+    },
+    {
+      "title": "HTML AAM for the input[type=\"color\"]",
+      "url": "https://w3c.github.io/html-aam/#el-input-color"
     }
   ],
   "assertions": [

--- a/data/tech/html/input(type-date)_element.json
+++ b/data/tech/html/input(type-date)_element.json
@@ -6,8 +6,12 @@
   "is_form_control": true,
   "references": [
     {
-      "title": "HTML5 spec for input[type=\"date\"]",
+      "title": "WHATWG HTML spec for input[type=\"date\"]",
       "url": "https://html.spec.whatwg.org/multipage/input.html#date-state-(type=date)"
+    },
+    {
+      "title": "HTML AAM for the input[type=\"date\"]",
+      "url": "https://w3c.github.io/html-aam/#el-input-date"
     }
   ],
   "assertions": [

--- a/data/tech/html/input(type-datetime-local)_element.json
+++ b/data/tech/html/input(type-datetime-local)_element.json
@@ -6,8 +6,12 @@
   "is_form_control": true,
   "references": [
     {
-      "title": "HTML5 spec for input[type=\"datetime-local\"]",
+      "title": "WHATWG HTML spec for input[type=\"datetime-local\"]",
       "url": "https://html.spec.whatwg.org/multipage/input.html#local-date-and-time-state-(type=datetime-local)"
+    },
+    {
+      "title": "HTML AAM for the input[type=\"datetime-local\"]",
+      "url": "https://w3c.github.io/html-aam/#el-input-datetime-local"
     }
   ],
   "assertions": [

--- a/data/tech/html/input(type-email)_element.json
+++ b/data/tech/html/input(type-email)_element.json
@@ -6,8 +6,12 @@
   "is_form_control": true,
   "references": [
     {
-      "title": "HTML5 spec for input[type=\"email\"]",
+      "title": "WHATWG HTML spec for input[type=\"email\"]",
       "url": "https://html.spec.whatwg.org/multipage/input.html#e-mail-state-(type=email)"
+    },
+    {
+      "title": "HTML AAM for the input[type=\"email\"]",
+      "url": "https://w3c.github.io/html-aam/#el-input-email"
     }
   ],
   "assertions": [

--- a/data/tech/html/input(type-file)_element.json
+++ b/data/tech/html/input(type-file)_element.json
@@ -6,8 +6,12 @@
   "is_form_control": true,
   "references": [
     {
-      "title": "HTML5 spec for input[type=\"file\"]",
+      "title": "WHATWG HTML spec for input[type=\"file\"]",
       "url": "https://html.spec.whatwg.org/multipage/input.html#file-upload-state-(type=file)"
+    },
+    {
+      "title": "HTML AAM for the input[type=\"file\"]",
+      "url": "https://w3c.github.io/html-aam/#el-input-file"
     }
   ],
   "related_issues": [

--- a/data/tech/html/input(type-hidden)_element.json
+++ b/data/tech/html/input(type-hidden)_element.json
@@ -6,8 +6,12 @@
   "is_form_control": true,
   "references": [
     {
-      "title": "HTML5 spec for input[type=\"hidden\"]",
+      "title": "WHATWG HTML spec for input[type=\"hidden\"]",
       "url": "https://html.spec.whatwg.org/multipage/input.html#hidden-state-(type=hidden)"
+    },
+    {
+      "title": "HTML AAM for the input[type=\"hidden\"]",
+      "url": "https://w3c.github.io/html-aam/#el-input-hidden"
     }
   ],
   "assertions": [

--- a/data/tech/html/input(type-image)_element.json
+++ b/data/tech/html/input(type-image)_element.json
@@ -6,8 +6,12 @@
   "is_form_control": true,
   "references": [
     {
-      "title": "HTML5 spec for input[type=\"image\"]",
+      "title": "WHATWG HTML spec for input[type=\"image\"]",
       "url": "https://html.spec.whatwg.org/multipage/input.html#image-button-state-(type=image)"
+    },
+    {
+      "title": "HTML AAM for the input[type=\"image\"]",
+      "url": "https://w3c.github.io/html-aam/#el-input-image"
     }
   ],
   "assertions": [

--- a/data/tech/html/input(type-month)_element.json
+++ b/data/tech/html/input(type-month)_element.json
@@ -6,8 +6,13 @@
   "is_form_control": true,
   "references": [
     {
-      "title": "HTML5 spec for input[type=\"month\"]",
+      "title": "WHATWG HTML spec for input[type=\"month\"]",
       "url": "https://html.spec.whatwg.org/multipage/input.html#month-state-(type=month)"
+    }
+    ,
+    {
+      "title": "HTML AAM for the input[type=\"month\"]",
+      "url": "https://w3c.github.io/html-aam/#el-input-month"
     }
   ],
   "assertions": [

--- a/data/tech/html/input(type-number)_element.json
+++ b/data/tech/html/input(type-number)_element.json
@@ -6,8 +6,12 @@
   "is_form_control": true,
   "references": [
     {
-      "title": "HTML5 spec for input[type=\"number\"]",
+      "title": "WHATWG HTML spec for input[type=\"number\"]",
       "url": "https://html.spec.whatwg.org/multipage/input.html#number-state-(type=number)"
+    },
+    {
+      "title": "HTML AAM for the input[type=\"number\"]",
+      "url": "https://w3c.github.io/html-aam/#el-input-number"
     }
   ],
   "assertions": [

--- a/data/tech/html/input(type-password)_element.json
+++ b/data/tech/html/input(type-password)_element.json
@@ -6,8 +6,12 @@
   "is_form_control": true,
   "references": [
     {
-      "title": "HTML5 spec for input[type=\"password\"]",
+      "title": "WHATWG HTML spec for input[type=\"password\"]",
       "url": "https://html.spec.whatwg.org/multipage/input.html#password-state-(type=password)"
+    },
+    {
+      "title": "HTML AAM for the input[type=\"password\"]",
+      "url": "https://w3c.github.io/html-aam/#el-input-password"
     }
   ],
   "assertions": [

--- a/data/tech/html/input(type-radio)_element.json
+++ b/data/tech/html/input(type-radio)_element.json
@@ -6,8 +6,12 @@
   "is_form_control": true,
   "references": [
     {
-      "title": "HTML5 spec for input[type=\"radio\"]",
+      "title": "WHATWG HTML spec for input[type=\"radio\"]",
       "url": "https://html.spec.whatwg.org/multipage/input.html#radio-button-state-(type=radio)"
+    },
+    {
+      "title": "HTML AAM for the input[type=\"radio\"]",
+      "url": "https://w3c.github.io/html-aam/#el-input-radio"
     }
   ],
   "assertions": [

--- a/data/tech/html/input(type-range)_element.json
+++ b/data/tech/html/input(type-range)_element.json
@@ -6,8 +6,12 @@
   "is_form_control": true,
   "references": [
     {
-      "title": "HTML5 spec for input[type=\"range\"]",
+      "title": "WHATWG HTML spec for input[type=\"range\"]",
       "url": "https://html.spec.whatwg.org/multipage/input.html#range-state-(type=range)"
+    },
+    {
+      "title": "HTML AAM for the input[type=\"range\"]",
+      "url": "https://w3c.github.io/html-aam/#el-input-range"
     }
   ],
   "related_features": [

--- a/data/tech/html/input(type-reset)_element.json
+++ b/data/tech/html/input(type-reset)_element.json
@@ -6,8 +6,12 @@
   "is_form_control": true,
   "references": [
     {
-      "title": "HTML5 spec for input[type=\"reset\"]",
+      "title": "WHATWG HTML spec for input[type=\"reset\"]",
       "url": "https://html.spec.whatwg.org/multipage/input.html#range-state-(type=range)"
+    },
+    {
+      "title": "HTML AAM for the input[type=\"reset\"]",
+      "url": "https://w3c.github.io/html-aam/#el-input-reset"
     }
   ],
   "assertions": [

--- a/data/tech/html/input(type-search)_element.json
+++ b/data/tech/html/input(type-search)_element.json
@@ -6,8 +6,12 @@
   "is_form_control": true,
   "references": [
     {
-      "title": "HTML5 spec for input[type=\"search\"]",
+      "title": "WHATWG HTML spec for input[type=\"search\"]",
       "url": "https://html.spec.whatwg.org/multipage/input.html#text-(type=text)-state-and-search-state-(type=search)"
+    },
+    {
+      "title": "HTML AAM for the input[type=\"search\"]",
+      "url": "https://w3c.github.io/html-aam/#el-input-search"
     }
   ],
   "assertions": [

--- a/data/tech/html/input(type-submit)_element.json
+++ b/data/tech/html/input(type-submit)_element.json
@@ -6,8 +6,12 @@
   "is_form_control": true,
   "references": [
     {
-      "title": "HTML5 spec for input[type=\"submit\"]",
+      "title": "WHATWG HTML spec for input[type=\"submit\"]",
       "url": "https://html.spec.whatwg.org/multipage/input.html#submit-button-state-(type=submit)"
+    },
+    {
+      "title": "HTML AAM for the input[type=\"submit\"]",
+      "url": "https://w3c.github.io/html-aam/#el-input-submit"
     }
   ],
   "assertions": [

--- a/data/tech/html/input(type-tel)_element.json
+++ b/data/tech/html/input(type-tel)_element.json
@@ -6,8 +6,12 @@
   "is_form_control": true,
   "references": [
     {
-      "title": "HTML5 spec for input[type=\"tel\"]",
+      "title": "WHATWG HTML spec for input[type=\"tel\"]",
       "url": "https://html.spec.whatwg.org/multipage/input.html#telephone-state-(type=tel)"
+    },
+    {
+      "title": "HTML AAM for the input[type=\"tel\"]",
+      "url": "https://w3c.github.io/html-aam/#el-input-tel"
     }
   ],
   "assertions": [

--- a/data/tech/html/input(type-text)_element.json
+++ b/data/tech/html/input(type-text)_element.json
@@ -6,8 +6,12 @@
   "is_form_control": true,
   "references": [
     {
-      "title": "HTML5 spec for input[type=\"text\"]",
+      "title": "WHATWG HTML spec for input[type=\"text\"]",
       "url": "https://html.spec.whatwg.org/multipage/input.html#text-(type=text)-state-and-search-state-(type=search)"
+    },
+    {
+      "title": "HTML AAM for the input[type=\"text\"]",
+      "url": "https://w3c.github.io/html-aam/#el-input-text"
     }
   ],
   "assertions": [

--- a/data/tech/html/input(type-time)_element.json
+++ b/data/tech/html/input(type-time)_element.json
@@ -6,8 +6,12 @@
   "is_form_control": true,
   "references": [
     {
-      "title": "HTML5 spec for input[type=\"time\"]",
+      "title": "WHATWG HTML spec for input[type=\"time\"]",
       "url": "https://html.spec.whatwg.org/multipage/input.html#time-state-(type=time)"
+    },
+    {
+      "title": "HTML AAM for the input[type=\"time\"]",
+      "url": "https://w3c.github.io/html-aam/#el-input-time"
     }
   ],
   "assertions": [

--- a/data/tech/html/input(type-url)_element.json
+++ b/data/tech/html/input(type-url)_element.json
@@ -6,8 +6,12 @@
   "is_form_control": true,
   "references": [
     {
-      "title": "HTML5 spec for input[type=\"url\"]",
+      "title": "WHATWG HTML spec for input[type=\"url\"]",
       "url": "https://html.spec.whatwg.org/multipage/input.html#url-state-(type=url)"
+    },
+    {
+      "title": "HTML AAM for the input[type=\"url\"]",
+      "url": "https://w3c.github.io/html-aam/#el-input-url"
     }
   ],
   "assertions": [

--- a/data/tech/html/input(type-week)_element.json
+++ b/data/tech/html/input(type-week)_element.json
@@ -6,8 +6,12 @@
   "is_form_control": true,
   "references": [
     {
-      "title": "HTML5 spec for input[type=\"week\"]",
+      "title": "WHATWG HTML spec for input[type=\"week\"]",
       "url": "https://html.spec.whatwg.org/multipage/input.html#week-state-(type=week)"
+    },
+    {
+      "title": "HTML AAM for the input[type=\"week\"]",
+      "url": "https://w3c.github.io/html-aam/#el-input-week"
     }
   ],
   "assertions": [

--- a/data/tech/html/label_element.json
+++ b/data/tech/html/label_element.json
@@ -5,16 +5,16 @@
   "recommendation": "Use the explicit label technique wherever possible and avoid depending on implicit labels.",
   "references": [
     {
-      "title": "HTML5 spec for label element",
-      "url": "https://w3c.github.io/html/sec-forms.html#the-label-element"
+      "title": "WHATWG HTML spec for the label element",
+      "url": "https://html.spec.whatwg.org/multipage/forms.html#the-label-element"
     },
     {
-      "title": "HTML5 Labelable Elements",
-      "url": "https://w3c.github.io/html/sec-forms.html#labelable-element"
+      "title": "HTML Labelable Elements",
+      "url": "https://html.spec.whatwg.org/multipage/forms.html#category-label"
     },
     {
-      "title": "HTML Accessibility API Mapping for the Label Element",
-      "url": "https://w3c.github.io/html-aam/#el-labelt"
+      "title": "HTML AAM for the label element",
+      "url": "https://w3c.github.io/html-aam/#el-label"
     }
   ],
   "assertions": [

--- a/data/tech/html/lang_attribute.json
+++ b/data/tech/html/lang_attribute.json
@@ -4,12 +4,12 @@
   "description": "The HTML `lang` attributes lets authors change the language for content on a page.",
   "references": [
     {
-      "title": "HTML5 spec for lang attribute",
-      "url": "https://w3c.github.io/html/dom.html#the-lang-and-xmllang-attributes"
+      "title": "WHATWG HTML spec for the lang attribute",
+      "url": "https://html.spec.whatwg.org/multipage/dom.html#attr-lang"
     },
     {
-      "title": "HTML AAM rules for the lang attribute",
-      "url": "https://www.w3.org/TR/html-aam-1.0/#details-id-214"
+      "title": "HTML AAM for the lang attribute",
+      "url": "https://w3c.github.io/html-aam/#att-lang"
     }
   ],
   "assertions": [

--- a/data/tech/html/legend_element.json
+++ b/data/tech/html/legend_element.json
@@ -8,8 +8,12 @@
   ],
   "references": [
     {
-      "title": "HTML5 spec for the fieldset element",
+      "title": "HTML spec for the legend element",
       "url": "https://html.spec.whatwg.org/multipage/form-elements.html#the-legend-element"
+    },
+    {
+      "title": "HTML AAM for the legend element",
+      "url": "https://w3c.github.io/html-aam/#el-legend"
     }
   ],
   "assertions": [

--- a/data/tech/html/li_element.json
+++ b/data/tech/html/li_element.json
@@ -5,8 +5,12 @@
   "description": "",
   "references": [
     {
-      "title": "HTML5 spec for li",
-      "url": "https://w3c.github.io/html/grouping-content.html#the-li-element"
+      "title": "WHATWG HTML spec for the li element",
+      "url": "https://html.spec.whatwg.org/multipage/grouping-content.html#the-li-element"
+    },
+    {
+      "title": "HTML AAM for the li element",
+      "url": "https://w3c.github.io/html-aam/#el-li"
     }
   ],
   "related_features": [

--- a/data/tech/html/list_attribute.json
+++ b/data/tech/html/list_attribute.json
@@ -8,8 +8,12 @@
   ],
   "references": [
     {
-      "title": "WHATWG HTML5 spec for the list attribute",
+      "title": "WHATWG HTML spec for the list attribute",
       "url": "https://html.spec.whatwg.org/multipage/input.html#the-list-attribute"
+    },
+    {
+      "title": "HTML AAM for the list attribute",
+      "url": "https://w3c.github.io/html-aam/#att-list"
     }
   ],
   "assertions": [

--- a/data/tech/html/max_attribute.json
+++ b/data/tech/html/max_attribute.json
@@ -8,12 +8,12 @@
   ],
   "references": [
     {
-      "title": "WHATWG HTML5 spec for the min and max attributes",
+      "title": "WHATWG HTML spec for the min and max attributes",
       "url": "https://html.spec.whatwg.org/multipage/input.html#the-min-and-max-attributes"
     },
     {
       "title": "HTML AAM for the max attribute applied to an input",
-      "url": "https://www.w3.org/TR/html-aam-1.0/#details-id-208"
+      "url": "https://w3c.github.io/html-aam/#att-max-input"
     }
   ],
   "assertions": [

--- a/data/tech/html/maxlength_attribute.json
+++ b/data/tech/html/maxlength_attribute.json
@@ -5,8 +5,16 @@
   "description": "The min and max attributes indicate the allowed range of values for the element.",
   "references": [
     {
-      "title": "WHATWG HTML5 spec for the minlength and maxlength attributes",
+      "title": "WHATWG HTML spec for the minlength and maxlength attributes",
       "url": "https://html.spec.whatwg.org/multipage/input.html#the-maxlength-and-minlength-attributes"
+    },
+    {
+      "title": "HTML AAM for the maxlength attribute",
+      "url": "https://w3c.github.io/html-aam/#att-maxlength"
+    },
+    {
+      "title": "HTML AAM for the minlength attribute",
+      "url": "https://w3c.github.io/html-aam/#att-minlength"
     }
   ],
   "assertions": [

--- a/data/tech/html/min_attribute.json
+++ b/data/tech/html/min_attribute.json
@@ -8,12 +8,12 @@
   ],
   "references": [
     {
-      "title": "WHATWG HTML5 spec for the min and max attributes",
+      "title": "WHATWG HTML spec for the min and max attributes",
       "url": "https://html.spec.whatwg.org/multipage/input.html#the-min-and-max-attributes"
     },
     {
-      "title": "HTML AAM for the max attribute applied to an input",
-      "url": "https://www.w3.org/TR/html-aam-1.0/#details-id-213"
+      "title": "HTML AAM for the min attribute applied to an input",
+      "url": "https://w3c.github.io/html-aam/#att-min-input"
     }
   ],
   "assertions": [

--- a/data/tech/html/ol_element.json
+++ b/data/tech/html/ol_element.json
@@ -8,8 +8,12 @@
   ],
   "references": [
     {
-      "title": "HTML5 spec for ol",
-      "url": "https://w3c.github.io/html/grouping-content.html#the-ol-element"
+      "title": "WHATWG HTML spec for the ol element",
+      "url": "https://html.spec.whatwg.org/multipage/grouping-content.html#the-ol-element"
+    },
+    {
+      "title": "HTML AAM for the ol element",
+      "url": "https://w3c.github.io/html-aam/#el-ol"
     }
   ],
   "assertions": [

--- a/data/tech/html/optgroup_element.json
+++ b/data/tech/html/optgroup_element.json
@@ -9,8 +9,12 @@
   ],
   "references": [
     {
-      "title": "HTML5 spec for opgroup",
+      "title": "WHATWG HTML spec for the optgroup element",
       "url": "https://html.spec.whatwg.org/multipage/form-elements.html#the-optgroup-element"
+    },
+    {
+      "title": "HTML AAM for the optgroup element",
+      "url": "https://w3c.github.io/html-aam/#el-optgroup"
     }
   ],
   "related_issues": [

--- a/data/tech/html/option_element.json
+++ b/data/tech/html/option_element.json
@@ -10,12 +10,12 @@
   ],
   "references": [
     {
-      "title": "WHATWG HTML5 spec for option",
+      "title": "WHATWG HTML spec for the option element",
       "url": "https://html.spec.whatwg.org/#the-option-element"
     },
     {
-      "title": "HTML AAM rules for the option element",
-      "url": "https://www.w3.org/TR/html-aam-1.0/#details-id-103"
+      "title": "HTML AAM for the option element",
+      "url": "https://w3c.github.io/html-aam/#el-option"
     }
   ],
   "assertions": [

--- a/data/tech/html/p_element.json
+++ b/data/tech/html/p_element.json
@@ -5,12 +5,12 @@
   "description": "",
   "references": [
     {
-      "title": "HTML5 spec for p",
-      "url": "https://w3c.github.io/html/grouping-content.html#the-p-element"
+      "title": "WHATWG HTML spec for the p element",
+      "url": "https://html.spec.whatwg.org/multipage/grouping-content.html#the-p-element"
     },
     {
-      "title": "HTML AAM rules for the p element",
-      "url": "https://www.w3.org/TR/html-aam-1.0/#details-id-105"
+      "title": "HTML AAM for the p element",
+      "url": "https://w3c.github.io/html-aam/#el-p"
     }
   ],
   "assertions": [],

--- a/data/tech/html/required_attribute.json
+++ b/data/tech/html/required_attribute.json
@@ -5,8 +5,12 @@
   "description": "The required attribute is a boolean attribute. When specified, the element is required.",
   "references": [
     {
-      "title": "HTML5 spec for the required attribute",
+      "title": "WHATWG HTML spec for the required attribute",
       "url": "https://html.spec.whatwg.org/multipage/input.html#the-required-attribute"
+    },
+    {
+      "title": "HTML AAM for the required attribute",
+      "url": "https://w3c.github.io/html-aam/#att-required"
     }
   ],
   "assertions": [

--- a/data/tech/html/role_attribute.json
+++ b/data/tech/html/role_attribute.json
@@ -5,7 +5,7 @@
   "description": "The role attribute is used to convey the purpose of various elements to users of assistive technology. While the role attribute is defined in ARIA, these expectations test the attribute as implemented in HTML.",
   "references": [
     {
-      "title": "HTML5 spec for the role attribute",
+      "title": "WHATWG HTML spec for the role attribute",
       "url": "https://html.spec.whatwg.org/multipage/infrastructure.html#attr-aria-role"
     },
     {

--- a/data/tech/html/scope_attribute.json
+++ b/data/tech/html/scope_attribute.json
@@ -4,12 +4,12 @@
   "description": "The HTML `scope` attributes lets authors define the scope of a table header (row or column).",
   "references": [
     {
-      "title": "HTML5 spec for scope attribute",
-      "url": "https://www.w3.org/TR/html/tabular-data.html#element-attrdef-th-scope"
+      "title": "WHATWG HTML spec for the scope attribute",
+      "url": "https://html.spec.whatwg.org/multipage/tables.html#attr-th-scope"
     },
     {
-      "title": "HTML AAM rules for the scope attribute",
-      "url": "https://www.w3.org/TR/html-aam-1.0/#details-id-251"
+      "title": "HTML AAM for the scope attribute",
+      "url": "https://w3c.github.io/html-aam/#att-scope"
     }
   ],
   "assertions": [

--- a/data/tech/html/section_element.json
+++ b/data/tech/html/section_element.json
@@ -9,12 +9,12 @@
   ],
   "references": [
     {
-      "title": "HTML5 spec for section",
-      "url": "https://w3c.github.io/html/sections.html#the-section-element"
+      "title": "WHATWG HTML spec for the section element",
+      "url": "https://html.spec.whatwg.org/multipage/sections.html#the-section-element"
     },
     {
-      "title": "HTML AAM role mapping for the section element",
-      "url": "https://www.w3.org/TR/html-aam-1.0/#details-id-119"
+      "title": "HTML AAM for the section element",
+      "url": "https://w3c.github.io/html-aam/#el-section"
     },
     {
       "title": "HTML AAM accessible name mapping for the section element",

--- a/data/tech/html/select_element.json
+++ b/data/tech/html/select_element.json
@@ -6,8 +6,12 @@
   "is_form_control": true,
   "references": [
     {
-      "title": "WHATWG HTML5 spec for select",
+      "title": "WHATWG HTML spec for the select element",
       "url": "https://html.spec.whatwg.org/#the-select-element"
+    },
+    {
+      "title": "HTML AAM for the select element",
+      "url": "https://w3c.github.io/html-aam/#el-select"
     }
   ],
   "related_features": [

--- a/data/tech/html/span_element.json
+++ b/data/tech/html/span_element.json
@@ -5,8 +5,12 @@
   "description": "",
   "references": [
     {
-      "title": "HTML5 spec for sapn",
+      "title": "WHATWG HTML spec for the span element",
       "url": "https://html.spec.whatwg.org/#the-span-element"
+    },
+    {
+      "title": "HTML AAM for the span element",
+      "url": "https://w3c.github.io/html-aam/#el-span"
     }
   ],
   "assertions": [],

--- a/data/tech/html/summary_element.json
+++ b/data/tech/html/summary_element.json
@@ -8,8 +8,12 @@
   ],
   "references": [
     {
-      "title": "WHATWG HTML5 spec for the summary element",
+      "title": "WHATWG HTML spec for the summary element",
       "url": "https://html.spec.whatwg.org/multipage/interactive-elements.html#the-summary-element"
+    },
+    {
+      "title": "HTML AAM for the summary element",
+      "url": "https://w3c.github.io/html-aam/#el-summary"
     }
   ],
   "related_issues": [

--- a/data/tech/html/svg_element.json
+++ b/data/tech/html/svg_element.json
@@ -5,12 +5,12 @@
   "description": "The SVG element in HTML is for inline SVG graphics.",
   "references": [
     {
-      "title": "HTML5 spec for svg",
-      "url": "https://w3c.github.io/html/semantics-embedded-content.html#svg"
+      "title": "WHATWG HTML spec for the svg element",
+      "url": "https://html.spec.whatwg.org/multipage/embedded-content-other.html#svg-0"
     },
     {
-      "title": "HTML AAM role mapping for the SVG element",
-      "url": "https://www.w3.org/TR/html-aam-1.0/#details-id-130"
+      "title": "HTML AAM for the svg element",
+      "url": "https://w3c.github.io/html-aam/#el-svg"
     },
     {
       "title": "HTML AAM accessible name mapping for SVGs",

--- a/data/tech/html/table_element.json
+++ b/data/tech/html/table_element.json
@@ -9,8 +9,12 @@
   ],
   "references": [
     {
-      "title": "HTML5 spec for td",
-      "url": "https://w3c.github.io/html/tabular-data.html#the-table-element"
+      "title": "WHATWG HTML spec for table element",
+      "url": "https://html.spec.whatwg.org/multipage/tables.html#the-table-element"
+    },
+    {
+      "title": "HTML AAM for the table element",
+      "url": "https://w3c.github.io/html-aam/#el-table"
     }
   ],
   "assertions": [

--- a/data/tech/html/td_element.json
+++ b/data/tech/html/td_element.json
@@ -9,8 +9,12 @@
   ],
   "references": [
     {
-      "title": "HTML5 spec for td",
-      "url": "https://w3c.github.io/html/tabular-data.html#the-td-element"
+      "title": "WHATWG HTML spec for td element",
+      "url": "https://html.spec.whatwg.org/multipage/tables.html#the-td-element"
+    },
+    {
+      "title": "HTML AAM for the td element",
+      "url": "https://w3c.github.io/html-aam/#el-td"
     }
   ],
   "assertions": [

--- a/data/tech/html/textarea_element.json
+++ b/data/tech/html/textarea_element.json
@@ -6,8 +6,12 @@
   "is_form_control": true,
   "references": [
     {
-      "title": "HTML5 spec for textarea",
+      "title": "WHATWG HTML spec for textarea element",
       "url": "https://html.spec.whatwg.org/multipage/form-elements.html#the-textarea-element"
+    },
+    {
+      "title": "HTML AAM for the textarea element",
+      "url": "https://w3c.github.io/html-aam/#el-textarea"
     }
   ],
   "assertions": [

--- a/data/tech/html/th_element.json
+++ b/data/tech/html/th_element.json
@@ -9,8 +9,12 @@
   ],
   "references": [
     {
-      "title": "HTML5 spec for th",
-      "url": "https://w3c.github.io/html/tabular-data.html#the-th-element"
+      "title": "WHATWG HTML spec for the th element",
+      "url": "https://html.spec.whatwg.org/multipage/tables.html#the-th-element"
+    },
+    {
+      "title": "HTML AAM for the th element",
+      "url": "https://w3c.github.io/html-aam/#el-th"
     }
   ],
   "assertions": [

--- a/data/tech/html/ul_element.json
+++ b/data/tech/html/ul_element.json
@@ -8,8 +8,12 @@
   ],
   "references": [
     {
-      "title": "HTML5 spec for ul",
-      "url": "https://w3c.github.io/html/grouping-content.html#the-ul-element"
+      "title": "WHATWG HTML spec for the ul element",
+      "url": "https://html.spec.whatwg.org/multipage/grouping-content.html#the-ul-element"
+    },
+    {
+      "title": "HTML AAM for the ul element",
+      "url": "https://w3c.github.io/html-aam/#el-ul"
     }
   ],
   "assertions": [


### PR DESCRIPTION
this commit makes all references to the HTML spec point to the WHATWG spec / have consistent naming of the link.  previous to this commit, many links to the W3C html spec would forward to the whatwg spec anyway, but certain attributes would result in broken forwarding links.  these attributes now all have the correct whatwg spec links.

this also adds / makes consistent all existing links to role mappings for each element/attribute.