### PR TITLE
Tidy up dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build": "node ./build.js",
     "prepublishOnly": "npm install && npm run build"
   },
-  "dependencies": {
+  "devDependencies": {
     "ajv": "^6.10.0",
     "axios": ">=0.21.1",
     "chai": "^4.2.0",
@@ -28,14 +28,12 @@
     "markdown-it-anchor": "^5.2.4",
     "minimist": "^1.2.5",
     "moment": "^2.24.0",
+    "mocha": "^8.2.1",
     "morgan": "^1.9.1",
     "node-fetch": "^2.6.1",
     "node-glob": "^1.2.0",
     "pug": "^3.0.1",
     "rimraf": "^2.6.3",
     "sanitize-filename": "^1.6.1"
-  },
-  "devDependencies": {
-    "mocha": "^8.2.1"
   }
 }


### PR DESCRIPTION
Moved all modules to the "devDependencies" property.

Because:
When the "dependencies" property has modules, this module installs with those tools for only-building the site.  I think maybe those tools are unnecessary to use in this module because include static JSON files.

FYI:
> If someone is planning on downloading and using your module in their program, then they probably don't want or need to download and build the external test or documentation framework that you use.
https://docs.npmjs.com/cli/v7/configuring-npm/package-json#devdependencies

