### PR TITLE
fix issue 112 - home page improvements

### DIFF
--- a/build.js
+++ b/build.js
@@ -161,6 +161,7 @@ let getFeatures = function(techId, buildDir) {
 			all_dates: feature.all_dates,
 			failing_dates: feature.failing_dates,
 			assertions: [],
+			supports_at: feature.supports_at,
 			core_must_support_string: feature.core_must_support_string,
 			core_should_support_string: feature.core_should_support_string,
 			core_may_support_string: feature.core_may_support_string

--- a/build.js
+++ b/build.js
@@ -118,7 +118,37 @@ let getFeatures = function(techId, buildDir) {
 					found = true;
 				}
 			});
+
+			
+			
 		}
+		//Include AT and browser version combinations in feature objects
+		let simplifiedVersions = {}
+
+		for (const test of feature.tests) {
+			for (at in test.versions) {
+				simplifiedVersions[at] = {}
+
+				for (browser in test.versions[at].browsers) {
+					simplifiedVersions[at][browser] = [];
+				}
+			}
+		}
+		//Add version combinations and exclude duplicates as to not clutter the user interface
+		for (const test of feature.tests) {
+			for (at in test.versions) {
+				for (browser in test.versions[at].browsers) {
+					if (browser in simplifiedVersions[at]) {
+						let versionString = `${test.versions[at].browsers[browser].at_version}/${test.versions[at].browsers[browser].browser_version}`;
+						if (!simplifiedVersions[at][browser].includes(versionString))
+							simplifiedVersions[at][browser].push(versionString);
+					}
+				}
+			}
+		}
+
+
+	
 
 		let simplifiedFeature = {
 			id: id,
@@ -137,6 +167,7 @@ let getFeatures = function(techId, buildDir) {
 			core_support_by_at_browser: feature.core_support_by_at_browser,
 			failing_tests: failingTests,
 			total_test_count: feature.tests.length,
+			allTests: simplifiedVersions,
 			all_dates: feature.all_dates,
 			failing_dates: feature.failing_dates,
 			assertions: [],

--- a/build.js
+++ b/build.js
@@ -134,6 +134,7 @@ let getFeatures = function(techId, buildDir) {
 				}
 				return {
 					title: test.title,
+					id: test.id,
 					versions: test.versions
 				}
 			});

--- a/build.js
+++ b/build.js
@@ -118,37 +118,26 @@ let getFeatures = function(techId, buildDir) {
 					found = true;
 				}
 			});
-
-			
-			
 		}
+		
 		//Include AT and browser version combinations in feature objects
-		let simplifiedVersions = {}
+		let simplifiedTests = [];
 
-		for (const test of feature.tests) {
-			for (at in test.versions) {
-				simplifiedVersions[at] = {}
-
-				for (browser in test.versions[at].browsers) {
-					simplifiedVersions[at][browser] = [];
-				}
-			}
-		}
-		//Add version combinations and exclude duplicates as to not clutter the user interface
-		for (const test of feature.tests) {
-			for (at in test.versions) {
-				for (browser in test.versions[at].browsers) {
-					if (browser in simplifiedVersions[at]) {
-						let versionString = `${test.versions[at].browsers[browser].at_version}/${test.versions[at].browsers[browser].browser_version}`;
-						if (!simplifiedVersions[at][browser].includes(versionString))
-							simplifiedVersions[at][browser].push(versionString);
+		if (feature.tests.length > 0) {
+			simplifiedTests = feature.tests.map(function (test) {
+				for (at in test.versions) {
+					test.versions[at].title = ATBrowsers.at[at].title;
+					test.versions[at].type = ATBrowsers.at[at].type;
+					for (browser in test.versions[at].browsers) {
+						test.versions[at].browsers[browser].title = ATBrowsers.browsers[browser].title;
 					}
 				}
-			}
+				return {
+					title: test.title,
+					versions: test.versions
+				}
+			});
 		}
-
-
-	
 
 		let simplifiedFeature = {
 			id: id,
@@ -167,7 +156,7 @@ let getFeatures = function(techId, buildDir) {
 			core_support_by_at_browser: feature.core_support_by_at_browser,
 			failing_tests: failingTests,
 			total_test_count: feature.tests.length,
-			allTests: simplifiedVersions,
+			allTests: simplifiedTests,
 			all_dates: feature.all_dates,
 			failing_dates: feature.failing_dates,
 			assertions: [],

--- a/public/stylesheets/style.css
+++ b/public/stylesheets/style.css
@@ -559,3 +559,8 @@ th a .applied_to {
   margin-top: .1em;
   margin-bottom: .1em;
 }
+
+.version-combinations > * {
+  margin:0;
+  font-weight: 400;
+}

--- a/routes/index.js
+++ b/routes/index.js
@@ -12,7 +12,8 @@ router.get('/', function(req, res, next) {
 		title: 'Accessibility Support',
 		features: require(__dirname+'/../build/features.json'),
 		ATBrowsers: require(__dirname+'/../data/ATBrowsers.json'),
-		moment: moment
+		moment: moment,
+		testHelper: testHelper,
 	});
 });
 

--- a/views/index.pug
+++ b/views/index.pug
@@ -62,6 +62,16 @@ block content
                               - continue
                             each browser in ATBrowsers.at[at].core_browsers
                               td(class=feature.core_support_by_at_browser[at][browser].string.class) #{feature.core_support_by_at_browser[at][browser].string.string}
+                                br
+                                dl(class="version-combinations") 
+                                  dt 
+                                    small Versions tested (SR/Browser)
+                                    if [at] in feature.allTests
+                                      if [browser] in feature.allTests[at]
+                                        each versCombo in feature.allTests[at][browser]
+                                          dd
+                                            small #{versCombo}
+                               
                 if (feature.core_support.vc.length)
                   div.responsive-table.support-summary-table.at-container(tabindex="0")
                     h3(id="feature-" + index + '-vc-h') Voice control support

--- a/views/index.pug
+++ b/views/index.pug
@@ -23,7 +23,7 @@ block content
               if (feature.assertions.length === 0 || feature.total_test_count === 0)
                 p We do not currently have any data on this feature. Please help contribute.
               else
-                if (feature.core_support.sr.length)
+                if (feature.core_support.sr.length && feature.supports_at.includes('sr'))
                   div.responsive-table.support-summary-table.at-container(tabindex="0")
                     h3(id="feature-"+index+'-sr-h') Screen reader support
                     div.expectation-summary
@@ -62,7 +62,7 @@ block content
                               - continue
                             each browser in ATBrowsers.at[at].core_browsers
                               td(class=feature.core_support_by_at_browser[at][browser].string.class) #{feature.core_support_by_at_browser[at][browser].string.string}
-                if (feature.core_support.vc.length)
+                if (feature.core_support.vc.length && feature.supports_at.includes('vc'))
                   div.responsive-table.support-summary-table.at-container(tabindex="0")
                     h3(id="feature-" + index + '-vc-h') Voice control support
                     div.expectation-summary

--- a/views/index.pug
+++ b/views/index.pug
@@ -62,16 +62,16 @@ block content
                               - continue
                             each browser in ATBrowsers.at[at].core_browsers
                               td(class=feature.core_support_by_at_browser[at][browser].string.class) #{feature.core_support_by_at_browser[at][browser].string.string}
-                                br
-                                dl(class="version-combinations") 
-                                  dt 
-                                    small Versions tested (SR/Browser)
-                                    if [at] in feature.allTests
-                                      if [browser] in feature.allTests[at]
-                                        each versCombo in feature.allTests[at][browser]
-                                          dd
-                                            small #{versCombo}
-                               
+                    details
+                      summary
+                        h4 Screen reader and browser versions tested
+                      each test in feature.allTests
+                        h5 Test: #{test.title}
+                        ul
+                        each at in test.versions
+                          if (at.type === 'sr')
+                            each browser in at.browsers
+                              li #{at.title} #{browser.at_version} with #{browser.title} #{browser.browser_version}
                 if (feature.core_support.vc.length)
                   div.responsive-table.support-summary-table.at-container(tabindex="0")
                     h3(id="feature-" + index + '-vc-h') Voice control support
@@ -110,5 +110,23 @@ block content
                               - continue
                             each browser in ATBrowsers.at[at].core_browsers
                               td(class=feature.core_support_by_at_browser[at][browser].string.class) #{feature.core_support_by_at_browser[at][browser].string.string}
+                    details
+                      summary
+                        h4 Voice control and browser versions tested
+                      each test in feature.allTests
+                        h5 Test: #{test.title}
+                          - let hasVoiceControlTests = false
+                        each at in test.versions
+                          if (at.type === 'vc')
+                            - hasVoiceControlTests = true
+                            - return
+                        if (hasVoiceControlTests)
+                          ul
+                            each at in test.versions
+                              if (at.type === 'vc')
+                                each browser in at.browsers
+                                  li #{at.title} #{browser.at_version} with #{browser.title} #{browser.browser_version}
+                        else
+                          p No test data available.
                 p Supported by #{feature.total_test_count} tests. Results range from #{moment(feature.all_dates.max).fromNow()} to #{moment(feature.all_dates.min).fromNow()}. #{(feature.failing_dates.max && moment().diff(feature.failing_dates.max, 'months') >= 9)? 'Caution: failing or partial results may be out of date. Consider contributing results.': ''}
       script(src="/js/search.js")

--- a/views/index.pug
+++ b/views/index.pug
@@ -62,16 +62,6 @@ block content
                               - continue
                             each browser in ATBrowsers.at[at].core_browsers
                               td(class=feature.core_support_by_at_browser[at][browser].string.class) #{feature.core_support_by_at_browser[at][browser].string.string}
-                    details
-                      summary
-                        h4 Screen reader and browser versions tested
-                      each test in feature.allTests
-                        h5 Test: #{test.title}
-                        ul
-                        each at in test.versions
-                          if (at.type === 'sr')
-                            each browser in at.browsers
-                              li #{at.title} #{browser.at_version} with #{browser.title} #{browser.browser_version}
                 if (feature.core_support.vc.length)
                   div.responsive-table.support-summary-table.at-container(tabindex="0")
                     h3(id="feature-" + index + '-vc-h') Voice control support
@@ -110,23 +100,15 @@ block content
                               - continue
                             each browser in ATBrowsers.at[at].core_browsers
                               td(class=feature.core_support_by_at_browser[at][browser].string.class) #{feature.core_support_by_at_browser[at][browser].string.string}
-                    details
-                      summary
-                        h4 Voice control and browser versions tested
-                      each test in feature.allTests
-                        h5 Test: #{test.title}
-                          - let hasVoiceControlTests = false
-                        each at in test.versions
-                          if (at.type === 'vc')
-                            - hasVoiceControlTests = true
-                            - return
-                        if (hasVoiceControlTests)
-                          ul
-                            each at in test.versions
-                              if (at.type === 'vc')
-                                each browser in at.browsers
-                                  li #{at.title} #{browser.at_version} with #{browser.title} #{browser.browser_version}
-                        else
-                          p No test data available.
                 p Supported by #{feature.total_test_count} tests. Results range from #{moment(feature.all_dates.max).fromNow()} to #{moment(feature.all_dates.min).fromNow()}. #{(feature.failing_dates.max && moment().diff(feature.failing_dates.max, 'months') >= 9)? 'Caution: failing or partial results may be out of date. Consider contributing results.': ''}
+                details
+                  summary
+                    h3 Test and version details
+                  each test in feature.allTests
+                    h4
+                      a(href="/tests/"+ testHelper.makeSafe(test.id)) Test: #{test.title}
+                    ul
+                      each at in test.versions
+                        each browser in at.browsers
+                          li #{at.title} #{browser.at_version} with #{browser.title} #{browser.browser_version}
       script(src="/js/search.js")


### PR DESCRIPTION
This PR

* shows version info on the home page listings
* links to relevant tests from the home page
* suppresses n/a AT on the home page (for example, if Voice Control is not applicable)