### PR TITLE
Adds 'prepublishOnly' build to ensure data can be published to npm

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,5 @@
+public/
+routes/
+scripts/
+src/
+views/

--- a/package.json
+++ b/package.json
@@ -1,11 +1,12 @@
 {
   "name": "accessibilitysupported-site",
   "version": "0.0.0",
-  "private": true,
+  "private": false,
   "scripts": {
     "start": "node ./bin/www",
     "test": "mocha --reporter progress",
-    "build": "node ./build.js"
+    "build": "node ./build.js",
+    "prepublishOnly": "npm install && npm run build"
   },
   "dependencies": {
     "ajv": "^6.10.0",

--- a/readme.md
+++ b/readme.md
@@ -55,3 +55,9 @@ Now you just need to make sure that everything was synced correctly. If you thin
 4. (optional) manually verify that everything looks good `npm run start`
 4. commit the changes: `git commit -m 'closes #{issue-number}'`
 5. push the changes `git push origin master`
+
+## Publishing/Releasing
+
+1. Ensure the code is up-to-date with what you want to be released (`git pull origin master`)
+1. `git tag vX.Y.Z` where "vX.Y.Z" is the desired version
+1. `git push origin master --follow-tags && npm publish`


### PR DESCRIPTION
this is some setup work related to #92

once this is merged, we (probably @mfairchild365 since he's the codeowner) will do something like:

```sh
$ git pull origin master
$ git tag v1.0.0
$ git push origin master --follow-tags && npm publish
```

## Ideas for future enhancements
- add a github action which automagically tags release / publishes build to npm on every commit that lands in `master`
- use something like [`standard-version`](https://www.npmjs.com/package/standard-version) to handle automatically generating changelogs for every release