### PR TITLE
Run tests v2

### DIFF
--- a/data/ATBrowsers.json
+++ b/data/ATBrowsers.json
@@ -294,6 +294,14 @@
             "sr/reading"
           ]
         },
+        "previous_unvisited_link": {
+          "command": "shift+u",
+          "name": "Previous unvisited link",
+          "tags": [
+            "elements",
+            "sr/reading"
+          ]
+        },
         "next_visited_link": {
           "command": "v",
           "name": "Next visited link",

--- a/data/schema/dev-test.json
+++ b/data/schema/dev-test.json
@@ -169,7 +169,12 @@
             }
           }
         },
-        "required": ["command", "css_target", "results"]
+        "anyOf": [
+          { "required":
+            [ "results", "command", "procedure_key" ] },
+          { "required":
+            [ "results", "command", "css_target", "before", "after" ] }
+        ]
       }
     },
     "assertion": {

--- a/data/tests/apg/modal-dialog-example.json
+++ b/data/tests/apg/modal-dialog-example.json
@@ -31,19 +31,248 @@
       "applied_to": "aria/dialog_role"
     }
   ],
+  "procedures": [
+    {
+      "key": "open_dialog",
+      "title": "open the dialog",
+      "css_target": "*[aria-role=\"dialog\" aria-modal=\"true\"]",
+      "steps": [
+        {
+          "action": "set mode to",
+          "value": "auto"
+        },
+        {
+          "action": "navigate forward to",
+          "selector": "button",
+          "ensure_at_location": {
+            "virtual": "on selector",
+            "focus": "on selector"
+          }
+        },
+        {
+          "action": "issue command",
+          "observe": "dialog will open and focus will be moved to the target",
+          "ensure_at_location": {
+            "virtual": "within target",
+            "focus": "within target"
+          }
+        }
+      ]
+    },
+    {
+      "key": "navigate_backwards_out_of_open_modal",
+      "title": "attempt to navigate backwards to content behind the open modal",
+      "css_target": "*[aria-role=\"dialog\" *[aria-modal=\"true\"]",
+      "steps": [
+        {
+          "action": "set mode to",
+          "value": "auto"
+        },
+        {
+          "action": "navigate forward to",
+          "selector": "button",
+          "ensure_at_location": {
+            "virtual": "on selector",
+            "focus": "on selector"
+          }
+        },
+        {
+          "action": "issue command",
+          "command": "activate_button",
+          "summary": "dialog will open and focus will be moved to the target",
+          "ensure_at_location": {
+            "virtual": "within target",
+            "focus": "within target"
+          }
+        },
+        {
+          "action": "issue command",
+          "multiple": true,
+          "summary": "attempt to navigate backwards past the start of the dialog",
+          "ensure_at_location": {
+            "virtual": "before target",
+            "focus": "before target"
+          }
+        }
+      ]
+    },
+    {
+      "key": "navigate_backwards_out_of_open_modal_VO",
+      "title": "attempt to navigate backwards to content behind the open modal",
+      "css_target": "*[aria-role=\"dialog\" *[aria-modal=\"true\"]",
+      "steps": [
+        {
+          "action": "set mode to",
+          "value": "auto"
+        },
+        {
+          "action": "navigate forward to",
+          "selector": "button",
+          "ensure_at_location": {
+            "virtual": "on selector",
+            "focus": "on selector"
+          }
+        },
+        {
+          "action": "issue command",
+          "command": "activate_button",
+          "summary": "dialog will open and focus will be moved to the target",
+          "ensure_at_location": {
+            "virtual": "within target",
+            "focus": "within target"
+          }
+        },
+        {
+          "action": "issue command",
+          "command": "exit_object",
+          "summary": "navigate to the dialog container",
+          "ensure_at_location": {
+            "virtual": "target",
+            "focus": "target"
+          }
+        },
+        {
+          "action": "issue command",
+          "multiple": true,
+          "summary": "attempt to navigate backwards past the start of the dialog",
+          "ensure_at_location": {
+            "virtual": "before target",
+            "focus": "before target"
+          }
+        }
+      ]
+    },
+    {
+      "key": "navigate_to_modal_container_VO",
+      "title": "navigate to modal container",
+      "css_target": "*[aria-role=\"dialog\" *[aria-modal=\"true\"]",
+      "steps": [
+        {
+          "action": "set mode to",
+          "value": "auto"
+        },
+        {
+          "action": "navigate forward to",
+          "selector": "button",
+          "ensure_at_location": {
+            "virtual": "on selector",
+            "focus": "on selector"
+          }
+        },
+        {
+          "action": "issue command",
+          "command": "activate_button",
+          "summary": "dialog will open and focus will be moved to the target",
+          "ensure_at_location": {
+            "virtual": "within target",
+            "focus": "within target"
+          }
+        },
+        {
+          "action": "issue command",
+          "summary": "navigate to the modal container",
+          "ensure_at_location": {
+            "virtual": "target",
+            "focus": "target"
+          }
+        }
+      ]
+    },
+    {
+      "key": "open_element_list_while_modal_open",
+      "title": "Open the element list while the modal is open",
+      "css_target": "*[aria-modal=true]",
+      "steps": [
+        {
+          "action": "set mode to",
+          "value": "auto"
+        },
+        {
+          "action": "navigate forward to",
+          "selector": "button",
+          "ensure_at_location": {
+            "virtual": "on selector",
+            "focus": "on selector"
+          }
+        },
+        {
+          "action": "issue command",
+          "command": "activate_button",
+          "summary": "dialog will open and focus will be moved to the target",
+          "ensure_at_location": {
+            "virtual": "within target",
+            "focus": "within target"
+          }
+        },
+        {
+          "action": "set mode to",
+          "value": "browse"
+        },
+        {
+          "action": "issue command",
+          "summary": "attempt to navigate to content behind the modal via the element list"
+        }
+      ]
+    },
+    {
+      "key": "navigate_forward_into_open_dialog",
+      "title": "navigate forward into open dialog",
+      "css_target": "*[aria-role=\"dialog\"]",
+      "steps": [
+        {
+          "action": "set mode to",
+          "value": "auto"
+        },
+        {
+          "action": "navigate forward to",
+          "selector": "button",
+          "ensure_at_location": {
+            "virtual": "on selector",
+            "focus": "on selector"
+          }
+        },
+        {
+          "action": "issue command",
+          "command": "activate_button",
+          "summary": "dialog will open and focus will be moved to the target",
+          "ensure_at_location": {
+            "virtual": "within target",
+            "focus": "within target"
+          }
+        },
+        {
+          "action": "set mode to",
+          "value": "browse"
+        },
+        {
+          "action": "issue command",
+          "command": "previous_item",
+          "multiple": true,
+          "summary": "navigate backwards out of the open dialog",
+          "ensure_at_location": {
+            "virtual": "before target",
+            "focus": "before target"
+          }
+        },
+        {
+          "action": "issue command",
+          "multiple": true,
+          "summary": "navigate forwards into the open dialog",
+          "ensure_at_location": {
+            "virtual": "within target",
+            "focus": "within target"
+          }
+        }
+      ]
+    }
+  ],
   "commands": {
     "dragon_win": {},
     "jaws": {
       "chrome": [
         {
           "command": "activate_button",
-          "css_target": "*[aria-role=\"dialog\" aria-modal=\"true\"]",
-          "before": {
-            "mode": "auto",
-            "virtual_location": "before target",
-            "focus_location": "before target"
-          },
-          "after": "within target",
+          "procedure_key": "open_dialog",
           "output": "\"add delivery address, modal dialog, street: edit, type in text\"",
           "results": [
             {
@@ -69,13 +298,7 @@
         },
         {
           "command": "previous_item",
-          "css_target": "*[aria-role=\"dialog\" *[aria-modal=\"true\"]",
-          "before": {
-            "mode": "auto",
-            "virtual_location": "within target",
-            "focus_location": "within target"
-          },
-          "after": "before target",
+          "procedure_key": "navigate_backwards_out_of_open_modal",
           "output": "not able to move outside of the modal",
           "results": [
             {
@@ -93,13 +316,7 @@
         },
         {
           "command": "open_element_list",
-          "css_target": "*[aria-modal=true]",
-          "before": {
-            "mode": "auto",
-            "virtual_location": "na",
-            "focus_location": "na"
-          },
-          "after": "na",
+          "procedure_key": "open_element_list_while_modal_open",
           "output": "outside content was displayed in content lists, such as the of links, etc. Note: not possible to navigate to an item in the list.",
           "results": [
             {
@@ -111,14 +328,8 @@
           ]
         },
         {
-          "command": "next_unvisited_link",
-          "css_target": "*[aria-modal=true]",
-          "before": {
-            "mode": "auto",
-            "virtual_location": "before target",
-            "focus_location": "before target"
-          },
-          "after": "target",
+          "command": "previous_unvisited_link",
+          "procedure_key": "navigate_backwards_out_of_open_modal",
           "output": "no links were found",
           "results": [
             {
@@ -134,13 +345,7 @@
       "ie": [
         {
           "command": "activate_button",
-          "css_target": "*[aria-role=\"dialog\" aria-modal=\"true\"]",
-          "before": {
-            "mode": "auto",
-            "virtual_location": "before target",
-            "focus_location": "before target"
-          },
-          "after": "within target",
+          "procedure_key": "open_dialog",
           "output": "\"add delivery address, modal dialog, street: edit, type in text\"",
           "results": [
             {
@@ -166,13 +371,7 @@
         },
         {
           "command": "previous_item",
-          "css_target": "*[aria-role=\"dialog\" aria-modal=\"true\"]",
-          "before": {
-            "mode": "auto",
-            "virtual_location": "within target",
-            "focus_location": "within target"
-          },
-          "after": "before target",
+          "procedure_key": "navigate_backwards_out_of_open_modal",
           "output": "not able to move outside of the modal",
           "results": [
             {
@@ -190,13 +389,7 @@
         },
         {
           "command": "open_element_list",
-          "css_target": "*[aria-modal=true]",
-          "before": {
-            "mode": "auto",
-            "virtual_location": "na",
-            "focus_location": "na"
-          },
-          "after": "na",
+          "procedure_key": "open_element_list_while_modal_open",
           "output": "outside content was displayed in content lists, such as the of links, etc. Note: it IS possible to navigate to headings in this list and break free from the modal.",
           "results": [
             {
@@ -208,14 +401,8 @@
           ]
         },
         {
-          "command": "next_unvisited_link",
-          "css_target": "*[aria-modal=true]",
-          "before": {
-            "mode": "auto",
-            "virtual_location": "before target",
-            "focus_location": "before target"
-          },
-          "after": "target",
+          "command": "previous_unvisited_link",
+          "procedure_key": "navigate_backwards_out_of_open_modal",
           "output": "no links were found",
           "results": [
             {
@@ -230,13 +417,7 @@
       "firefox": [
         {
           "command": "activate_button",
-          "css_target": "*[aria-role=\"dialog\" aria-modal=\"true\"]",
-          "before": {
-            "mode": "auto",
-            "virtual_location": "before target",
-            "focus_location": "before target"
-          },
-          "after": "within target",
+          "procedure_key": "open_dialog",
           "output": "\"add delivery address, modal dialog...\"",
           "results": [
             {
@@ -262,13 +443,7 @@
         },
         {
           "command": "previous_item",
-          "css_target": "*[aria-role=\"dialog\" aria-modal=\"true\"]",
-          "before": {
-            "mode": "auto",
-            "virtual_location": "within target",
-            "focus_location": "within target"
-          },
-          "after": "before target",
+          "procedure_key": "navigate_backwards_out_of_open_modal",
           "output": "not able to move outside of the modal",
           "results": [
             {
@@ -287,13 +462,7 @@
         },
         {
           "command": "open_element_list",
-          "css_target": "*[aria-modal=true]",
-          "before": {
-            "mode": "auto",
-            "virtual_location": "na",
-            "focus_location": "na"
-          },
-          "after": "na",
+          "procedure_key": "open_element_list_while_modal_open",
           "output": "outside content was displayed in content lists, such as the of links, etc.",
           "results": [
             {
@@ -305,14 +474,8 @@
           ]
         },
         {
-          "command": "next_unvisited_link",
-          "css_target": "*[aria-modal=true]",
-          "before": {
-            "mode": "auto",
-            "virtual_location": "before target",
-            "focus_location": "before target"
-          },
-          "after": "target",
+          "command": "previous_unvisited_link",
+          "procedure_key": "navigate_backwards_out_of_open_modal",
           "output": "no links were found",
           "results": [
             {
@@ -330,13 +493,7 @@
       "edge": [
         {
           "command": "activate_button",
-          "css_target": "*[aria-role=\"dialog\" aria-modal=\"true\"]",
-          "before": {
-            "mode": "auto",
-            "virtual_location": "before target",
-            "focus_location": "before target"
-          },
-          "after": "within target",
+          "procedure_key": "open_dialog",
           "output": "\"<title of page>, tab, Add delivery address, dialog, street, edit, scan off, heading level 2, add delivery address, street\"",
           "results": [
             {
@@ -360,13 +517,7 @@
         },
         {
           "command": "next_item",
-          "css_target": "*[aria-role=\"dialog\"]",
-          "before": {
-            "mode": "auto",
-            "virtual_location": "before target",
-            "focus_location": "before target"
-          },
-          "after": "within target",
+          "procedure_key": "navigate_forward_into_open_dialog",
           "output": "\"heading level 2, add delivery address\"",
           "results": [
             {
@@ -389,13 +540,7 @@
         },
         {
           "command": "previous_item",
-          "css_target": "*[aria-role=\"dialog\" aria-modal=\"true\"]",
-          "before": {
-            "mode": "auto",
-            "virtual_location": "within target",
-            "focus_location": "within target"
-          },
-          "after": "before target",
+          "procedure_key": "navigate_backwards_out_of_open_modal",
           "output": "\"Link, modal dialog design pattern in wai-aria authoring practices 1.2\"",
           "results": [
             {
@@ -413,13 +558,7 @@
         },
         {
           "command": "previous_heading",
-          "css_target": "*[aria-modal=true]",
-          "before": {
-            "mode": "auto",
-            "virtual_location": "within target",
-            "focus_location": "within target"
-          },
-          "after": "before target",
+          "procedure_key": "navigate_backwards_out_of_open_modal",
           "output": "headings were found outside of the modal",
           "results": [
             {
@@ -436,13 +575,7 @@
       "chrome": [
         {
           "command": "activate_button",
-          "css_target": "*[aria-role=\"dialog\" aria-modal=\"true\"]",
-          "before": {
-            "mode": "auto",
-            "virtual_location": "before target",
-            "focus_location": "before target"
-          },
-          "after": "within target",
+          "procedure_key": "open_dialog",
           "output": "\"Add delivery address, dialog, street, edit, blank\"",
           "results": [
             {
@@ -466,13 +599,7 @@
         },
         {
           "command": "previous_item",
-          "css_target": "*[aria-role=\"dialog\" aria-modal=\"true\"]",
-          "before": {
-            "mode": "auto",
-            "virtual_location": "within target",
-            "focus_location": "within target"
-          },
-          "after": "before target",
+          "procedure_key": "navigate_backwards_out_of_open_modal",
           "output": "not able to move outside of the modal",
           "results": [
             {
@@ -491,13 +618,7 @@
         },
         {
           "command": "previous_form_field",
-          "css_target": "*[aria-modal=true]",
-          "before": {
-            "mode": "auto",
-            "virtual_location": "within target",
-            "focus_location": "within target"
-          },
-          "after": "before target",
+          "procedure_key": "navigate_backwards_out_of_open_modal",
           "output": "no outside form fields were found",
           "results": [
             {
@@ -510,13 +631,7 @@
         },
         {
           "command": "previous_link",
-          "css_target": "*[aria-modal=true]",
-          "before": {
-            "mode": "auto",
-            "virtual_location": "within target",
-            "focus_location": "within target"
-          },
-          "after": "before target",
+          "procedure_key": "navigate_backwards_out_of_open_modal",
           "output": "no outside links were found",
           "results": [
             {
@@ -529,13 +644,7 @@
         },
         {
           "command": "open_element_list",
-          "css_target": "*[aria-modal=true]",
-          "before": {
-            "mode": "auto",
-            "virtual_location": "na",
-            "focus_location": "na"
-          },
-          "after": "na",
+          "procedure_key": "open_element_list_while_modal_open",
           "output": "only content within the modal was included in the lists",
           "results": [
             {
@@ -550,13 +659,7 @@
       "firefox": [
         {
           "command": "activate_button",
-          "css_target": "*[aria-role=\"dialog\" aria-modal=\"true\"]",
-          "before": {
-            "mode": "auto",
-            "virtual_location": "before target",
-            "focus_location": "before target"
-          },
-          "after": "within target",
+          "procedure_key": "open_dialog",
           "output": "\"Add delivery address, dialog, street, edit, has auto complete, blank.\"",
           "results": [
             {
@@ -580,13 +683,7 @@
         },
         {
           "command": "previous_item",
-          "css_target": "*[aria-role=\"dialog\" aria-modal=\"true\"]",
-          "before": {
-            "mode": "auto",
-            "virtual_location": "within target",
-            "focus_location": "within target"
-          },
-          "after": "before target",
+          "procedure_key": "navigate_backwards_out_of_open_modal",
           "output": "not able to move outside of the modal",
           "results": [
             {
@@ -605,13 +702,7 @@
         },
         {
           "command": "previous_form_field",
-          "css_target": "*[aria-modal=true]",
-          "before": {
-            "mode": "auto",
-            "virtual_location": "within target",
-            "focus_location": "within target"
-          },
-          "after": "before target",
+          "procedure_key": "navigate_backwards_out_of_open_modal",
           "output": "no outside form fields were found",
           "results": [
             {
@@ -666,13 +757,7 @@
       "and_chr": [
         {
           "command": "activate_button",
-          "css_target": "*[aria-role=\"dialog\" aria-modal=\"true\"]",
-          "before": {
-            "mode": "auto",
-            "virtual_location": "before target",
-            "focus_location": "before target"
-          },
-          "after": "within target",
+          "procedure_key": "open_dialog",
           "output": "\"edit box, street, in pager\"",
           "results": [
             {
@@ -723,13 +808,7 @@
         },
         {
           "command": "previous_item",
-          "css_target": "*[aria-role=\"dialog\" aria-modal=\"true\"]",
-          "before": {
-            "mode": "auto",
-            "virtual_location": "within target",
-            "focus_location": "within target"
-          },
-          "after": "before target",
+          "procedure_key": "navigate_backwards_out_of_open_modal",
           "output": "\"modal dialog design pattern in wai-aria authoring practices 1.2, link\"",
           "results": [
             {
@@ -747,13 +826,7 @@
         },
         {
           "command": "next_item",
-          "css_target": "*[aria-role=\"dialog\"]",
-          "before": {
-            "mode": "auto",
-            "virtual_location": "before target",
-            "focus_location": "before target"
-          },
-          "after": "within target",
+          "key": "navigate_forward_into_open_dialog",
           "output": "dialog boundary not conveyed",
           "results": [
             {
@@ -765,13 +838,7 @@
         },
         {
           "command": "previous_link",
-          "css_target": "*[aria-modal=true]",
-          "before": {
-            "mode": "auto",
-            "virtual_location": "within target",
-            "focus_location": "within target"
-          },
-          "after": "before target",
+          "procedure_key": "navigate_backwards_out_of_open_modal",
           "output": "content outside of the modal was announced",
           "results": [
             {
@@ -789,13 +856,7 @@
       "ios_saf": [
         {
           "command": "activate_button",
-          "css_target": "*[aria-role=\"dialog\" aria-modal=\"true\"]",
-          "before": {
-            "mode": "auto",
-            "virtual_location": "start of target",
-            "focus_location": "start of target"
-          },
-          "after": "within target",
+          "procedure_key": "open_dialog",
           "output": "\"(earcon indicating button was activated)\"",
           "results": [
             {
@@ -814,13 +875,7 @@
         },
         {
           "command": "previous_item",
-          "css_target": "*[aria-role=\"dialog\" aria-modal=\"true\"]",
-          "before": {
-            "mode": "auto",
-            "virtual_location": "start of target",
-            "focus_location": "start of target"
-          },
-          "after": "before target",
+          "procedure_key": "navigate_backwards_out_of_open_modal",
           "output": "\"modal dialog design pattern in wai-aria authoring practices 1.2, link\"",
           "results": [
             {
@@ -838,13 +893,7 @@
         },
         {
           "command": "next_item",
-          "css_target": "*[aria-role=\"dialog\"]",
-          "before": {
-            "mode": "auto",
-            "virtual_location": "before target",
-            "focus_location": "before target"
-          },
-          "after": "within target",
+          "procedure_key": "navigate_forward_into_open_dialog",
           "output": "\"add delivery address, web dialog...\"",
           "results": [
             {
@@ -866,13 +915,7 @@
         },
         {
           "command": "previous_link",
-          "css_target": "*[aria-modal=true]",
-          "before": {
-            "mode": "auto",
-            "virtual_location": "within target",
-            "focus_location": "within target"
-          },
-          "after": "before target",
+          "procedure_key": "navigate_backwards_out_of_open_modal",
           "output": "\"modal dialog design pattern in wai-aria authoring practices 1.2, link\"",
           "results": [
             {
@@ -885,13 +928,7 @@
         },
         {
           "command": "previous_form_field",
-          "css_target": "*[aria-modal=true]",
-          "before": {
-            "mode": "auto",
-            "virtual_location": "within target",
-            "focus_location": "within target"
-          },
-          "after": "before target",
+          "procedure_key": "navigate_backwards_out_of_open_modal",
           "output": "\"add delivery address, button\"",
           "results": [
             {
@@ -908,13 +945,7 @@
       "safari": [
         {
           "command": "activate_button",
-          "css_target": "*[aria-role=\"dialog\" aria-modal=\"true\"]",
-          "before": {
-            "mode": "auto",
-            "virtual_location": "before target",
-            "focus_location": "before target"
-          },
-          "after": "target",
+          "procedure_key": "open_dialog",
           "output": "\"street, edit text\"",
           "results": [
             {
@@ -938,13 +969,7 @@
         },
         {
           "command": "exit_object",
-          "css_target": "*[aria-role=\"dialog\"]",
-          "before": {
-            "mode": "auto",
-            "virtual_location": "within target",
-            "focus_location": "within target"
-          },
-          "after": "target",
+          "procedure_key": "navigate_to_modal_container_VO",
           "output": "\"Out of add delivery address, web dialog...\"",
           "results": [
             {
@@ -966,13 +991,7 @@
         },
         {
           "command": "previous_item",
-          "css_target": "*[aria-role=\"dialog\" aria-modal=\"true\"]",
-          "before": {
-            "mode": "auto",
-            "virtual_location": "within target",
-            "focus_location": "within target"
-          },
-          "after": "before target",
+          "procedure_key": "navigate_backwards_out_of_open_modal_VO",
           "output": "\"modal dialog design pattern in wai-aria authoring practices 1.2, link\"",
           "notes": "Could navigate to the previous link, but nothing past that.",
           "results": [
@@ -986,32 +1005,8 @@
           ]
         },
         {
-          "command": "next_item",
-          "css_target": "*[aria-role=\"dialog\"]",
-          "before": {
-            "mode": "auto",
-            "virtual_location": "target",
-            "focus_location": "target"
-          },
-          "after": "before target",
-          "output": "Unable to navigate out of the dialog object and the dialog role is conveyed when entering the container is focused by VO",
-          "results": [
-            {
-              "feature_id": "aria/dialog_role",
-              "feature_assertion_id": "convey_boundaries",
-              "result": "pass"
-            }
-          ]
-        },
-        {
           "command": "previous_heading",
-          "css_target": "*[aria-modal=true]",
-          "before": {
-            "mode": "auto",
-            "virtual_location": "within target",
-            "focus_location": "within target"
-          },
-          "after": "before target",
+          "procedure_key": "navigate_backwards_out_of_open_modal_VO",
           "output": "previous headings in outside content were found",
           "results": [
             {
@@ -1024,13 +1019,7 @@
         },
         {
           "command": "open_element_list",
-          "css_target": "*[aria-modal=true]",
-          "before": {
-            "mode": "auto",
-            "virtual_location": "na",
-            "focus_location": "na"
-          },
-          "after": "na",
+          "procedure_key": "open_element_list_while_modal_open",
           "output": "headings, links, and other content was listed and could be navigated to",
           "results": [
             {
@@ -1047,13 +1036,7 @@
       "firefox": [
         {
           "command": "activate_button",
-          "css_target": "*[aria-role=\"dialog\"]",
-          "before": {
-            "mode": "auto",
-            "virtual_location": "before target",
-            "focus_location": "before target"
-          },
-          "after": "target",
+          "procedure_key": "open_dialog",
           "output": "contents of modal was announced, but not the dialog name, role, or state (modal)",
           "results": [
             {
@@ -1070,13 +1053,7 @@
         },
         {
           "command": "previous_item",
-          "css_target": "*[aria-role=\"dialog\" aria-modal=\"true\"]",
-          "before": {
-            "mode": "auto",
-            "virtual_location": "within target",
-            "focus_location": "within target"
-          },
-          "after": "start of target",
+          "procedure_key": "navigate_backwards_out_of_open_modal",
           "output": "\"add delivery address dialog, street, entry\" ",
           "results": [
             {
@@ -1113,13 +1090,7 @@
         },
         {
           "command": "previous_form_field",
-          "css_target": "*[aria-modal=true]",
-          "before": {
-            "mode": "auto",
-            "virtual_location": "within target",
-            "focus_location": "within target"
-          },
-          "after": "before target",
+          "procedure_key": "navigate_backwards_out_of_open_modal",
           "output": "no outside form fields were found",
           "results": [
             {
@@ -1132,13 +1103,7 @@
         },
         {
           "command": "previous_link",
-          "css_target": "*[aria-modal=true]",
-          "before": {
-            "mode": "auto",
-            "virtual_location": "within target",
-            "focus_location": "within target"
-          },
-          "after": "before target",
+          "procedure_key": "navigate_backwards_out_of_open_modal",
           "output": "The link just before the dialog example was announced, but the reading cursor was immediately sent back to the open dialog. Not possible to find other links outside of the dialog.",
           "results": [
             {
@@ -1165,13 +1130,7 @@
         },
         {
           "command": "list_links",
-          "css_target": "*[aria-modal=true]",
-          "before": {
-            "mode": "auto",
-            "virtual_location": "before target",
-            "focus_location": "before target"
-          },
-          "after": "target",
+          "procedure_key": "open_element_list_while_modal_open",
           "output": "outside links are listed. When jumping to those links, focus is redirected back to the open dialog.",
           "results": [
             {

--- a/data/tests/apg/modal-dialog-example.json
+++ b/data/tests/apg/modal-dialog-example.json
@@ -715,13 +715,7 @@
         },
         {
           "command": "previous_link",
-          "css_target": "*[aria-modal=true]",
-          "before": {
-            "mode": "auto",
-            "virtual_location": "within target",
-            "focus_location": "within target"
-          },
-          "after": "before target",
+          "procedure_key": "navigate_backwards_out_of_open_modal",
           "output": "no outside links were found",
           "results": [
             {
@@ -734,13 +728,7 @@
         },
         {
           "command": "open_element_list",
-          "css_target": "*[aria-modal=true]",
-          "before": {
-            "mode": "auto",
-            "virtual_location": "na",
-            "focus_location": "na"
-          },
-          "after": "na",
+          "procedure_key": "open_element_list_while_modal_open",
           "output": "only content within the modal was included in the lists",
           "results": [
             {
@@ -783,31 +771,6 @@
         },
         {
           "command": "previous_item",
-          "css_target": "*[aria-role=\"dialog\"]",
-          "before": {
-            "mode": "auto",
-            "virtual_location": "start of target",
-            "focus_location": "start of target"
-          },
-          "after": "within target",
-          "output": "\"edit box, street\"",
-          "results": [
-            {
-              "feature_id": "aria/dialog_role",
-              "feature_assertion_id": "convey_role",
-              "result": "fail",
-              "notes": "not conveyed when navigating to the boundary of the dialog"
-            },
-            {
-              "feature_id": "aria/dialog_role",
-              "feature_assertion_id": "convey_name",
-              "result": "fail",
-              "notes": "not conveyed when navigating to the boundary of the dialog"
-            }
-          ]
-        },
-        {
-          "command": "previous_item",
           "procedure_key": "navigate_backwards_out_of_open_modal",
           "output": "\"modal dialog design pattern in wai-aria authoring practices 1.2, link\"",
           "results": [
@@ -826,7 +789,7 @@
         },
         {
           "command": "next_item",
-          "key": "navigate_forward_into_open_dialog",
+          "procedure_key": "navigate_forward_into_open_dialog",
           "output": "dialog boundary not conveyed",
           "results": [
             {

--- a/public/js/feature-test.js
+++ b/public/js/feature-test.js
@@ -82,11 +82,12 @@ function displayTestingPrefs(focusResults)
 	resultsContainer.appendChild(dl);
 	resultsContainer.classList.add('call-out');
 
-	// Remove all existing assertion fieldsets
-	removeAllAssertionFieldsets();
+	// Remove current combo
+	hideAllCombos();
 
-	// Build new assertion fieldsets
-	buildAssertionFieldsets(at_value, browser_value);
+	let section = document.querySelector('#combo-'+at_value+'-'+browser_value);
+	console.log(section);
+	section.removeAttribute('hidden');
 
 	if (focusResults) {
 		heading.focus();
@@ -119,576 +120,13 @@ function displayTestingPrefs(focusResults)
 	span.innerText = ATBrowsers.at[at_value].title + ' and ' + ATBrowsers.browsers[browser_value].title;
 }
 
-var removeAllAssertionFieldsets = function() {
-	var assertions = document.querySelectorAll('fieldset.assertion');
+var hideAllCombos = function() {
+	var combos = document.querySelectorAll('.combo');
 	for (var i=0; i < assertions.length; i++) {
-		assertions[i].parentNode.remove();
+		combos[i].setAttribute('hidden', true);
 	}
 };
 
-var buildAssertionFieldsets = function(at_value, browser_value) {
-
-	var num_fieldsets = 0;
-	test.assertions.forEach(function(assertion, assertion_key) {
-
-		if (-1 === assertion.supports_at.indexOf(ATBrowsers.at[at_value].type)) {
-			return;
-		}
-
-		var supportPoint = assertion.results[at_value].browsers[browser_value];
-		if (supportPoint && supportPoint.support === "na") {
-			// don't render assertions that are not applicable
-			return;
-		}
-
-		num_fieldsets++;
-
-		var fieldset = document.createElement('fieldset');
-		fieldset.classList.add('assertion');
-		fieldset.setAttribute('data-feature-assertion-id', assertion.feature_assertion_id);
-		fieldset.setAttribute('data-feature-id', assertion.feature_id);
-		fieldset.setAttribute('data-assertion-key', assertion_key);
-		var name = assertion.feature_id+'.'+assertion.feature_assertion_id;
-		// The feature ID might contain a /, which isn't a valid HTML id. Convert it to a dash.
-		fieldset.setAttribute('id', name
-			.replace('/', '-')
-			.replace('.', '--')
-			.replace('(', '-')
-			.replace(')', '-')
-		);
-		fieldset.setAttribute('data-name', name);
-		var legend = document.createElement('legend');
-		var short_title = assertion.assertion_title;
-		short_title = short_title.replace('The assistive technology ', '');
-		short_title = short_title.replace('The screen reader', '');
-		legend.innerText = assertion.feature_title + ': ' + short_title;
-		fieldset.append(legend);
-
-		var p = document.createElement('p');
-		p.innerText = 'The following are instructions for testing this expectation.';
-
-		var instructions_ol = document.createElement('ol');
-		var li = document.createElement('li');
-		li.innerText = 'Find all elements in the example that match this selector: ';
-		var strong = document.createElement('strong');
-		strong.innerText = assertion.css_target;
-		li.appendChild(strong);
-		instructions_ol.appendChild(li);
-
-		var li = document.createElement('li');
-		li.innerText = 'Navigate to each matching element and interact with it. Record your findings below for every command that you used.';
-		instructions_ol.appendChild(li);
-
-		var li = document.createElement('li');
-		li.innerText = 'Does the output meet the expectation? Record your findings below for every command that you used.';
-		instructions_ol.appendChild(li);
-
-		if (assertion.expected_value) {
-			var li = document.createElement('li');
-			li.innerText = 'Expected value: ' + assertion.css_target;
-			instructions_ol.appendChild(li);
-		}
-
-		fieldset.append(p);
-		fieldset.append(instructions_ol);
-
-		// Example output
-		if (assertion.assertion_examples && assertion.assertion_examples.length) {
-			var p = document.createElement('p');
-			p.innerText = 'The following are some examples of how assistive technologies might support this expectation.';
-			var examples_ul = document.createElement('ul');
-
-			assertion.assertion_examples.forEach(function(example) {
-				var li = document.createElement('li');
-				li.innerText = example;
-				examples_ul.append(li);
-			});
-
-			fieldset.append(p);
-			fieldset.append(examples_ul);
-		}
-
-		var addOutputButton = document.createElement('button');
-		addOutputButton.classList.add('add-output-row');
-		addOutputButton.innerText = 'add an output row';
-		fieldset.append(addOutputButton);
-
-		addOutputButton.addEventListener('click', function(e) {
-			e.preventDefault();
-			e.stopPropagation();
-			createCommandOutputRow(assertion, e.target.parentNode, null, true);
-		});
-
-		var noteLabel = document.createElement('label');
-		noteLabel.innerText = 'Notes';
-		noteLabel.setAttribute('for', fieldset.getAttribute('id')+'--note');
-		var noteTextarea = document.createElement('textarea');
-        noteTextarea.setAttribute('id', fieldset.getAttribute('id')+'--note');
-        noteTextarea.setAttribute('name', fieldset.getAttribute('data-name')+'.note');
-
-        if (assertion.results[at_value].browsers[browser_value].notes) {
-            noteTextarea.innerText = assertion.results[at_value].browsers[browser_value].notes;
-        }
-        fieldset.append(noteLabel);
-        fieldset.append(noteTextarea);
-
-		// TODO: add details (such as selector)
-
-		// TODO: Add output rows
-
-		if (supportPoint.output) {
-			supportPoint.output.forEach(function(row, row_key) {
-				createCommandOutputRow(assertion, fieldset, row, false);
-			});
-		} else {
-			createCommandOutputRow(assertion, fieldset, null, false);
-		}
-
-		var assertion_container = document.createElement('div');
-		assertion_container.classList.add('assertion-container');
-		assertion_container.append(fieldset);
-		assertions_container.append(assertion_container);
-	});
-
-	if (num_fieldsets === 0) {
-		var message = document.createElement('p');
-		message.innerText = "Sorry, no assertions apply to the chosen testing combination.";
-		assertions_container.append(message);
-	}
-};
-
-var removeAllCommandOutputRows = function(assertion_fieldset) {
-	var currentRows = assertion_fieldset.querySelectorAll('fieldset.output-row');
-	for (var i=0; i < currentRows.length; i++) {
-		currentRows[i].remove();
-	}
-};
-
-var createCommandOutputRow = function(assertion, assertion_fieldset, output_row, focus) {
-	var addOutputButton = assertion_fieldset.querySelector('button.add-output-row');
-	var currentRows = assertion_fieldset.querySelectorAll('fieldset.output-row');
-	var key = currentRows.length+1;
-	var fieldset = document.createElement('fieldset');
-	fieldset.classList.add('output-row');
-	var legend = document.createElement('legend');
-	legend.innerText = 'Output row ' + key;
-	fieldset.appendChild(legend);
-
-
-    var div = document.createElement('div');
-    div.classList.add('control');
-    var id = assertion_fieldset.getAttribute('id')+'--output_'+key+'_command';
-    var command_select = document.createElement('select');
-    command_select.setAttribute('id', id);
-	command_select.setAttribute('data-property', 'command');
-    command_select.setAttribute('name', assertion_fieldset.getAttribute('data-name')+'.output_'+key+'_command');
-    var label = document.createElement('label');
-    label.innerText = 'The command used (required)';
-    label.setAttribute('for', id);
-    div.appendChild(label);
-
-    // Default null state
-	var option = document.createElement('option');
-	option.innerText = '-- select an option --';
-	option.setAttribute('value', '');
-	command_select.appendChild(option);
-
-    var at_value = sessionStorage.getItem('at');
-	var keys = Object.getOwnPropertyNames(ATBrowsers.at[at_value].commands);
-    for (var i=0; i<ATBrowsers.command_tags.length; i++) {
-    	var tag = ATBrowsers.command_tags[i];
-    	var optgroup = null;
-        for (var ii=0; ii<keys.length; ii++) {
-        	var command = ATBrowsers.at[at_value].commands[keys[ii]];
-        	if (!command.tags.includes(tag.id)) {
-        		continue;
-			}
-
-        	var include = false;
-			assertion.operation_modes.forEach(function(tag) {
-				if (command.tags.includes(tag)) {
-					include = true;
-				}
-			});
-
-			if (!include) {
-				continue;
-			}
-
-			if (!optgroup) {
-				// Create the optgroup
-				optgroup = document.createElement('optgroup');
-				optgroup.setAttribute('label', tag.name);
-				command_select.appendChild(optgroup);
-			}
-			// Create the option
-            var option = document.createElement('option');
-            option.innerText = command.name;
-            option.innerText += ' ('+command.command+')';
-            option.setAttribute('value', keys[ii]);
-
-            if (output_row && output_row.command === keys[ii]) {
-            	option.setAttribute('selected', 'selected');
-            }
-
-            optgroup.appendChild(option);
-        }
-    }
-
-    div.appendChild(command_select);
-    fieldset.appendChild(div);
-
-	// at mode before command is executed
-	var div = document.createElement('div');
-	div.classList.add('control');
-	var label = document.createElement('label');
-	label.innerText = 'AT mode before executing the command';
-	var id = assertion_fieldset.getAttribute('id')+'--output_'+key+'_before_mode';
-	label.setAttribute('for', id);
-	var select = document.createElement('select');
-	select.setAttribute('id', id);
-	select.setAttribute('data-property', 'before');
-	select.setAttribute('data-sub-property', 'mode');
-	select.setAttribute('name', assertion_fieldset.getAttribute('data-name')+'.output_'+key+'_before_mode');
-	var options = [
-		{
-			label: 'auto (mode not explicitly set; usually browse mode for screen readers)',
-			value: 'auto'
-		},
-		{
-			label: 'browse mode (browse, document, or table)',
-			value: 'browse'
-		},
-		{
-			label: 'forms mode (form or application mode)',
-			value: 'forms'
-		},
-		{
-			label: 'n/a',
-			value: 'na'
-		}
-	];
-
-	options.forEach(function(data) {
-		var option = document.createElement('option');
-		option.innerText = data.label;
-		option.value = data.value;
-
-		if (output_row && output_row.before.mode === data.value) {
-			option.setAttribute('selected', 'selected');
-		} else if (!output_row && ATBrowsers.at[at_value].type === "vc" && data.value === "na") {
-			option.setAttribute('selected', 'selected');
-		}
-
-		select.appendChild(option);
-	});
-	div.appendChild(label);
-	div.appendChild(select);
-	fieldset.appendChild(div);
-
-    // keyboard focus target before
-	var div = document.createElement('div');
-	div.classList.add('control');
-	var label = document.createElement('label');
-	label.innerText = 'Location of keyboard focus before executing the command';
-	var id = assertion_fieldset.getAttribute('id')+'--output_'+key+'_before_focus';
-	label.setAttribute('for', id);
-	var select = document.createElement('select');
-	select.setAttribute('id', id);
-	select.setAttribute('data-property', 'before');
-	select.setAttribute('data-sub-property', 'focus_location');
-	select.setAttribute('name', assertion_fieldset.getAttribute('data-name')+'.output_'+key+'_before_focus');
-	var options = [
-		{
-			label: 'unknown',
-			value: ''
-		},
-		{
-			label: 'before target',
-			value: 'before target'
-		},
-		{
-			label: 'after target',
-			value: 'after target'
-		},
-		{
-			label: 'start of target',
-			value: 'start of target'
-		},
-		{
-			label: 'target',
-			value: 'target'
-		},
-		{
-			label: 'within target',
-			value: 'within target'
-		},
-		{
-			label: 'end of target',
-			value: 'end of target'
-		},
-		{
-			label: 'n/a',
-			value: 'na'
-		}
-	];
-
-	options.forEach(function(data) {
-		var option = document.createElement('option');
-		option.innerText = data.label;
-		option.value = data.value;
-
-		if (output_row && output_row.before.focus_location === data.value) {
-			option.setAttribute('selected', 'selected');
-		} else if (!output_row && ATBrowsers.at[at_value].type === "vc" && data.value === "na") {
-			option.setAttribute('selected', 'selected');
-		}
-
-		select.appendChild(option);
-	});
-	div.appendChild(label);
-	div.appendChild(select);
-	fieldset.appendChild(div);
-
-	// virtual cursor target before
-	var div = document.createElement('div');
-	div.classList.add('control');
-	var label = document.createElement('label');
-	label.innerText = 'Location of virtual cursor before executing the command';
-	var id = assertion_fieldset.getAttribute('id')+'--output_'+key+'_before_virtual';
-	label.setAttribute('for', id);
-	var select = document.createElement('select');
-	select.setAttribute('id', id);
-	select.setAttribute('data-property', 'before');
-	select.setAttribute('data-sub-property', 'virtual_location');
-	select.setAttribute('name', assertion_fieldset.getAttribute('data-name')+'.output_'+key+'_before_virtual');
-	var options = [
-		{
-			label: 'unknown',
-			value: ''
-		},
-		{
-			label: 'before target',
-			value: 'before target'
-		},
-		{
-			label: 'after target',
-			value: 'after target'
-		},
-		{
-			label: 'start of target',
-			value: 'start of target'
-		},
-		{
-			label: 'target',
-			value: 'target'
-		},
-		{
-			label: 'within target',
-			value: 'within target'
-		},
-		{
-			label: 'end of target',
-			value: 'end of target'
-		},
-		{
-			label: 'n/a',
-			value: 'na'
-		}
-	];
-
-	options.forEach(function(data) {
-		var option = document.createElement('option');
-		option.innerText = data.label;
-		option.value = data.value;
-
-		if (output_row && output_row.before.virtual_location === data.value) {
-			option.setAttribute('selected', 'selected');
-		} else if (!output_row && ATBrowsers.at[at_value].type === "vc" && data.value === "na") {
-			option.setAttribute('selected', 'selected');
-		}
-
-		select.appendChild(option);
-	});
-	div.appendChild(label);
-	div.appendChild(select);
-	fieldset.appendChild(div);
-
-	// target after command
-	var div = document.createElement('div');
-	div.classList.add('control');
-	var label = document.createElement('label');
-	label.innerText = 'Location of focus or virtual cursor after command';
-	var id = assertion_fieldset.getAttribute('id')+'--output_'+key+'_after';
-	label.setAttribute('for', id);
-	var select = document.createElement('select');
-	select.setAttribute('data-property', 'after');
-	select.setAttribute('id', id);
-	select.setAttribute('name', assertion_fieldset.getAttribute('data-name')+'.output_'+key+'_after');
-	var options = [
-		{
-			label: 'unknown',
-			value: ''
-		},
-		{
-			label: 'target',
-			value: 'target'
-		},
-		{
-			label: 'start of target',
-			value: 'start of target'
-		},
-		{
-			label: 'end of target',
-			value: 'end of target'
-		},
-		{
-			label: 'past target',
-			value: 'past target'
-		},
-		{
-			label: 'before target',
-			value: 'before target'
-		},
-		{
-			label: 'within target',
-			value: 'within target'
-		},
-		{
-			label: 'after target',
-			value: 'after target'
-		},
-		{
-			label: 'n/a',
-			value: 'na'
-		}
-	];
-
-	options.forEach(function(data) {
-		var option = document.createElement('option');
-		option.innerText = data.label;
-		option.value = data.value;
-
-		if (output_row && output_row.after === data.value) {
-			option.setAttribute('selected', 'selected');
-		}
-
-		select.appendChild(option);
-	});
-	div.appendChild(label);
-	div.appendChild(select);
-	fieldset.appendChild(div);
-
-
-	// output from AT
-	var div = document.createElement('div');
-	div.classList.add('control');
-	var label = document.createElement('label');
-	label.innerText = 'Output from AT (required)';
-	var id = assertion_fieldset.getAttribute('id')+'--output_'+key+'_output';
-	label.setAttribute('for', id);
-	var input = document.createElement('input');
-	input.setAttribute('data-property', 'output');
-	input.setAttribute('type', 'text');
-	input.setAttribute('id', id);
-	input.setAttribute('name', assertion_fieldset.getAttribute('data-name')+'.output_'+key+'_output');
-	div.appendChild(label);
-	div.appendChild(input);
-	fieldset.appendChild(div);
-
-	if (output_row) {
-		input.value = output_row.output;
-	}
-
-	// Result
-	var div = document.createElement('div');
-	div.classList.add('control');
-	var label = document.createElement('label');
-	label.innerText = 'result (required)';
-	var id = assertion_fieldset.getAttribute('id')+'--output_'+key+'_result';
-	label.setAttribute('for', id);
-	var select = document.createElement('select');
-	select.setAttribute('data-property', 'result');
-	select.setAttribute('id', id);
-	select.setAttribute('name', assertion_fieldset.getAttribute('data-name')+'.output_'+key+'_result');
-	var option = document.createElement('option');
-	option.innerText = 'pass';
-	option.value = 'pass';
-	select.appendChild(option);
-	var option = document.createElement('option');
-	option.innerText = 'fail';
-	option.value = 'fail';
-	select.appendChild(option);
-	var option = document.createElement('option');
-	option.innerText = 'partial';
-	option.value = 'partial';
-	select.appendChild(option);
-	div.appendChild(label);
-	div.appendChild(select);
-	fieldset.appendChild(div);
-
-	if (output_row) {
-		select.value = output_row.result;
-	}
-
-	// support is locked behind settings
-	var div = document.createElement('div');
-	div.classList.add('control');
-	var label = document.createElement('label');
-	label.innerText = 'If support is hidden behind non-default settings, briefly describe that setting';
-	var id = assertion_fieldset.getAttribute('id')+'--output_'+key+'_behind_setting';
-	label.setAttribute('for', id);
-	var input = document.createElement('input');
-	input.setAttribute('data-property', 'behind_setting');
-	input.setAttribute('type', 'text');
-	input.setAttribute('id', id);
-	input.setAttribute('name', assertion_fieldset.getAttribute('data-name')+'.output_'+key+'_behind_setting');
-	div.appendChild(label);
-	div.appendChild(input);
-	fieldset.appendChild(div);
-
-	if (output_row && output_row.behind_setting) {
-		input.value = output_row.behind_setting;
-	}
-
-	// output notes
-	var div = document.createElement('div');
-	div.classList.add('control');
-	var label = document.createElement('label');
-	label.innerText = 'Brief notes';
-	var id = assertion_fieldset.getAttribute('id')+'--output_'+key+'_notes';
-	label.setAttribute('for', id);
-	var input = document.createElement('input');
-	input.setAttribute('data-property', 'notes');
-	input.setAttribute('type', 'text');
-	input.setAttribute('id', id);
-	input.setAttribute('name', assertion_fieldset.getAttribute('data-name')+'.output_'+key+'_notes');
-	div.appendChild(label);
-	div.appendChild(input);
-	fieldset.appendChild(div);
-
-	if (output_row && output_row.notes) {
-		input.value = output_row.notes;
-	}
-
-	if (currentRows.length > 0) {
-		// Don't allow removing the first row
-		var removeButton = document.createElement('button');
-		removeButton.innerText = 'Remove this row';
-		removeButton.addEventListener('click', function(e) {
-			e.preventDefault();
-			fieldset.remove();
-			addOutputButton.focus();
-		});
-		fieldset.appendChild(removeButton);
-	}
-
-	addOutputButton.parentElement.insertBefore(fieldset, addOutputButton);
-
-	if (focus) {
-        command_select.focus();
-	}
-};
 
 
 function initFeatureTest() {
@@ -730,34 +168,6 @@ function initFeatureTest() {
 			dom_os_version.setAttribute('aria-invalid', 'true');
 		}
 
-		var assertion_fieldsets = document.querySelectorAll('fieldset.assertion');
-		assertion_fieldsets.forEach(function(assertion_fieldset) {
-			var currentRows = assertion_fieldset.querySelectorAll('fieldset.output-row');
-			for (var i=0; i<currentRows.length; i++) {
-				var assertion_fieldset = currentRows[i].closest('fieldset.assertion');
-				var assertion_legend = assertion_fieldset.querySelector('legend');
-				var id = assertion_fieldset.getAttribute('id');
-				var idPrefix = '#'+id+'--'+'output_'+(i+1);
-				var command = document.querySelector(idPrefix+'_command');
-				var output = document.querySelector(idPrefix+'_command');
-				var result = document.querySelector(idPrefix+'_result');
-
-				if (!command.value) {
-					errors.push(generateErrorLink(idPrefix+'_command', assertion_legend.innerText+ " - Output row " + (i+1) + " command is required"));
-					command.setAttribute('aria-invalid', 'true');
-				}
-				if (!output.value) {
-					errors.push(generateErrorLink(idPrefix+'_output', assertion_legend.innerText+ " - Output row " + (i+1) + " output is required"));
-					output.setAttribute('aria-invalid', 'true');
-				}
-				if (!result.value) {
-					errors.push(generateErrorLink(idPrefix+'_result', assertion_legend.innerText+ " - Output row " + (i+1) + " result is required"));
-					result.setAttribute('aria-invalid', 'true');
-				}
-			}
-		});
-
-
 		if (errors.length) {
 			var ul = document.createElement('ul');
 			for (var i=0; i<errors.length; i++) {
@@ -781,7 +191,6 @@ function initFeatureTest() {
 
 		return true;
 	};
-
 
 	form.addEventListener('submit', function(e) {
 		e.preventDefault();
@@ -819,76 +228,72 @@ function initFeatureTest() {
         body += '| browser_version | ' + dom_browser_version.value + ' |\n';
         body += '| os_version | ' + dom_os_version.value + ' |\n';
 
-        var assertion_fieldsets = document.querySelectorAll('fieldset.assertion');
+        var commands = document.querySelectorAll('#combo-'+at_value+'-'+browser_value+' fieldset.command');
+        console.log(commands);
 
-        assertion_fieldsets.forEach(function(fieldset) {
-            var legend = fieldset.querySelector('legend');
-            var output_rows = fieldset.querySelectorAll('fieldset.output-row');
-			var output_body = '';
-			var assertion_key = parseInt(fieldset.getAttribute("data-assertion-key"));
+			var diff = '';
 
-			output_rows.forEach(function(output_row, output_row_index) {
-				var controls = output_row.querySelectorAll('input, select');
-				if (test.assertions[assertion_key].results[at_value].browsers[browser_value].support === "na") {
-					// nothing to report here
-					return;
+        let getDiff = function(title, before, after) {
+        	var diff = '';
+        	if (before === after) {
+        		return diff;
+			}
+
+        	if (!before) {
+        		before = '(empty)';
+			}
+
+        	if (!after) {
+        		after = '(empty)';
+			}
+
+        	diff += title + '\n';
+        	diff += '**before:**' + '\n';
+        	diff += '```' + before + '```\n';
+			diff += '**after:**' + '\n';
+			diff += '```' + after + '```\n';
+			diff += '\n';
+			return diff;
+		};
+
+        commands.forEach(command => {
+			var commandDiff = '';
+
+			var legend = command.querySelector('legend');
+
+			commandDiff += getDiff('### output', command.querySelector('.output-before').value, command.querySelector('.output-after').value);
+			commandDiff += getDiff('### notes', command.querySelector('.notes-before').value, command.querySelector('.notes-after').value);
+
+			var results = command.querySelectorAll('fieldset');
+			results.forEach(result => {
+				var resultDiff = '';
+
+				var legend = result.querySelector('legend');
+				resultDiff += getDiff('### result', result.querySelector('.result-before').value, result.querySelector('.result-after').value);
+				resultDiff += getDiff('### note', result.querySelector('.note-before').value, result.querySelector('.note-after').value);
+
+				if (resultDiff) {
+					resultDiff = 'key: '+result.querySelector('.result-key').value+'\n\n'+resultDiff;
+					resultDiff = '### result for '+legend.innerText+'\n\n'+resultDiff;
 				}
 
-				var current = test.assertions[assertion_key].results[at_value].browsers[browser_value].output[output_row_index];
-
-
-				controls.forEach(function(control) {
-					var name = control.getAttribute('name');
-					name = name.split('.');
-					name = name[name.length -1]; // the name is namespaced, and we already provide that namespace info, so just send the last bit.
-					var property = control.getAttribute('data-property');
-					var subProperty = control.getAttribute('data-sub-property');
-
-					if (subProperty) {
-						// We need to check sub properties a bit differently
-						if (current[property][subProperty] === control.value
-							|| (current[property][subProperty] === undefined && control.value === '')) {
-							// Only send over changes in data.
-							return;
-						}
-					} else {
-						// we need to check sub properties a bit differentlyß
-						if (current[property] === control.value
-							|| (current[property] === undefined && control.value === '')) {
-							// Only send over changes in data.
-							return;
-						}
-					}
-
-					var old_value = '';
-					if (subProperty && current[property][subProperty]) {
-						old_value = current[property][subProperty];
-					} else if (current[property]) {
-						old_value = current[property];
-					}
-
-					output_body += '| ' + name + ' | ' + control.value + ' | ' + old_value + ' |\n';
-				});
+				// bubble up
+				commandDiff += resultDiff;
 			});
 
-			var note = fieldset.querySelector('textarea');
-
-			if (note.value && note.value !== test.assertions[assertion_key].results[at_value].browsers[browser_value].notes) {
-				output_body += '\n== begin notes ==\n';
-				output_body +=  note.value;
-				output_body += '\n== end notes ==\n';
+			if (commandDiff) {
+				commandDiff = '## '+legend.innerText+'\n' + 'Command used: `' + command.querySelector('.command').value + '`\n\n' + commandDiff;
 			}
 
-			if (output_body) {
-				body += '\n\n';
-				body += legend.innerText+'\n\n';
-				body += '| property | new value | old value |\n';
-				body += '| --- | --- | --- |\n';
-				body += '| feature_id | ' + fieldset.getAttribute('data-feature-id') + ' | - |\n';
-				body += '| feature_assertion_id | ' + fieldset.getAttribute('data-feature-assertion-id') + ' | - |\n';
-				body += output_body;
-			}
-        });
+			// bubble up
+			diff += commandDiff;
+		});
+
+        if (!diff) {
+        	diff = 'no changes (same results were confirmed)';
+		}
+
+		body += '\n\n'+diff;
 
 		var isCore = false;
 		if (ATBrowsers.core_at.includes(data.get('at')) && ATBrowsers.at[data.get('at')].core_browsers.includes(data.get('browser'))) {

--- a/public/js/feature-test.js
+++ b/public/js/feature-test.js
@@ -263,6 +263,7 @@ function initFeatureTest() {
 
 			commandDiff += getDiff('### output', command.querySelector('.output-before').value, command.querySelector('.output-after').value);
 			commandDiff += getDiff('### notes', command.querySelector('.notes-before').value, command.querySelector('.notes-after').value);
+			commandDiff += getDiff('### behind setting', command.querySelector('.behind-setting-before').value, command.querySelector('.behind-setting-after').value);
 
 			var results = command.querySelectorAll('fieldset');
 			results.forEach(result => {

--- a/public/js/feature-test.js
+++ b/public/js/feature-test.js
@@ -221,42 +221,42 @@ function initFeatureTest() {
 
 		body += '| property | value |\n';
 		body += '| --- | --- |\n';
-        body += '| title | ' + dom_title.value + ' |\n';
+		body += '| title | ' + dom_title.value + ' |\n';
 		body += '| at | ' + dom_at.value + ' |\n';
-        body += '| at_version | ' + dom_at_version.value + ' |\n';
-        body += '| browser | ' + dom_browser.value + ' |\n';
-        body += '| browser_version | ' + dom_browser_version.value + ' |\n';
-        body += '| os_version | ' + dom_os_version.value + ' |\n';
+		body += '| at_version | ' + dom_at_version.value + ' |\n';
+		body += '| browser | ' + dom_browser.value + ' |\n';
+		body += '| browser_version | ' + dom_browser_version.value + ' |\n';
+		body += '| os_version | ' + dom_os_version.value + ' |\n';
 
-        var commands = document.querySelectorAll('#combo-'+at_value+'-'+browser_value+' fieldset.command');
-        console.log(commands);
+		var commands = document.querySelectorAll('#combo-'+at_value+'-'+browser_value+' fieldset.command');
+		console.log(commands);
 
+		var diff = '';
+
+		let getDiff = function(title, before, after) {
 			var diff = '';
-
-        let getDiff = function(title, before, after) {
-        	var diff = '';
-        	if (before === after) {
-        		return diff;
+			if (before === after) {
+				return diff;
 			}
 
-        	if (!before) {
-        		before = '(empty)';
+			if (!before) {
+				before = '(empty)';
 			}
 
-        	if (!after) {
-        		after = '(empty)';
+			if (!after) {
+				after = '(empty)';
 			}
 
-        	diff += title + '\n';
-        	diff += '**before:**' + '\n';
-        	diff += '```' + before + '```\n';
+			diff += title + '\n';
+			diff += '**before:**' + '\n';
+			diff += '```' + before + '```\n';
 			diff += '**after:**' + '\n';
 			diff += '```' + after + '```\n';
 			diff += '\n';
 			return diff;
 		};
 
-        commands.forEach(command => {
+		commands.forEach(command => {
 			var commandDiff = '';
 
 			var legend = command.querySelector('legend');
@@ -289,8 +289,8 @@ function initFeatureTest() {
 			diff += commandDiff;
 		});
 
-        if (!diff) {
-        	diff = 'no changes (same results were confirmed)';
+		if (!diff) {
+			diff = 'no changes (same results were confirmed)';
 		}
 
 		body += '\n\n'+diff;

--- a/routes/tests.js
+++ b/routes/tests.js
@@ -114,7 +114,7 @@ router.get('/:testId/run', function(req, res, next) {
 		test_html = fs.readFileSync(test_html_file, 'utf8');
 	}
 
-	res.render('test-case-run2', {
+	res.render('test-case-run', {
 		title: 'Test: '+test.title + ' | Accessibility Support',
 		techId: req.params.techId,
 		testMap: testMap,

--- a/routes/tests.js
+++ b/routes/tests.js
@@ -77,10 +77,10 @@ router.get('/:testId', function(req, res, next) {
 
 /* Run a specific test for a feature. */
 router.get('/:testId/run', function(req, res, next) {
-    let testId = testHelper.undoMakeSafe(req.params.testId);
-    let testMap = require(__dirname+'/../build/test_map');
-    let features = testMap[testId];
-    let test_html, test, test_html_file;
+	let testId = testHelper.undoMakeSafe(req.params.testId);
+	let testMap = require(__dirname+'/../build/test_map');
+	let features = testMap[testId];
+	let test_html, test, dev_test, test_html_file;
 
 	if (!features || !features.length) {
 		// Not found in the test_map.
@@ -96,28 +96,37 @@ router.get('/:testId/run', function(req, res, next) {
 		return;
 	}
 
+	try {
+		dev_test = require(__dirname+'/../data/tests/'+testId+'.json');
+	} catch (e) {
+		// Not found
+		next(createError(404));
+		return;
+	}
+
 	test_html_file = __dirname+'/../data/tests/html/'+testId+'.html';
 
 	if (test.html_file) {
 		test_html_file = __dirname+'/../data/tests/html/'+test.html_file;
 	}
 
-    if (fs.existsSync(test_html_file)) {
-        test_html = fs.readFileSync(test_html_file, 'utf8');
-    }
+	if (fs.existsSync(test_html_file)) {
+		test_html = fs.readFileSync(test_html_file, 'utf8');
+	}
 
-    res.render('test-case-run', {
-        title: 'Test: '+test.title + ' | Accessibility Support',
-        techId: req.params.techId,
-        testMap: testMap,
-        testHTML: test_html,
-        test: test,
-        features: features,
-        ATBrowsers: require(__dirname+'/../data/ATBrowsers.json'),
+	res.render('test-case-run2', {
+		title: 'Test: '+test.title + ' | Accessibility Support',
+		techId: req.params.techId,
+		testMap: testMap,
+		testHTML: test_html,
+		test: test,
+		devTest: dev_test,
+		features: features,
+		ATBrowsers: require(__dirname+'/../data/ATBrowsers.json'),
 		md: md,
-        testHelper: testHelper,
+		testHelper: testHelper,
 		moment: moment
-    });
+	});
 });
 
 /* GET a specific test for a feature. */

--- a/routes/tests.js
+++ b/routes/tests.js
@@ -32,7 +32,7 @@ router.get('/', function(req, res, next) {
 
 /* GET a specific test for a feature. */
 router.get('/:testId', function(req, res, next) {
-    let testId = testHelper.undoMakeSafe(req.params.testId);
+	let testId = testHelper.undoMakeSafe(req.params.testId);
 	let testMap = require(__dirname+'/../build/test_map');
 	let features = testMap[testId];
 	let test_html, test, test_html_file;
@@ -70,7 +70,7 @@ router.get('/:testId', function(req, res, next) {
 		features: features,
 		ATBrowsers: require(__dirname+'/../data/ATBrowsers.json'),
 		md: md,
-        testHelper: testHelper,
+		testHelper: testHelper,
 		moment: moment
 	});
 });
@@ -131,8 +131,8 @@ router.get('/:testId/run', function(req, res, next) {
 
 /* GET a specific test for a feature. */
 router.get('/:testId/:featureId/:featureAssertionId/:atId/:browserId', function(req, res, next) {
-    let testId = testHelper.undoMakeSafe(req.params.testId);
-    let featureId = testHelper.undoMakeSafe(req.params.featureId);
+	let testId = testHelper.undoMakeSafe(req.params.testId);
+	let featureId = testHelper.undoMakeSafe(req.params.featureId);
 	let testMap = require(__dirname+'/../build/test_map');
 	let features = testMap[testId];
 	let test_html, test, test_html_file;
@@ -176,15 +176,15 @@ router.get('/:testId/:featureId/:featureAssertionId/:atId/:browserId', function(
 		return;
 	}
 
-    test_html_file = __dirname+'/../data/tests/html/'+testId+'.html';
+	test_html_file = __dirname+'/../data/tests/html/'+testId+'.html';
 
-    if (test.html_file) {
-        test_html_file = __dirname+'/../data/tests/html/'+test.html_file;
-    }
+	if (test.html_file) {
+		test_html_file = __dirname+'/../data/tests/html/'+test.html_file;
+	}
 
-    if (fs.existsSync(test_html_file)) {
-        test_html = fs.readFileSync(test_html_file, 'utf8');
-    }
+	if (fs.existsSync(test_html_file)) {
+		test_html = fs.readFileSync(test_html_file, 'utf8');
+	}
 
 	res.render('test-case-support-point', {
 		title: req.params.atId + '/' + req.params.browserId + ' | Test: '+test.title + ' | Accessibility Support',
@@ -198,7 +198,7 @@ router.get('/:testId/:featureId/:featureAssertionId/:atId/:browserId', function(
 		ATBrowsers: ATBrowsers,
 		md: md,
 		assertion: assertion,
-        testHelper: testHelper,
+		testHelper: testHelper,
 		moment: moment
 	});
 });

--- a/src/feature-helper.js
+++ b/src/feature-helper.js
@@ -936,6 +936,7 @@ helper.initalizeTestCase = function (testCase) {
 		testCase.assertions[assertion_key].assertion_title = ref_assertion.title;
 		testCase.assertions[assertion_key].assertion_strength = ref_assertion.strength;
 		testCase.assertions[assertion_key].assertion_notes = ref_assertion.notes;
+		testCase.assertions[assertion_key].assertion_examples = ref_assertion.examples;
 
 		testCase.assertions[assertion_key].core_support = {
 			sr: [],

--- a/src/feature-helper.js
+++ b/src/feature-helper.js
@@ -700,6 +700,34 @@ helper.initalizeTestCase = function (testCase) {
 				return;
 			}
 			testCase.commands[at][browser].forEach(function(command) {
+
+				if (command.procedure_key) {
+					let procedure_index = testCase.procedures.findIndex(obj =>
+						obj.key === command.procedure_key
+					);
+
+					if (procedure_index === -1) {
+						console.log('error: procedure key of "' + command.procedure_key + '" was not found',  "testCase: " + testCase.id,);
+					}
+
+					// clone so that we can customize per AT
+					let procedure = JSON.parse(JSON.stringify(testCase.procedures[procedure_index]));
+
+					if (['vo_ios', 'talkback'].includes(at)) {
+						procedure.steps = procedure.steps.filter(step => {
+							return step.action !== "set mode to"
+						});
+						procedure.steps.forEach(step => {
+							if (step.ensure_at_location && step.ensure_at_location.focus) {
+								delete step.ensure_at_location.focus;
+							}
+						});
+					}
+
+					// merge the procedure into the command
+					command = Object.assign({}, procedure, command);
+				}
+
 				command.results.forEach(function(result) {
 					if (!result.applied_to) {
 						result.applied_to = null;
@@ -889,7 +917,6 @@ helper.initalizeTestCase = function (testCase) {
 		} else if (testCase.assertions[assertion_key].supports_at.length === 1 && testCase.assertions[assertion_key].supports_at[0] === 'vc') {
 			titleModifier = 'The voice control software ';
 		}
-
 		let ref_applied_to_feature = null;
 		if (assertion.applied_to) {
 			ref_applied_to_feature = require('../data/tech/'+assertion.applied_to+".json");

--- a/src/test-id-helper.js
+++ b/src/test-id-helper.js
@@ -12,4 +12,152 @@ testHelper.trimTechFromAssertion = function(string) {
     return string;
 };
 
+testHelper.generateTestTitle = function(command, at) {
+    let getHumanLocation = function(location) {
+        return location.replace(/(target)/g, "the $1");
+    }
+
+    if (command.title && command.steps) {
+        return command.title+' using '+at.commands[command.command].name+' ('+at.commands[command.command].command+')';
+    }
+
+    if (command.title) {
+        return command.title;
+    }
+
+    let title = 'Use ' + at.commands[command.command].command + ' ('+at.commands[command.command].name+')';
+
+    if (at.type === 'vc') {
+        return title;
+    }
+
+    if (command.before.virtual_location === 'na') {
+        // This is a command where the location of focus/cursor does not matter (like opening a list of elements)
+        return title;
+    }
+
+    if (command.before.virtual_location === 'target'
+        && command.before.focus_location === 'target'
+        && command.after === 'target') {
+        return title + ' on the target of `'+command.css_target+'`';
+    }
+
+    if (command.before.virtual_location === 'before target'
+        && command.after === 'target') {
+        let suffix = '';
+        if (command.before.virtual_location !== command.before.focus_location) {
+            suffix = ' (leave keyboard focus '+getHumanLocation(command.before.focus_location)+')'
+        }
+        return title + ' to navigate forward to `'+command.css_target+'`' + suffix;
+    }
+
+    if (command.before.virtual_location === 'before target'
+        && command.after === 'within target') {
+        let suffix = '';
+        if (command.before.virtual_location !== command.before.focus_location) {
+            suffix = ' (leave keyboard focus '+getHumanLocation(command.before.focus_location)+')'
+        }
+        return title + ' to navigate forward into `'+command.css_target+'`'+suffix;
+    }
+
+    if (command.before.virtual_location === 'before target'
+        && command.after === 'start of target') {
+        let suffix = '';
+        if (command.before.virtual_location !== command.before.focus_location) {
+            suffix = ' (leave keyboard focus '+getHumanLocation(command.before.focus_location)+')'
+        }
+        return title + ' to navigate forward to the start of `'+command.css_target+'`'+suffix;
+    }
+
+    if (command.before.virtual_location === 'after target'
+        && command.after === 'target') {
+        let suffix = '';
+        if (command.before.virtual_location !== command.before.focus_location) {
+            suffix = ' (leave keyboard focus '+getHumanLocation(command.before.focus_location)+')'
+        }
+        return title + ' to navigate backwards to `'+command.css_target+'`'+suffix;
+    }
+
+    if (command.before.virtual_location === 'after target'
+        && command.after === 'within target') {
+        let suffix = '';
+        if (command.before.virtual_location !== command.before.focus_location) {
+            suffix = ' (leave keyboard focus '+getHumanLocation(command.before.focus_location)+')'
+        }
+        return title + ' to navigate backwards into `'+command.css_target+'`'+suffix;
+    }
+
+    if (command.before.virtual_location === 'after target'
+        && command.after === 'end of target') {
+        let suffix = '';
+        if (command.before.virtual_location !== command.before.focus_location) {
+            suffix = ' (leave keyboard focus '+getHumanLocation(command.before.focus_location)+')'
+        }
+        return title + ' to navigate backwards to the end of `'+command.css_target+'`'+suffix;
+    }
+
+    if (command.before.virtual_location === 'within target'
+        && command.after === 'end of target') {
+        let suffix = '';
+        if (command.before.virtual_location !== command.before.focus_location) {
+            suffix = ' (leave keyboard focus '+getHumanLocation(command.before.focus_location)+')'
+        }
+        return title + ' to navigate forwards to the end of `'+command.css_target+'`'+suffix;
+    }
+
+    if (command.before.virtual_location === 'within target'
+        && command.after === 'after target') {
+        let suffix = '';
+        if (command.before.virtual_location !== command.before.focus_location) {
+            suffix = ' (leave keyboard focus '+getHumanLocation(command.before.focus_location)+')'
+        }
+        return title + ' to navigate forwards out of `'+command.css_target+'`'+suffix;
+    }
+
+    if (command.before.virtual_location === 'within target'
+        && command.after === 'start of target') {
+        let suffix = '';
+        if (command.before.virtual_location !== command.before.focus_location) {
+            suffix = ' (leave keyboard focus '+getHumanLocation(command.before.focus_location)+')'
+        }
+        return title + ' to navigate backwards to the start of `'+command.css_target+'`'+suffix;
+    }
+
+    if (command.before.virtual_location === 'within target'
+        && command.after === 'before target') {
+        let suffix = '';
+        if (command.before.virtual_location !== command.before.focus_location) {
+            suffix = ' (leave keyboard focus '+getHumanLocation(command.before.focus_location)+')'
+        }
+        return title + ' to navigate backwards out of `'+command.css_target+'`'+suffix;
+    }
+
+    if (command.before.virtual_location === 'within target'
+        && command.after === 'within target') {
+        let suffix = '';
+        if (command.before.virtual_location !== command.before.focus_location) {
+            suffix = ' (leave keyboard focus '+getHumanLocation(command.before.focus_location)+')'
+        }
+        return title + ' to navigate within `'+command.css_target+'`'+suffix;
+    }
+
+    return 'unknown'
+}
+
+testHelper.getAssertionKey = function(test, feature_id, feature_assertion_id, applied_to, references) {
+    if (!references) {
+        references = [];
+    }
+    if (!applied_to) {
+        applied_to = null;
+    }
+    return test.assertions.findIndex(obj => {
+            return obj.feature_id === feature_id
+                && obj.feature_assertion_id === feature_assertion_id
+                && obj.applied_to === applied_to
+                && obj.references.join('-') === references.join('-')
+        }
+    );
+}
+
 module.exports = testHelper;

--- a/views/test-case-run.pug
+++ b/views/test-case-run.pug
@@ -1,5 +1,6 @@
 extends layout
 include test-case/assertion
+include test-procedure.mixin.pug
 
 block content
     div.content-wrapper
@@ -41,25 +42,16 @@ block content
 
                 p Please be sure to read the full instructions before completing the test.
 
-                div(id="step2" hidden)
-                    h2 Step 2: Test the expectations and submit your findings
+                div(id="step2")
+                    h2 Step 2: Run test cases and submit your findings
 
                     ol
                         li Launch the chosen assistive technology that you want to test with.
+                        li Ensure that your OS, AT, and Browser are all up to date.
                         li Navigate to the test page iframe (after these instructions) or #[a(href='/tests/html/' + test.html_file) open the test page].
-                        li For each expectation, locate the target element(s) and test whether or not the expectation is met
-                        li The assistive technology might provide many commands that apply to the expectation. Try to test as many as possible.
-                        li Record your findings. Please include detailed notes about what commands were used.
+                        li For each test case, locate the target element(s) and test whether or not the expectations are met
 
                     p(class="note") Note: Screen readers will usually announce an element in the format: <span class='inline-quote'>"&lt;role&gt;, &lt;accessible name&gt;, &lt;other states and properties&gt;, &lt;accessible description&gt;"</span>. The order in which the name, role, and properties are announced might differ between screen readers. The exact vocabulary used will also differ.
-
-                    div
-                        if test.html_file.startsWith('http')
-                            a(href=test.html_file + test.html_file) open the external test page
-                        else
-                            a(href="/tests/html/" + test.html_file) open the test page
-                                div
-                                    iframe(src='/tests/html/' + test.html_file aria-label="the test page")
 
                     form.submit-test-result.stacked-form
                         input(type="hidden" name="title" value=test.id)
@@ -89,6 +81,72 @@ block content
                                     input(type="text" name="browser_version" id="browser_version" aria-required="true")
 
                         div(id="assertions").control
+
+                            - var all_at = ATBrowsers.core_at.concat(ATBrowsers.extended_at);
+                            each at in ATBrowsers.at
+                                - var all_browsers = [].concat(at.core_browsers).concat(at.extended_browsers);
+                                each browser_id in all_browsers
+                                    div(id="combo-"+at.id+'-'+browser_id hidden class='combo')
+                                        h3(tabindex='-1') Test cases for #{at.title} + #{ATBrowsers.browsers[browser_id].title}
+                                        if (!devTest.commands[at.id] || !devTest.commands[at.id][browser_id])
+                                            p The test has not been configured for this combination. Please open a GitHub issue.
+                                        else
+                                            each command, command_index in devTest.commands[at.id][browser_id]
+                                                fieldset.command
+                                                    legend Test case: #{testHelper.generateTestTitle(command, at)}
+                                                    +test-procedure(command, at, ATBrowsers.browsers[browser_id], ATBrowsers, test)
+
+                                                    // Command key
+                                                    input(type="hidden" class='command' id=at.id+'-'+browser_id+'-'+command_index+'-command' value=command.command)
+
+                                                    //output
+                                                    input(type="hidden" class='output-before' id=at.id+'-'+browser_id+'-'+command_index+'-output-before' value=command.output)
+                                                    label(for=at.id+'-'+browser_id+'-'+command_index+'-output') Output
+                                                    textarea(id=at.id+'-'+browser_id+'-'+command_index+'-output' class='output-after') #{command.output}
+
+                                                    // notes
+                                                    input(type="hidden" class='notes-before' id=at.id + '-' + browser_id + '-' + command_index + '-notes-before' value=command.notes)
+                                                    label(for=at.id + '-' + browser_id + '-' + command_index + '-notes') Notes
+                                                    textarea(id=at.id + '-' + browser_id + '-' + command_index + '-notes' class='notes-after') #{command.notes}
+
+                                                    each result, result_index in command.results
+                                                        - var assertion_key = testHelper.getAssertionKey(test, result.feature_id, result.feature_assertion_id, result.applied_to, result.references);
+                                                        fieldset
+                                                            legend #{test.assertions[assertion_key].feature_title}, #{test.assertions[assertion_key].assertion_strength[at.type]} #{test.assertions[assertion_key].assertion_title}
+                                                                if (test.assertions[assertion_key].applied_to_title)
+                                                                    span , applied to #{test.assertions[assertion_key].applied_to_title}
+                                                                if (test.assertions[assertion_key].references_titles)
+                                                                    span , references #{test.assertions[assertion_key].references_titles.join(', ')}
+
+                                                            if (test.assertions[assertion_key].assertion_examples)
+                                                                p Examples:
+                                                                ul
+                                                                    for example in test.assertions[assertion_key].assertion_examples
+                                                                        li #{example}
+
+                                                            - var key = result.feature_id+'; '+result.feature_assertion_id
+                                                            if (result.applied_to)
+                                                                - key += '; applied to: ' + result.applied_to
+                                                            if (result.references)
+                                                                - key += '; references: ' + result.references
+                                                            input(type="hidden" class='result-key' id=at.id + '-' + browser_id + '-' + command_index + '-results-'+result_index+'-result-key' value=key)
+                                                            // result
+                                                            input(type="hidden" class='result-before' id=at.id + '-' + browser_id + '-' + command_index + '-results-'+result_index+'-result-before' value=result.result)
+                                                            label(for=at.id + '-' + browser_id + '-' + command_index + '-results-'+result_index+'-result') Result
+                                                                div
+                                                                    select(id=at.id + '-' + browser_id + '-' + command_index + '-results-'+result_index+'-result' class='result-after')
+                                                                        option(value="unknown" selected=(result.result === 'unknown')) unknown
+                                                                        option(value="pass" selected=(result.result === 'pass')) pass
+                                                                        option(value="fail" selected=(result.result === 'fail')) fail
+                                                                        option(value="partial" selected=(result.result === 'partial')) partial
+
+                                                            // result notes
+                                                            input(type="hidden" class='note-before' id=at.id + '-' + browser_id + '-' + command_index + '-results-'+result_index+'-notes-before' value=result.note)
+                                                            label(for=at.id + '-' + browser_id + '-' + command_index + '-results-'+result_index+'-notes') Notes
+                                                            textarea(id=at.id + '-' + browser_id + '-' + command_index + '-results-'+result_index+'-notes' class='note-after') #{result.note}
+
+
+
 
                         div.control
                             button Create GitHub Issue

--- a/views/test-case-run.pug
+++ b/views/test-case-run.pug
@@ -109,6 +109,11 @@ block content
                                                     label(for=at.id + '-' + browser_id + '-' + command_index + '-notes') Notes
                                                     textarea(id=at.id + '-' + browser_id + '-' + command_index + '-notes' class='notes-after') #{command.notes}
 
+                                                    // behind_setting
+                                                    input(type="hidden" class='behind-setting-before' id=at.id + '-' + browser_id + '-' + command_index + '-behind-setting-before' value=command.behind_setting)
+                                                    label(for=at.id + '-' + browser_id + '-' + command_index + '-behind-setting') If support is hidden behind non-default settings, briefly describe that setting
+                                                    textarea(id=at.id + '-' + browser_id + '-' + command_index + '-behind-setting' class='behind-setting-after') #{command.behind_setting}
+
                                                     each result, result_index in command.results
                                                         - var assertion_key = testHelper.getAssertionKey(test, result.feature_id, result.feature_assertion_id, result.applied_to, result.references);
                                                         fieldset
@@ -144,9 +149,6 @@ block content
                                                             input(type="hidden" class='note-before' id=at.id + '-' + browser_id + '-' + command_index + '-results-'+result_index+'-notes-before' value=result.note)
                                                             label(for=at.id + '-' + browser_id + '-' + command_index + '-results-'+result_index+'-notes') Notes
                                                             textarea(id=at.id + '-' + browser_id + '-' + command_index + '-results-'+result_index+'-notes' class='note-after') #{result.note}
-
-
-
 
                         div.control
                             button Create GitHub Issue

--- a/views/test-case.pug
+++ b/views/test-case.pug
@@ -181,7 +181,15 @@ block content
                                                                         span= " ("+ATBrowsers.at[at].commands[output.command].name+")"
                                                                     else
                                                                         strong= ", " + output.command
-
+                                                                if (output.title)
+                                                                    li
+                                                                        strong= "procedure title: "
+                                                                        span= output.title + ' using '
+                                                                        if (ATBrowsers.at[at].commands[output.command])
+                                                                            span=  ATBrowsers.at[at].commands[output.command].command
+                                                                            span= " (" + ATBrowsers.at[at].commands[output.command].name + ")"
+                                                                        else
+                                                                            strong= " " + output.command
                                                                 if (output.before && ATBrowsers.at[at].type === "sr")
                                                                     li before the command was executed
                                                                         ul
@@ -193,12 +201,12 @@ block content
                                                                                     strong= "mode: "
                                                                                     span= mode
 
-                                                                                if (output.before.focus_location !== "na")
+                                                                                if (output.before.focus_location && output.before.focus_location !== "na")
                                                                                     li
                                                                                         strong= "keyboard focus location: "
                                                                                         span= output.before.focus_location
 
-                                                                                if (output.before.virtual_location !== "na")
+                                                                                if (output.before.virtual_location && output.before.virtual_location !== "na")
                                                                                     li
                                                                                         strong= "virtual cursor location: "
                                                                                         span= output.before.virtual_location
@@ -207,6 +215,55 @@ block content
                                                                     li
                                                                         strong= "location after command: "
                                                                         span= output.after
+                                                                if (output.steps && output.steps.length)
+                                                                    li
+                                                                        strong Steps to reproduce
+                                                                        ol
+                                                                            li navigate to test HTML
+                                                                            each step in output.steps
+                                                                                if (step.action === 'navigate forward to' || step.action === 'navigate backwards to')
+                                                                                    li #{step.action + ' '}
+                                                                                        if (step.selector === 'target')
+                                                                                            span `#{output.css_target}`
+                                                                                        else
+                                                                                            span `#{step.selector}`
+                                                                                if (step.action === 'set mode to')
+                                                                                    li #{step.action} #{step.value}
+                                                                                        if (step.value === 'auto')
+                                                                                            span  (do not explicitly change the mode)
+                                                                                if (step.action === 'issue command')
+                                                                                    li #{step.action}
+                                                                                        if (step.command)
+                                                                                            if (ATBrowsers.at[at].commands[step.command])
+                                                                                                span= ' "'+ATBrowsers.at[at].commands[step.command].command+'"'
+                                                                                                span= " (" + ATBrowsers.at[at].commands[step.command].name + ")"
+                                                                                            else
+                                                                                                strong #{' "'+step.command+'"'}
+                                                                                        else
+                                                                                            if (ATBrowsers.at[at].commands[output.command])
+                                                                                                span= ' "'+ATBrowsers.at[at].commands[output.command].command+'"'
+                                                                                                span= " (" + ATBrowsers.at[at].commands[output.command].name + ")"
+                                                                                            else
+                                                                                                strong #{' "'+output.command+'"'}
+                                                                                        if (step.multiple)
+                                                                                                span  multiple times
+                                                                                        if (step.summary || step.ensure_at_location)
+                                                                                            ul
+                                                                                                if (step.summary)
+                                                                                                    li summary: #{step.summary}
+                                                                                                if (step.ensure_at_location)
+                                                                                                    li Ensure AT location after executing the command
+                                                                                                        ul
+                                                                                                            if (step.ensure_at_location.focus)
+                                                                                                                li
+                                                                                                                    strong= "keyboard focus location: "
+                                                                                                                    span #{step.ensure_at_location.focus}
+                                                                                                            if (step.ensure_at_location.virtual)
+                                                                                                                li
+                                                                                                                    strong= "virtual cursor location: "
+                                                                                                                    span #{step.ensure_at_location.virtual}
+                                                                            li is the expectation met?
+
                                                                 li
                                                                     strong Output:
                                                                     span= " " + output.output

--- a/views/test-case.pug
+++ b/views/test-case.pug
@@ -1,5 +1,6 @@
 extends layout
 include test-case/assertion
+include test-procedure.mixin.pug
 
 block content
     div.content-wrapper
@@ -175,95 +176,9 @@ block content
                                                             span(class="output-result "+output.result)= " (" + output.result + ")"
                                                             ul
                                                                 li
-                                                                    strong= "command: "
-                                                                    if (ATBrowsers.at[at].commands[output.command])
-                                                                        span=  ATBrowsers.at[at].commands[output.command].command
-                                                                        span= " ("+ATBrowsers.at[at].commands[output.command].name+")"
-                                                                    else
-                                                                        strong= ", " + output.command
-                                                                if (output.title)
-                                                                    li
-                                                                        strong= "procedure title: "
-                                                                        span= output.title + ' using '
-                                                                        if (ATBrowsers.at[at].commands[output.command])
-                                                                            span=  ATBrowsers.at[at].commands[output.command].command
-                                                                            span= " (" + ATBrowsers.at[at].commands[output.command].name + ")"
-                                                                        else
-                                                                            strong= " " + output.command
-                                                                if (output.before && ATBrowsers.at[at].type === "sr")
-                                                                    li before the command was executed
-                                                                        ul
-                                                                            if (output.before.mode !== "na")
-                                                                                - var mode = output.before.mode
-                                                                                if (mode === "auto")
-                                                                                    - mode = "auto (mode not explicitly)";
-                                                                                li
-                                                                                    strong= "mode: "
-                                                                                    span= mode
-
-                                                                                if (output.before.focus_location && output.before.focus_location !== "na")
-                                                                                    li
-                                                                                        strong= "keyboard focus location: "
-                                                                                        span= output.before.focus_location
-
-                                                                                if (output.before.virtual_location && output.before.virtual_location !== "na")
-                                                                                    li
-                                                                                        strong= "virtual cursor location: "
-                                                                                        span= output.before.virtual_location
-
-                                                                if (output.after && output.after !== "na")
-                                                                    li
-                                                                        strong= "location after command: "
-                                                                        span= output.after
-                                                                if (output.steps && output.steps.length)
-                                                                    li
-                                                                        strong Steps to reproduce
-                                                                        ol
-                                                                            li navigate to test HTML
-                                                                            each step in output.steps
-                                                                                if (step.action === 'navigate forward to' || step.action === 'navigate backwards to')
-                                                                                    li #{step.action + ' '}
-                                                                                        if (step.selector === 'target')
-                                                                                            span `#{output.css_target}`
-                                                                                        else
-                                                                                            span `#{step.selector}`
-                                                                                if (step.action === 'set mode to')
-                                                                                    li #{step.action} #{step.value}
-                                                                                        if (step.value === 'auto')
-                                                                                            span  (do not explicitly change the mode)
-                                                                                if (step.action === 'issue command')
-                                                                                    li #{step.action}
-                                                                                        if (step.command)
-                                                                                            if (ATBrowsers.at[at].commands[step.command])
-                                                                                                span= ' "'+ATBrowsers.at[at].commands[step.command].command+'"'
-                                                                                                span= " (" + ATBrowsers.at[at].commands[step.command].name + ")"
-                                                                                            else
-                                                                                                strong #{' "'+step.command+'"'}
-                                                                                        else
-                                                                                            if (ATBrowsers.at[at].commands[output.command])
-                                                                                                span= ' "'+ATBrowsers.at[at].commands[output.command].command+'"'
-                                                                                                span= " (" + ATBrowsers.at[at].commands[output.command].name + ")"
-                                                                                            else
-                                                                                                strong #{' "'+output.command+'"'}
-                                                                                        if (step.multiple)
-                                                                                                span  multiple times
-                                                                                        if (step.summary || step.ensure_at_location)
-                                                                                            ul
-                                                                                                if (step.summary)
-                                                                                                    li summary: #{step.summary}
-                                                                                                if (step.ensure_at_location)
-                                                                                                    li Ensure AT location after executing the command
-                                                                                                        ul
-                                                                                                            if (step.ensure_at_location.focus)
-                                                                                                                li
-                                                                                                                    strong= "keyboard focus location: "
-                                                                                                                    span #{step.ensure_at_location.focus}
-                                                                                                            if (step.ensure_at_location.virtual)
-                                                                                                                li
-                                                                                                                    strong= "virtual cursor location: "
-                                                                                                                    span #{step.ensure_at_location.virtual}
-                                                                            li is the expectation met?
-
+                                                                    details
+                                                                        summary Test Case: #{testHelper.generateTestTitle(output, ATBrowsers.at[at])}
+                                                                        +test-procedure(output, ATBrowsers.at[at], ATBrowsers.browsers[browser], ATBrowsers, test)
                                                                 li
                                                                     strong Output:
                                                                     span= " " + output.output
@@ -326,38 +241,9 @@ block content
                                                                 span= " (" + output.result + ")"
                                                                 ul
                                                                     li
-                                                                        strong= "command: "
-                                                                        if (ATBrowsers.at[at.id].commands[output.command])
-                                                                            span=  ATBrowsers.at[at.id].commands[output.command].command
-                                                                            span= " ("+ATBrowsers.at[at.id].commands[output.command].name+")"
-                                                                        else
-                                                                            strong= ", " + output.command
-
-                                                                    if (output.before && ATBrowsers.at[at.id].type === "sr")
-                                                                        li before the command was executed
-                                                                            ul
-                                                                                if (output.before.mode !== "na")
-                                                                                    - var mode = output.before.mode
-                                                                                    if (mode === "auto")
-                                                                                        - mode = "auto (mode not explicitly)";
-                                                                                    li
-                                                                                        strong= "mode: "
-                                                                                        span= mode
-
-                                                                                    if (output.before.focus_location !== "na")
-                                                                                        li
-                                                                                            strong= "keyboard focus location: "
-                                                                                            span= output.before.focus_location
-
-                                                                                    if (output.before.virtual_location !== "na")
-                                                                                        li
-                                                                                            strong= "virtual cursor location: "
-                                                                                            span= output.before.virtual_location
-
-                                                                    if (output.after && output.after !== "na")
-                                                                        li
-                                                                            strong= "location after command: "
-                                                                            span= output.after
+                                                                        details
+                                                                            summary Test Case: #{testHelper.generateTestTitle(output, ATBrowsers.at[at.id])}
+                                                                            +test-procedure(output, ATBrowsers.at[at.id], ATBrowsers.browsers[browser], ATBrowsers, test)
                                                                     li
                                                                         strong Output:
                                                                         span= " " + output.output

--- a/views/test-procedure.mixin.pug
+++ b/views/test-procedure.mixin.pug
@@ -1,0 +1,75 @@
+mixin test-procedure(testCase, at, browser, ATBrowsers, test)
+
+    ol
+        li Launch #{at.title} and #{browser.title}.
+        li Navigate to #[a(href='/tests/html/' + test.html_file) the test page].
+        if (testCase.before)
+            li Identify all elements that match this selector:
+                code #{testCase.css_target}
+                ul
+                    li If multiple elements match the target, repeat this test for all instances. However, choose a single instance to report against. If you feel that the selector should be more specific, please open a GitHub Issue.
+            if (at.type === 'sr')
+                li Position and configure the screen reader so that the following conditions are met
+                    ul
+                        if (testCase.before.virtual_location && testCase.before.virtual_location !== 'na')
+                            li Virtual focus is: #{testCase.before.virtual_location}
+                        if (testCase.before.focus_location && testCase.before.focus_location !== 'na')
+                            li Keyboard focus is: #{testCase.before.focus_location}
+                        if (testCase.before.mode && testCase.before.mode !== 'na')
+                            li Mode is: #{testCase.before.mode}
+                                if (testCase.before.mode === 'auto')
+                                    span  (do not explicitly change the mode)
+                                else
+                                    span  (explicitly change the mode if needed)
+                li Issue the command:
+                    code  #{at.commands[testCase.command].command}
+                    span  (#{at.commands[testCase.command].name})
+                    ul
+                        li After issuing the command, virtual focus should be: #{testCase.after}
+                li Record results for the relevant expectations
+        else if (testCase.steps)
+            each step in testCase.steps
+                if (step.action === 'navigate forward to' || step.action === 'navigate backwards to')
+                    li #{step.action + ' '}
+                        if (step.selector === 'target')
+                            span `#{testCase.css_target}`
+                        else
+                            span `#{step.selector}`
+                if (step.action === 'set mode to')
+                    li #{step.action} #{step.value}
+                        if (step.value === 'auto')
+                            span  (do not explicitly change the mode)
+                if (step.action === 'issue command')
+                    li #{step.action}
+                        if (step.command)
+                            if (at.commands[step.command])
+                                span= ' "'+at.commands[step.command].command+'"'
+                                span= " (" + at.commands[step.command].name + ")"
+                            else
+                                strong #{' "'+step.command+'"'}
+                        else
+                            if (at.commands[testCase.command])
+                                span= ' "'+at.commands[testCase.command].command+'"'
+                                span= " (" + at.commands[testCase.command].name + ")"
+                            else
+                                strong #{' "'+testCase.command+'"'}
+                        if (step.multiple)
+                            span  multiple times
+                        if (step.summary || step.ensure_at_location)
+                            ul
+                                if (step.summary)
+                                    li summary: #{step.summary}
+                                if (step.ensure_at_location)
+                                    li Ensure AT location after executing the command
+                                        ul
+                                            if (step.ensure_at_location.focus)
+                                                li
+                                                    strong= "keyboard focus location: "
+                                                    span #{step.ensure_at_location.focus}
+                                            if (step.ensure_at_location.virtual)
+                                                li
+                                                    strong= "virtual cursor location: "
+                                                    span #{step.ensure_at_location.virtual}
+            li is the expectation met?
+        else
+            p unknown test procedure


### PR DESCRIPTION
Goals

- [x] Refactor the 'run test' page to make running tests more efficient. The page is currently centered around expectations, and because one command can be relevant to many expectations, this results in redundancies and re-testing the same thing over and over.
- [x] Generate test procedure titles to make it easier to find out what exactly is being tested at a glance
- [x] Reduce and re-use code as much as possible

TODO:

- [x] Implement the above
- [x] Wire up fields for when support is hidden behind settings
- [x] Test and verify that everything still works