### PR TITLE
banner role additions

### DIFF
--- a/data/tech/aria/banner_role.json
+++ b/data/tech/aria/banner_role.json
@@ -9,6 +9,39 @@
       "url": "https://www.w3.org/TR/wai-aria-1.1/#banner"
     }
   ],
-  "assertions": [],
-  "date_updated": "2019-01-06"
+  "assertions": [
+    {
+      "id": "convey_role",
+      "strength": {
+        "sr": "MUST",
+        "vc": "NA"
+      },
+      "css_target": "role=\"banner\"",
+      "operation_modes": [
+        "sr/reading",
+        "sr/interaction"
+      ]
+    },
+    {
+      "id": "convey_name",
+      "strength": {
+        "sr": "MUST",
+        "vc": "NA"
+      },
+      "css_target": "role=\"banner\"",
+      "operation_modes": [
+        "sr/reading",
+        "sr/interaction"
+      ]
+    },
+    {
+      "id": "convey_boundaries",
+      "css_target": "role=\"banner\""
+    },
+    {
+      "id": "provide_shortcuts",
+      "css_target": "role=\"banner\""
+    }
+  ],
+  "date_updated": "2021-12-21"
 }

--- a/data/tests/html/aria/landmarks-aria-named.html
+++ b/data/tests/html/aria/landmarks-aria-named.html
@@ -4,13 +4,21 @@
 <head>
   <title>ARIA named landmarks test suite</title>
   <style type="text/css">
-    div { border: 1px solid darkblue; padding: 10px }
+    div {
+      border: 1px solid darkblue;
+      padding: 10px
+    }
   </style>
 </head>
 
 <body>
+  <p>
+    <a href="#mainheading">Skip link</a>
+    <button type="button" onclick="alert('Pre-header button pressed');">Pre-header button</button>
+  </p>
   <div role="banner" aria-label="Site header">
     <p>This is the start of the banner role container</p>
+    <p><button type="button" onclick="alert('Header button 1 pressed');">Header button 1</button></p>
     <p><a href="/">A11ySupport home</a></p>
     <div role="search" aria-label="Site search">
       <p>This is the start of a search role container</p>
@@ -18,6 +26,7 @@
       <input id="txtSearch" type="search" />
       <p>This is the end of a search role container</p>
     </div>
+    <p><button type="button" onclick="alert('Header button 2 pressed');">Header button 2</button></p>
     <p>This is the end of the banner role container</p>
   </div>
   <div role="navigation" aria-label="Site sections">
@@ -42,7 +51,7 @@
   </div>
   <div role="main" aria-label="Site main">
     <p>This is the start of the main role container</p>
-    <h1>ARIA landmarks testing</h1>
+    <h1 id="mainheading">ARIA landmarks testing</h1>
     <button type="button" onclick="alert('You don\'t follow instructions very well');">Don't click me</button>
     <p>This is the end of the main role container</p>
   </div>

--- a/data/tests/html/aria/landmarks-aria-unnamed.html
+++ b/data/tests/html/aria/landmarks-aria-unnamed.html
@@ -4,13 +4,21 @@
 <head>
   <title>ARIA unnamed landmarks test suite</title>
   <style type="text/css">
-    div { border: 1px solid darkblue; padding: 10px }
+    div {
+      border: 1px solid darkblue;
+      padding: 10px
+    }
   </style>
 </head>
 
 <body>
+  <p>
+    <a href="#mainheading">Skip link</a>
+    <button type="button" onclick="alert('Pre-header button pressed');">Pre-header button</button>
+  </p>
   <div role="banner">
     <p>This is the start of the banner role container</p>
+    <p><button type="button" onclick="alert('Header button 1 pressed');">Header button 1</button></p>
     <p><a href="/">A11ySupport home</a></p>
     <div role="search">
       <p>This is the start of a search role container</p>
@@ -18,6 +26,7 @@
       <input id="txtSearch" type="search" />
       <p>This is the end of a search role container</p>
     </div>
+    <p><button type="button" onclick="alert('Header button 2 pressed');">Header button 2</button></p>
     <p>This is the end of the banner role container</p>
   </div>
   <div role="navigation">
@@ -40,7 +49,7 @@
     <p><button type="button" onclick="alert('nav button 2 pressed');">Nav button 2</button></p>
     <p>This is the end of an unnamed navigation role container</p>
   </div>
-  <div role="main">
+  <div role="main" id="mainheading">
     <p>This is the start of the main role container</p>
     <h1>ARIA landmarks testing</h1>
     <button type="button" onclick="alert('You don\'t follow instructions very well');">Don't click me</button>

--- a/data/tests/tech/aria/role-banner-named.json
+++ b/data/tests/tech/aria/role-banner-named.json
@@ -1,0 +1,1523 @@
+{
+  "title": "named banner role",
+  "description": "This test checks a named banner role",
+  "html_file": "aria/landmarks-aria-named.html",
+  "assertions": [
+    {
+      "feature_id": "aria/banner_role",
+      "feature_assertion_id": "convey_role"
+    },
+    {
+      "feature_id": "aria/banner_role",
+      "feature_assertion_id": "convey_name"
+    },
+    {
+      "feature_id": "aria/banner_role",
+      "feature_assertion_id": "convey_boundaries"
+    },
+    {
+      "feature_id": "aria/banner_role",
+      "feature_assertion_id": "provide_shortcuts"
+    }
+  ],
+  "commands": {
+    "jaws": {
+      "chrome": [
+        {
+          "command": "next_region",
+          "css_target": "role=\"banner\"",
+          "before": {
+            "mode": "auto",
+            "virtual_location": "before target",
+            "focus_location": "before target"
+          },
+          "after": "target",
+          "output": "\"This is the start of the header role container, Site header, banner\"",
+          "results": [
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_role",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_name",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "provide_shortcuts",
+              "result": "pass"
+            }
+          ]
+        },
+        {
+          "command": "list_regions",
+          "css_target": "role=\"banner\"",
+          "before": {
+            "mode": "auto",
+            "virtual_location": "before target",
+            "focus_location": "before target"
+          },
+          "after": "target",
+          "output": "Regions list includes \"Site header banner\"",
+          "results": [
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_role",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_name",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "provide_shortcuts",
+              "result": "pass"
+            }
+          ]
+        },
+        {
+          "command": "next_focusable_item",
+          "css_target": "role=\"banner\" > button",
+          "before": {
+            "mode": "auto",
+            "virtual_location": "before target",
+            "focus_location": "before target"
+          },
+          "after": "target",
+          "output": "\"Site header, banner, region, Header button 1, button\"",
+          "results": [
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_role",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_name",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_boundaries",
+              "result": "pass"
+            }
+          ]
+        },
+        {
+          "command": "previous_focusable_item",
+          "css_target": "role=\"banner\" > button",
+          "before": {
+            "mode": "auto",
+            "virtual_location": "after target",
+            "focus_location": "after target"
+          },
+          "after": "target",
+          "output": "\"Site header, banner region, Header button 2, button\"",
+          "results": [
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_role",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_name",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_boundaries",
+              "result": "pass"
+            }
+          ]
+        },
+        {
+          "command": "next_item",
+          "css_target": "role=\"banner\"",
+          "before": {
+            "mode": "auto",
+            "virtual_location": "before target",
+            "focus_location": "before target"
+          },
+          "after": "start of target",
+          "output": "\"This is the start of the banner role container\"",
+          "results": [
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_role",
+              "result": "fail"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_name",
+              "result": "fail"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_boundaries",
+              "result": "fail"
+            }
+          ]
+        },
+        {
+          "command": "previous_item",
+          "css_target": "role=\"banner\"",
+          "before": {
+            "mode": "auto",
+            "virtual_location": "after target",
+            "focus_location": "after target"
+          },
+          "after": "end of target",
+          "output": "\"This is the end of the banner role container\"",
+          "results": [
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_role",
+              "result": "fail"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_name",
+              "result": "fail"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_boundaries",
+              "result": "fail"
+            }
+          ]
+        }
+      ],
+      "edge": [
+        {
+          "command": "next_region",
+          "css_target": "role=\"banner\"",
+          "before": {
+            "mode": "auto",
+            "virtual_location": "before target",
+            "focus_location": "before target"
+          },
+          "after": "target",
+          "output": "\"This is the start of the banner role container, Site header, banner\"",
+          "results": [
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_role",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_name",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "provide_shortcuts",
+              "result": "pass"
+            }
+          ]
+        },
+        {
+          "command": "list_regions",
+          "css_target": "role=\"banner\"",
+          "before": {
+            "mode": "auto",
+            "virtual_location": "before target",
+            "focus_location": "before target"
+          },
+          "after": "target",
+          "output": "Regions list includes \"Site header banner\"",
+          "results": [
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_role",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_name",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "provide_shortcuts",
+              "result": "pass"
+            }
+          ]
+        },
+        {
+          "command": "next_focusable_item",
+          "css_target": "role=\"banner\" > button",
+          "before": {
+            "mode": "auto",
+            "virtual_location": "before target",
+            "focus_location": "before target"
+          },
+          "after": "target",
+          "output": "\"Site header, banner, region, Header button 1, button\"",
+          "results": [
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_role",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_name",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_boundaries",
+              "result": "pass"
+            }
+          ]
+        },
+        {
+          "command": "previous_focusable_item",
+          "css_target": "role=\"banner\" > button",
+          "before": {
+            "mode": "auto",
+            "virtual_location": "after target",
+            "focus_location": "after target"
+          },
+          "after": "target",
+          "output": "\"Site header, banner region, Header button 2, button\"",
+          "results": [
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_role",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_name",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_boundaries",
+              "result": "pass"
+            }
+          ]
+        },
+        {
+          "command": "next_item",
+          "css_target": "role=\"banner\"",
+          "before": {
+            "mode": "auto",
+            "virtual_location": "before target",
+            "focus_location": "before target"
+          },
+          "after": "start of target",
+          "output": "\"This is the start of the banner role container\"",
+          "results": [
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_role",
+              "result": "fail"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_name",
+              "result": "fail"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_boundaries",
+              "result": "fail"
+            }
+          ]
+        },
+        {
+          "command": "previous_item",
+          "css_target": "role=\"banner\"",
+          "before": {
+            "mode": "auto",
+            "virtual_location": "after target",
+            "focus_location": "after target"
+          },
+          "after": "end of target",
+          "output": "\"This is the end of the banner role container\"",
+          "results": [
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_role",
+              "result": "fail"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_name",
+              "result": "fail"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_boundaries",
+              "result": "fail"
+            }
+          ]
+        }
+      ],
+      "firefox": [
+        {
+          "command": "next_focusable_item",
+          "css_target": "role=\"banner\" > button",
+          "before": {
+            "mode": "auto",
+            "virtual_location": "before target",
+            "focus_location": "before target"
+          },
+          "after": "target",
+          "output": "\"Site header, banner region, Header button 1, button\"",
+          "results": [
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_role",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_name",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_boundaries",
+              "result": "pass"
+            }
+          ]
+        },
+        {
+          "command": "previous_focusable_item",
+          "css_target": "role=\"banner\" > button",
+          "before": {
+            "mode": "auto",
+            "virtual_location": "after target",
+            "focus_location": "after target"
+          },
+          "after": "target",
+          "output": "\"Site header, banner region, Header button 2, button\"",
+          "results": [
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_role",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_name",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_boundaries",
+              "result": "pass"
+            }
+          ]
+        }
+      ]
+    },
+    "narrator": {
+      "edge": [
+        {
+          "command": "next_landmark",
+          "css_target": "role=\"banner\"",
+          "before": {
+            "mode": "auto",
+            "virtual_location": "before target",
+            "focus_location": "before target"
+          },
+          "after": "target",
+          "output": "\"Site header, banner, landmark\"",
+          "results": [
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_role",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_name",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "provide_shortcuts",
+              "result": "pass"
+            }
+          ]
+        },
+        {
+          "command": "list_landmarks",
+          "css_target": "role=\"banner\"",
+          "before": {
+            "mode": "auto",
+            "virtual_location": "before target",
+            "focus_location": "before target"
+          },
+          "after": "target",
+          "output": "Landmarks list includes \"Site header; banner\"",
+          "results": [
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_role",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_name",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "provide_shortcuts",
+              "result": "pass"
+            }
+          ]
+        },
+        {
+          "command": "next_focusable_item",
+          "css_target": "role=\"banner\" > button",
+          "before": {
+            "mode": "auto",
+            "virtual_location": "before target",
+            "focus_location": "before target"
+          },
+          "after": "target",
+          "output": "\"Site header, header button 1, button\"",
+          "results": [
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_role",
+              "result": "fail"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_name",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_boundaries",
+              "result": "pass",
+              "notes": "Boundary conveyed by container name"
+            }
+          ]
+        },
+        {
+          "command": "previous_focusable_item",
+          "css_target": "role=\"banner\" > button",
+          "before": {
+            "mode": "auto",
+            "virtual_location": "after target",
+            "focus_location": "after target"
+          },
+          "after": "target",
+          "output": "\"Site header, Header button 2, button\"",
+          "results": [
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_role",
+              "result": "fail"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_name",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_boundaries",
+              "result": "pass",
+              "notes": "Boundary conveyed by container name"
+            }
+          ]
+        },
+        {
+          "command": "next_item",
+          "css_target": "role=\"banner\"",
+          "before": {
+            "mode": "auto",
+            "virtual_location": "before target",
+            "focus_location": "before target"
+          },
+          "after": "start of target",
+          "output": "\"This is the start of the banner role container\"",
+          "results": [
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_role",
+              "result": "fail"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_name",
+              "result": "fail"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_boundaries",
+              "result": "fail"
+            }
+          ]
+        },
+        {
+          "command": "previous_item",
+          "css_target": "role=\"banner\"",
+          "before": {
+            "mode": "auto",
+            "virtual_location": "after target",
+            "focus_location": "after target"
+          },
+          "after": "end of target",
+          "output": "\"This is the end of the banner role container\"",
+          "results": [
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_role",
+              "result": "fail"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_name",
+              "result": "fail"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_boundaries",
+              "result": "fail"
+            }
+          ]
+        }
+      ]
+    },
+    "nvda": {
+      "chrome": [
+        {
+          "command": "next_landmark",
+          "css_target": "role=\"banner\"",
+          "before": {
+            "mode": "auto",
+            "virtual_location": "before target",
+            "focus_location": "before target"
+          },
+          "after": "target",
+          "output": "\"Site header, banner, landmark, This is the start of the banner role container\"",
+          "results": [
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_role",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_name",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "provide_shortcuts",
+              "result": "pass"
+            }
+          ]
+        },
+        {
+          "command": "open_element_list",
+          "css_target": "role=\"banner\"",
+          "before": {
+            "mode": "auto",
+            "virtual_location": "before target",
+            "focus_location": "before target"
+          },
+          "after": "target",
+          "output": "Elements landmarks lists includes \"Site header; banner\"",
+          "results": [
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_role",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_name",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "provide_shortcuts",
+              "result": "pass"
+            }
+          ]
+        },
+        {
+          "command": "next_focusable_item",
+          "css_target": "role=\"banner\" > button",
+          "before": {
+            "mode": "auto",
+            "virtual_location": "before target",
+            "focus_location": "before target"
+          },
+          "after": "target",
+          "output": "\"Site header, banner, landmark, Header button 1, button\"",
+          "results": [
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_role",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_name",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_boundaries",
+              "result": "pass"
+            }
+          ]
+        },
+        {
+          "command": "previous_focusable_item",
+          "css_target": "role=\"banner\" > button",
+          "before": {
+            "mode": "auto",
+            "virtual_location": "after target",
+            "focus_location": "after target"
+          },
+          "after": "target",
+          "output": "\"Site header, banner, landmark, Header button 2, button\"",
+          "results": [
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_role",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_name",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_boundaries",
+              "result": "pass"
+            }
+          ]
+        },
+        {
+          "command": "next_item",
+          "css_target": "role=\"banner\"",
+          "before": {
+            "mode": "auto",
+            "virtual_location": "before target",
+            "focus_location": "before target"
+          },
+          "after": "start of target",
+          "output": "\"Site header, banner, landmark, This is the start of the banner role container\"",
+          "results": [
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_role",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_name",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_boundaries",
+              "result": "pass"
+            }
+          ]
+        },
+        {
+          "command": "previous_item",
+          "css_target": "role=\"banner\"",
+          "before": {
+            "mode": "auto",
+            "virtual_location": "after target",
+            "focus_location": "after target"
+          },
+          "after": "end of target",
+          "output": "\"Site header, banner, landmark, This is the end of the banner role container\"",
+          "results": [
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_role",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_name",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_boundaries",
+              "result": "pass"
+            }
+          ]
+        }
+      ],
+      "edge": [
+        {
+          "command": "next_landmark",
+          "css_target": "role=\"banner\"",
+          "before": {
+            "mode": "auto",
+            "virtual_location": "before target",
+            "focus_location": "before target"
+          },
+          "after": "target",
+          "output": "\"Site header, banner, landmark, This is the start of the banner role container\"",
+          "results": [
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_role",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_name",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "provide_shortcuts",
+              "result": "pass"
+            }
+          ]
+        },
+        {
+          "command": "open_element_list",
+          "css_target": "role=\"banner\"",
+          "before": {
+            "mode": "auto",
+            "virtual_location": "before target",
+            "focus_location": "before target"
+          },
+          "after": "target",
+          "output": "Elements landmarks list includes \"Site header; banner\"",
+          "results": [
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_role",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_name",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "provide_shortcuts",
+              "result": "pass"
+            }
+          ]
+        },
+        {
+          "command": "next_focusable_item",
+          "css_target": "role=\"banner\" > button",
+          "before": {
+            "mode": "auto",
+            "virtual_location": "before target",
+            "focus_location": "before target"
+          },
+          "after": "target",
+          "output": "\"Site header, banner, landmark, Header button 1, button\"",
+          "results": [
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_role",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_name",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_boundaries",
+              "result": "pass"
+            }
+          ]
+        },
+        {
+          "command": "previous_focusable_item",
+          "css_target": "role=\"banner\" > button",
+          "before": {
+            "mode": "auto",
+            "virtual_location": "after target",
+            "focus_location": "after target"
+          },
+          "after": "target",
+          "output": "\"Site header, banner, landmark, Header button 2, button\"",
+          "results": [
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_role",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_name",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_boundaries",
+              "result": "pass"
+            }
+          ]
+        },
+        {
+          "command": "next_item",
+          "css_target": "role=\"banner\"",
+          "before": {
+            "mode": "auto",
+            "virtual_location": "before target",
+            "focus_location": "before target"
+          },
+          "after": "start of target",
+          "output": "\"Site header, banner, landmark, This is the start of the banner role container\"",
+          "results": [
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_role",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_name",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_boundaries",
+              "result": "pass"
+            }
+          ]
+        },
+        {
+          "command": "previous_item",
+          "css_target": "role=\"banner\"",
+          "before": {
+            "mode": "auto",
+            "virtual_location": "after target",
+            "focus_location": "after target"
+          },
+          "after": "end of target",
+          "output": "\"Site header, banner, landmark, This is the end of the banner role container\"",
+          "results": [
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_role",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_name",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_boundaries",
+              "result": "pass"
+            }
+          ]
+        }
+      ],
+      "firefox": [
+        {
+          "command": "next_landmark",
+          "css_target": "role=\"banner\"",
+          "before": {
+            "mode": "auto",
+            "virtual_location": "before target",
+            "focus_location": "before target"
+          },
+          "after": "target",
+          "output": "\"Site header, banner, landmark, This is the start of the banner role container\"",
+          "results": [
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_role",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_name",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "provide_shortcuts",
+              "result": "pass"
+            }
+          ]
+        },
+        {
+          "command": "open_element_list",
+          "css_target": "role=\"banner\"",
+          "before": {
+            "mode": "auto",
+            "virtual_location": "before target",
+            "focus_location": "before target"
+          },
+          "after": "target",
+          "output": "Elements landmarks list includes \"Site header; banner\"",
+          "results": [
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_role",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_name",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "provide_shortcuts",
+              "result": "pass"
+            }
+          ]
+        },
+        {
+          "command": "next_focusable_item",
+          "css_target": "role=\"banner\" > button",
+          "before": {
+            "mode": "auto",
+            "virtual_location": "before target",
+            "focus_location": "before target"
+          },
+          "after": "target",
+          "output": "\"Site header, banner, landmark, Header button 1, button\"",
+          "results": [
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_role",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_name",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_boundaries",
+              "result": "pass"
+            }
+          ]
+        },
+        {
+          "command": "previous_focusable_item",
+          "css_target": "role=\"banner\" > button",
+          "before": {
+            "mode": "auto",
+            "virtual_location": "after target",
+            "focus_location": "after target"
+          },
+          "after": "target",
+          "output": "\"Site header, banner, landmark, Header button 2, button\"",
+          "results": [
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_role",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_name",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_boundaries",
+              "result": "pass"
+            }
+          ]
+        },
+        {
+          "command": "next_item",
+          "css_target": "role=\"banner\"",
+          "before": {
+            "mode": "auto",
+            "virtual_location": "before target",
+            "focus_location": "before target"
+          },
+          "after": "start of target",
+          "output": "\"Site header, banner, landmark, This is the start of the banner role container\"",
+          "results": [
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_role",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_name",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_boundaries",
+              "result": "pass"
+            }
+          ]
+        },
+        {
+          "command": "previous_item",
+          "css_target": "role=\"banner\"",
+          "before": {
+            "mode": "auto",
+            "virtual_location": "after target",
+            "focus_location": "after target"
+          },
+          "after": "end of target",
+          "output": "\"Site header, banner, landmark, This is the end of the banner role container\"",
+          "results": [
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_role",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_name",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_boundaries",
+              "result": "pass"
+            }
+          ]
+        }
+      ]
+    },
+    "talkback": {
+      "and_chr": [
+        {
+          "command": "next_landmark",
+          "css_target": "role=\"banner\"",
+          "before": {
+            "mode": "auto",
+            "virtual_location": "before target",
+            "focus_location": "before target"
+          },
+          "after": "target",
+          "output": "\"Site header, banner, This is the start of the banner role container...\"",
+          "results": [
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_role",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_name",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "provide_shortcuts",
+              "result": "pass"
+            }
+          ]
+        },
+        {
+          "command": "next_item",
+          "css_target": "role=\"banner\"",
+          "before": {
+            "mode": "auto",
+            "virtual_location": "before target",
+            "focus_location": "before target"
+          },
+          "after": "start of target",
+          "output": "\"This is the start of the banner role container\"",
+          "results": [
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_role",
+              "result": "fail"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_name",
+              "result": "fail"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_boundaries",
+              "result": "fail"
+            }
+          ]
+        },
+        {
+          "command": "previous_item",
+          "css_target": "role=\"banner\"",
+          "before": {
+            "mode": "auto",
+            "virtual_location": "after target",
+            "focus_location": "after target"
+          },
+          "after": "end of target",
+          "output": "\"This is the end of the banner role container\"",
+          "results": [
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_role",
+              "result": "fail"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_name",
+              "result": "fail"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_boundaries",
+              "result": "fail"
+            }
+          ]
+        }
+      ]
+    },
+    "vo_ios": {
+      "ios_saf": [
+        {
+          "command": "next_landmark",
+          "css_target": "role=\"banner\"",
+          "before": {
+            "mode": "auto",
+            "virtual_location": "before target",
+            "focus_location": "before target"
+          },
+          "after": "target",
+          "output": "\"This is the start of the banner role container, Site header, banner, Landmark\"",
+          "results": [
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_role",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_name",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "provide_shortcuts",
+              "result": "pass"
+            }
+          ]
+        },
+        {
+          "command": "next_item",
+          "css_target": "role=\"banner\"",
+          "before": {
+            "mode": "auto",
+            "virtual_location": "before target",
+            "focus_location": "before target"
+          },
+          "after": "start of target",
+          "output": "\"This is the start of the banner role container, Site header, banner, Landmark\"",
+          "results": [
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_role",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_name",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_boundaries",
+              "result": "pass"
+            }
+          ]
+        },
+        {
+          "command": "previous_item",
+          "css_target": "role=\"banner\"",
+          "before": {
+            "mode": "auto",
+            "virtual_location": "after target",
+            "focus_location": "after target"
+          },
+          "after": "end of target",
+          "output": "\"This is the end of the banner role container, end, Site header, banner\"",
+          "results": [
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_role",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_name",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_boundaries",
+              "result": "pass"
+            }
+          ]
+        }
+      ]
+    },
+    "vo_macos": {
+      "safari": [
+        {
+          "command": "open_element_list",
+          "css_target": "role=\"banner\"",
+          "before": {
+            "mode": "auto",
+            "virtual_location": "before target",
+            "focus_location": "before target"
+          },
+          "after": "target",
+          "output": "Landmarks list includes \"Site header banner\"",
+          "results": [
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_role",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_name",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "provide_shortcuts",
+              "result": "pass"
+            }
+          ]
+        },
+        {
+          "command": "next_focusable_item",
+          "css_target": "role=\"banner\" > button",
+          "before": {
+            "mode": "auto",
+            "virtual_location": "before target",
+            "focus_location": "before target"
+          },
+          "after": "target",
+          "output": "\"Header button 1, button, Site header, banner\"",
+          "results": [
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_role",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_name",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_boundaries",
+              "result": "pass"
+            }
+          ]
+        },
+        {
+          "command": "previous_focusable_item",
+          "css_target": "role=\"banner\" > button",
+          "before": {
+            "mode": "auto",
+            "virtual_location": "after target",
+            "focus_location": "after target"
+          },
+          "after": "target",
+          "output": "\"Header button 2, button, Site header, banner\"",
+          "results": [
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_role",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_name",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_boundaries",
+              "result": "pass"
+            }
+          ]
+        },
+        {
+          "command": "next_item",
+          "css_target": "role=\"banner\"",
+          "before": {
+            "mode": "auto",
+            "virtual_location": "before target",
+            "focus_location": "before target"
+          },
+          "after": "start of target",
+          "output": "\"Site header, banner\"",
+          "results": [
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_role",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_name",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_boundaries",
+              "result": "pass"
+            }
+          ]
+        },
+        {
+          "command": "previous_item",
+          "css_target": "role=\"banner\"",
+          "before": {
+            "mode": "auto",
+            "virtual_location": "after target",
+            "focus_location": "after target"
+          },
+          "after": "end of target",
+          "output": "\"end of, Site header, banner\"",
+          "results": [
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_role",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_name",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_boundaries",
+              "result": "pass"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "history": [
+    {
+      "date": "2021-12-21",
+      "message": "Test created"
+    }
+  ],
+  "versions": {
+    "jaws": {
+      "browsers": {
+        "chrome": {
+          "at_version": "2022.2112.24",
+          "browser_version": "96",
+          "os_version": "21H1",
+          "date": "2021-12-21"
+        },
+        "edge": {
+          "at_version": "2022.2112.24",
+          "browser_version": "96",
+          "os_version": "21H1",
+          "date": "2021-12-21"
+        },
+        "firefox": {
+          "at_version": "2022.2112.24",
+          "browser_version": "95",
+          "os_version": "21H1",
+          "date": "2021-12-21"
+        }
+      }
+    },
+    "narrator": {
+      "browsers": {
+        "edge": {
+          "at_version": "21H1",
+          "browser_version": "96",
+          "os_version": "21H1",
+          "date": "2021-12-21"
+        }
+      }
+    },
+    "nvda": {
+      "browsers": {
+        "chrome": {
+          "at_version": "2021.3",
+          "os_version": "21H1",
+          "browser_version": "96",
+          "date": "2021-12-21"
+        },
+        "edge": {
+          "at_version": "2021.3",
+          "os_version": "21H1",
+          "browser_version": "96",
+          "date": "2021-12-21"
+        },
+        "firefox": {
+          "at_version": "2021.3",
+          "browser_version": "95",
+          "os_version": "21H1",
+          "date": "2021-12-21"
+        }
+      }
+    },
+    "talkback": {
+      "browsers": {
+        "and_chr": {
+          "at_version": "12.1",
+          "browser_version": "96",
+          "os_version": "12",
+          "date": "2021-12-21"
+        }
+      }
+    },
+    "vo_ios": {
+      "browsers": {
+        "ios_saf": {
+          "at_version": "15.1",
+          "browser_version": "15.1",
+          "os_version": "15.1",
+          "date": "2021-12-21"
+        }
+      }
+    },
+    "vo_macos": {
+      "browsers": {
+        "safari": {
+          "at_version": "11.6.1",
+          "browser_version": "15.1",
+          "os_version": "11.6.1",
+          "date": "2021-12-21"
+        }
+      }
+    }
+  }
+}

--- a/data/tests/tech/aria/role-banner-named.json
+++ b/data/tests/tech/aria/role-banner-named.json
@@ -144,22 +144,23 @@
             "focus_location": "before target"
           },
           "after": "start of target",
-          "output": "\"This is the start of the banner role container\"",
+          "output": "\"Site header, banner\"",
+          "behind_setting": "Utilities > Settings Center > Web / HTML / PDFs > Reading > Web Verbosity Level = High",
           "results": [
             {
               "feature_id": "aria/banner_role",
               "feature_assertion_id": "convey_role",
-              "result": "fail"
+              "result": "pass"
             },
             {
               "feature_id": "aria/banner_role",
               "feature_assertion_id": "convey_name",
-              "result": "fail"
+              "result": "pass"
             },
             {
               "feature_id": "aria/banner_role",
               "feature_assertion_id": "convey_boundaries",
-              "result": "fail"
+              "result": "pass"
             }
           ]
         },
@@ -172,22 +173,23 @@
             "focus_location": "after target"
           },
           "after": "end of target",
-          "output": "\"This is the end of the banner role container\"",
+          "output": "\"Site header, banner, end\"",
+          "behind_setting": "Utilities > Settings Center > Web / HTML / PDFs > Reading > Web Verbosity Level = High",
           "results": [
             {
               "feature_id": "aria/banner_role",
               "feature_assertion_id": "convey_role",
-              "result": "fail"
+              "result": "pass"
             },
             {
               "feature_id": "aria/banner_role",
               "feature_assertion_id": "convey_name",
-              "result": "fail"
+              "result": "pass"
             },
             {
               "feature_id": "aria/banner_role",
               "feature_assertion_id": "convey_boundaries",
-              "result": "fail"
+              "result": "pass"
             }
           ]
         }
@@ -314,22 +316,23 @@
             "focus_location": "before target"
           },
           "after": "start of target",
-          "output": "\"This is the start of the banner role container\"",
+          "output": "\"Site header, banner\"",
+          "behind_setting": "Utilities > Settings Center > Web / HTML / PDFs > Reading > Web Verbosity Level = High",
           "results": [
             {
               "feature_id": "aria/banner_role",
               "feature_assertion_id": "convey_role",
-              "result": "fail"
+              "result": "pass"
             },
             {
               "feature_id": "aria/banner_role",
               "feature_assertion_id": "convey_name",
-              "result": "fail"
+              "result": "pass"
             },
             {
               "feature_id": "aria/banner_role",
               "feature_assertion_id": "convey_boundaries",
-              "result": "fail"
+              "result": "pass"
             }
           ]
         },
@@ -342,27 +345,84 @@
             "focus_location": "after target"
           },
           "after": "end of target",
-          "output": "\"This is the end of the banner role container\"",
+          "output": "\"Site header, banner, end\"",
+          "behind_setting": "Utilities > Settings Center > Web / HTML / PDFs > Reading > Web Verbosity Level = High",
           "results": [
             {
               "feature_id": "aria/banner_role",
               "feature_assertion_id": "convey_role",
-              "result": "fail"
+              "result": "pass"
             },
             {
               "feature_id": "aria/banner_role",
               "feature_assertion_id": "convey_name",
-              "result": "fail"
+              "result": "pass"
             },
             {
               "feature_id": "aria/banner_role",
               "feature_assertion_id": "convey_boundaries",
-              "result": "fail"
+              "result": "pass"
             }
           ]
         }
       ],
       "firefox": [
+        {
+          "command": "next_region",
+          "css_target": "role=\"banner\"",
+          "before": {
+            "mode": "auto",
+            "virtual_location": "before target",
+            "focus_location": "before target"
+          },
+          "after": "target",
+          "output": "\"This is the start of the banner role container, Site header, banner\"",
+          "results": [
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_role",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_name",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "provide_shortcuts",
+              "result": "pass"
+            }
+          ]
+        },
+        {
+          "command": "list_regions",
+          "css_target": "role=\"banner\"",
+          "before": {
+            "mode": "auto",
+            "virtual_location": "before target",
+            "focus_location": "before target"
+          },
+          "after": "target",
+          "output": "Regions list includes \"Site header banner\"",
+          "results": [
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_role",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_name",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "provide_shortcuts",
+              "result": "pass"
+            }
+          ]
+        },
         {
           "command": "next_focusable_item",
           "css_target": "role=\"banner\" > button",
@@ -401,6 +461,64 @@
           },
           "after": "target",
           "output": "\"Site header, banner region, Header button 2, button\"",
+          "results": [
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_role",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_name",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_boundaries",
+              "result": "pass"
+            }
+          ]
+        },
+        {
+          "command": "next_item",
+          "css_target": "role=\"banner\"",
+          "before": {
+            "mode": "auto",
+            "virtual_location": "before target",
+            "focus_location": "before target"
+          },
+          "after": "start of target",
+          "output": "\"Site header, banner\"",
+          "behind_setting": "Utilities > Settings Center > Web / HTML / PDFs > Reading > Web Verbosity Level = High",
+          "results": [
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_role",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_name",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_boundaries",
+              "result": "pass"
+            }
+          ]
+        },
+        {
+          "command": "previous_item",
+          "css_target": "role=\"banner\"",
+          "before": {
+            "mode": "auto",
+            "virtual_location": "after target",
+            "focus_location": "after target"
+          },
+          "after": "end of target",
+          "output": "\"Site header, banner, end\"",
+          "behind_setting": "Utilities > Settings Center > Web / HTML / PDFs > Reading > Web Verbosity Level = High",
           "results": [
             {
               "feature_id": "aria/banner_role",
@@ -492,9 +610,47 @@
           "results": [
             {
               "feature_id": "aria/banner_role",
-              "feature_assertion_id": "convey_role",
-              "result": "fail"
+              "feature_assertion_id": "convey_name",
+              "result": "pass"
             },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_boundaries",
+              "result": "pass",
+              "notes": "Boundary conveyed by container name"
+            }
+          ]
+        },
+        {
+          "command": "next_focusable_item",
+          "css_target": "role=\"banner\" > button",
+          "before": {
+            "mode": "auto",
+            "virtual_location": "before target",
+            "focus_location": "before target"
+          },
+          "after": "target",
+          "output": "\"Site header, banner, header button 1, button\"",
+          "behind_setting": "Settings > Ease of access > Narrator > Change the level of context Narrator provides for buttons and other controls = \"3 - Immediate context name and type\"",
+          "results": [
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_role",
+              "result": "pass"
+            }
+          ]
+        },
+        {
+          "command": "previous_focusable_item",
+          "css_target": "role=\"banner\" > button",
+          "before": {
+            "mode": "auto",
+            "virtual_location": "after target",
+            "focus_location": "after target"
+          },
+          "after": "target",
+          "output": "\"Site header, Header button 2, button\"",
+          "results": [
             {
               "feature_id": "aria/banner_role",
               "feature_assertion_id": "convey_name",
@@ -517,23 +673,13 @@
             "focus_location": "after target"
           },
           "after": "target",
-          "output": "\"Site header, Header button 2, button\"",
+          "output": "\"Site header, banner, Header button 2, button\"",
+          "behind_setting": "Settings > Ease of access > Narrator > Change the level of context Narrator provides for buttons and other controls = \"3 - Immediate context name and type\"",
           "results": [
             {
               "feature_id": "aria/banner_role",
               "feature_assertion_id": "convey_role",
-              "result": "fail"
-            },
-            {
-              "feature_id": "aria/banner_role",
-              "feature_assertion_id": "convey_name",
               "result": "pass"
-            },
-            {
-              "feature_id": "aria/banner_role",
-              "feature_assertion_id": "convey_boundaries",
-              "result": "pass",
-              "notes": "Boundary conveyed by container name"
             }
           ]
         },

--- a/data/tests/tech/aria/role-banner-unnamed.json
+++ b/data/tests/tech/aria/role-banner-unnamed.json
@@ -120,17 +120,18 @@
             "focus_location": "before target"
           },
           "after": "start of target",
-          "output": "\"This is the start of the banner role container\"",
+          "output": "\"banner\"",
+          "behind_setting": "Utilities > Settings Center > Web / HTML / PDFs > Reading > Web Verbosity Level = High",
           "results": [
             {
               "feature_id": "aria/banner_role",
               "feature_assertion_id": "convey_role",
-              "result": "fail"
+              "result": "pass"
             },
             {
               "feature_id": "aria/banner_role",
               "feature_assertion_id": "convey_boundaries",
-              "result": "fail"
+              "result": "pass"
             }
           ]
         },
@@ -143,17 +144,18 @@
             "focus_location": "after target"
           },
           "after": "end of target",
-          "output": "\"This is the end of the banner role container\"",
+          "output": "\"banner end\"",
+          "behind_setting": "Utilities > Settings Center > Web / HTML / PDFs > Reading > Web Verbosity Level = High",
           "results": [
             {
               "feature_id": "aria/banner_role",
               "feature_assertion_id": "convey_role",
-              "result": "fail"
+              "result": "pass"
             },
             {
               "feature_id": "aria/banner_role",
               "feature_assertion_id": "convey_boundaries",
-              "result": "fail"
+              "result": "pass"
             }
           ]
         }
@@ -260,17 +262,18 @@
             "focus_location": "before target"
           },
           "after": "start of target",
-          "output": "\"This is the start of the banner role container\"",
+          "output": "\"banner\"",
+          "behind_setting": "Utilities > Settings Center > Web / HTML / PDFs > Reading > Web Verbosity Level = High",
           "results": [
             {
               "feature_id": "aria/banner_role",
               "feature_assertion_id": "convey_role",
-              "result": "fail"
+              "result": "pass"
             },
             {
               "feature_id": "aria/banner_role",
               "feature_assertion_id": "convey_boundaries",
-              "result": "fail"
+              "result": "pass"
             }
           ]
         },
@@ -283,22 +286,69 @@
             "focus_location": "after target"
           },
           "after": "end of target",
-          "output": "\"This is the end of the banner role container\"",
+          "output": "\"banner end\"",
+          "behind_setting": "Utilities > Settings Center > Web / HTML / PDFs > Reading > Web Verbosity Level = High",
           "results": [
             {
               "feature_id": "aria/banner_role",
               "feature_assertion_id": "convey_role",
-              "result": "fail"
+              "result": "pass"
             },
             {
               "feature_id": "aria/banner_role",
               "feature_assertion_id": "convey_boundaries",
-              "result": "fail"
+              "result": "pass"
             }
           ]
         }
       ],
       "firefox": [
+        {
+          "command": "next_region",
+          "css_target": "role=\"banner\"",
+          "before": {
+            "mode": "auto",
+            "virtual_location": "before target",
+            "focus_location": "before target"
+          },
+          "after": "target",
+          "output": "\"This is the start of the banner role container, banner\"",
+          "results": [
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_role",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "provide_shortcuts",
+              "result": "pass"
+            }
+          ]
+        },
+        {
+          "command": "list_regions",
+          "css_target": "role=\"banner\"",
+          "before": {
+            "mode": "auto",
+            "virtual_location": "before target",
+            "focus_location": "before target"
+          },
+          "after": "target",
+          "output": "Regions list includes \"Banner\"",
+          "results": [
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_role",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "provide_shortcuts",
+              "result": "pass"
+            }
+          ]
+        },
         {
           "command": "next_focusable_item",
           "css_target": "role=\"banner\" > button",
@@ -332,6 +382,54 @@
           },
           "after": "target",
           "output": "\"banner region, Header button 2, button\"",
+          "results": [
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_role",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_boundaries",
+              "result": "pass"
+            }
+          ]
+        },
+        {
+          "command": "next_item",
+          "css_target": "role=\"banner\"",
+          "before": {
+            "mode": "auto",
+            "virtual_location": "before target",
+            "focus_location": "before target"
+          },
+          "after": "start of target",
+          "output": "\"banner\"",
+          "behind_setting": "Utilities > Settings Center > Web / HTML / PDFs > Reading > Web Verbosity Level = High",
+          "results": [
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_role",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_boundaries",
+              "result": "pass"
+            }
+          ]
+        },
+        {
+          "command": "previous_item",
+          "css_target": "role=\"banner\"",
+          "before": {
+            "mode": "auto",
+            "virtual_location": "after target",
+            "focus_location": "after target"
+          },
+          "after": "end of target",
+          "output": "\"banner end\"",
+          "behind_setting": "Utilities > Settings Center > Web / HTML / PDFs > Reading > Web Verbosity Level = High",
           "results": [
             {
               "feature_id": "aria/banner_role",

--- a/data/tests/tech/aria/role-banner-unnamed.json
+++ b/data/tests/tech/aria/role-banner-unnamed.json
@@ -1,0 +1,1272 @@
+{
+  "title": "unnamed banner role",
+  "description": "This test checks an unnamed banner role",
+  "html_file": "aria/landmarks-aria-unnamed.html",
+  "assertions": [
+    {
+      "feature_id": "aria/banner_role",
+      "feature_assertion_id": "convey_role"
+    },
+    {
+      "feature_id": "aria/banner_role",
+      "feature_assertion_id": "convey_boundaries"
+    },
+    {
+      "feature_id": "aria/banner_role",
+      "feature_assertion_id": "provide_shortcuts"
+    }
+  ],
+  "commands": {
+    "jaws": {
+      "chrome": [
+        {
+          "command": "next_region",
+          "css_target": "role=\"banner\"",
+          "before": {
+            "mode": "auto",
+            "virtual_location": "before target",
+            "focus_location": "before target"
+          },
+          "after": "target",
+          "output": "\"This is the start of the banner role container, banner\"",
+          "results": [
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_role",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "provide_shortcuts",
+              "result": "pass"
+            }
+          ]
+        },
+        {
+          "command": "list_regions",
+          "css_target": "role=\"banner\"",
+          "before": {
+            "mode": "auto",
+            "virtual_location": "before target",
+            "focus_location": "before target"
+          },
+          "after": "target",
+          "output": "Regions list includes \"Banner\"",
+          "results": [
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_role",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "provide_shortcuts",
+              "result": "pass"
+            }
+          ]
+        },
+        {
+          "command": "next_focusable_item",
+          "css_target": "role=\"banner\" > button",
+          "before": {
+            "mode": "auto",
+            "virtual_location": "before target",
+            "focus_location": "before target"
+          },
+          "after": "target",
+          "output": "\"banner region, Header button 1, button\"",
+          "results": [
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_role",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_boundaries",
+              "result": "pass"
+            }
+          ]
+        },
+        {
+          "command": "previous_focusable_item",
+          "css_target": "role=\"banner\" > button",
+          "before": {
+            "mode": "auto",
+            "virtual_location": "after target",
+            "focus_location": "after target"
+          },
+          "after": "target",
+          "output": "\"banner region, Header button 2, button\"",
+          "results": [
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_role",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_boundaries",
+              "result": "pass"
+            }
+          ]
+        },
+        {
+          "command": "next_item",
+          "css_target": "role=\"banner\"",
+          "before": {
+            "mode": "auto",
+            "virtual_location": "before target",
+            "focus_location": "before target"
+          },
+          "after": "start of target",
+          "output": "\"This is the start of the banner role container\"",
+          "results": [
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_role",
+              "result": "fail"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_boundaries",
+              "result": "fail"
+            }
+          ]
+        },
+        {
+          "command": "previous_item",
+          "css_target": "role=\"banner\"",
+          "before": {
+            "mode": "auto",
+            "virtual_location": "after target",
+            "focus_location": "after target"
+          },
+          "after": "end of target",
+          "output": "\"This is the end of the banner role container\"",
+          "results": [
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_role",
+              "result": "fail"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_boundaries",
+              "result": "fail"
+            }
+          ]
+        }
+      ],
+      "edge": [
+        {
+          "command": "next_region",
+          "css_target": "role=\"banner\"",
+          "before": {
+            "mode": "auto",
+            "virtual_location": "before target",
+            "focus_location": "before target"
+          },
+          "after": "target",
+          "output": "\"This is the start of the banner role container, banner\"",
+          "results": [
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_role",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "provide_shortcuts",
+              "result": "pass"
+            }
+          ]
+        },
+        {
+          "command": "list_regions",
+          "css_target": "role=\"banner\"",
+          "before": {
+            "mode": "auto",
+            "virtual_location": "before target",
+            "focus_location": "before target"
+          },
+          "after": "target",
+          "output": "Regions list includes \"Banner\"",
+          "results": [
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_role",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "provide_shortcuts",
+              "result": "pass"
+            }
+          ]
+        },
+        {
+          "command": "next_focusable_item",
+          "css_target": "role=\"banner\" > button",
+          "before": {
+            "mode": "auto",
+            "virtual_location": "before target",
+            "focus_location": "before target"
+          },
+          "after": "target",
+          "output": "\"banner region, Header button 1, button\"",
+          "results": [
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_role",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_boundaries",
+              "result": "pass"
+            }
+          ]
+        },
+        {
+          "command": "previous_focusable_item",
+          "css_target": "role=\"banner\" > button",
+          "before": {
+            "mode": "auto",
+            "virtual_location": "after target",
+            "focus_location": "after target"
+          },
+          "after": "target",
+          "output": "\"banner region, Header button 2, button\"",
+          "results": [
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_role",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_boundaries",
+              "result": "pass"
+            }
+          ]
+        },
+        {
+          "command": "next_item",
+          "css_target": "role=\"banner\"",
+          "before": {
+            "mode": "auto",
+            "virtual_location": "before target",
+            "focus_location": "before target"
+          },
+          "after": "start of target",
+          "output": "\"This is the start of the banner role container\"",
+          "results": [
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_role",
+              "result": "fail"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_boundaries",
+              "result": "fail"
+            }
+          ]
+        },
+        {
+          "command": "previous_item",
+          "css_target": "role=\"banner\"",
+          "before": {
+            "mode": "auto",
+            "virtual_location": "after target",
+            "focus_location": "after target"
+          },
+          "after": "end of target",
+          "output": "\"This is the end of the banner role container\"",
+          "results": [
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_role",
+              "result": "fail"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_boundaries",
+              "result": "fail"
+            }
+          ]
+        }
+      ],
+      "firefox": [
+        {
+          "command": "next_focusable_item",
+          "css_target": "role=\"banner\" > button",
+          "before": {
+            "mode": "auto",
+            "virtual_location": "before target",
+            "focus_location": "before target"
+          },
+          "after": "target",
+          "output": "\"banner region, Header button 1, button\"",
+          "results": [
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_role",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_boundaries",
+              "result": "pass"
+            }
+          ]
+        },
+        {
+          "command": "previous_focusable_item",
+          "css_target": "role=\"banner\" > button",
+          "before": {
+            "mode": "auto",
+            "virtual_location": "after target",
+            "focus_location": "after target"
+          },
+          "after": "target",
+          "output": "\"banner region, Header button 2, button\"",
+          "results": [
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_role",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_boundaries",
+              "result": "pass"
+            }
+          ]
+        }
+      ]
+    },
+    "narrator": {
+      "edge": [
+        {
+          "command": "next_landmark",
+          "css_target": "role=\"banner\"",
+          "before": {
+            "mode": "auto",
+            "virtual_location": "before target",
+            "focus_location": "before target"
+          },
+          "after": "target",
+          "output": "\"banner, landmark\"",
+          "results": [
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_role",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "provide_shortcuts",
+              "result": "pass"
+            }
+          ]
+        },
+        {
+          "command": "list_landmarks",
+          "css_target": "role=\"banner\"",
+          "before": {
+            "mode": "auto",
+            "virtual_location": "before target",
+            "focus_location": "before target"
+          },
+          "after": "target",
+          "output": "Landmarks list includes \"banner\"",
+          "results": [
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_role",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "provide_shortcuts",
+              "result": "pass"
+            }
+          ]
+        },
+        {
+          "command": "next_focusable_item",
+          "css_target": "role=\"banner\" > button",
+          "before": {
+            "mode": "auto",
+            "virtual_location": "before target",
+            "focus_location": "before target"
+          },
+          "after": "target",
+          "output": "\"banner, Header button 1, button\"",
+          "results": [
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_role",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_boundaries",
+              "result": "pass"
+            }
+          ]
+        },
+        {
+          "command": "previous_focusable_item",
+          "css_target": "role=\"banner\" > button",
+          "before": {
+            "mode": "auto",
+            "virtual_location": "after target",
+            "focus_location": "after target"
+          },
+          "after": "target",
+          "output": "\"banner, Header button 2, button\"",
+          "results": [
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_role",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_boundaries",
+              "result": "pass"
+            }
+          ]
+        },
+        {
+          "command": "next_item",
+          "css_target": "role=\"banner\"",
+          "before": {
+            "mode": "auto",
+            "virtual_location": "before target",
+            "focus_location": "before target"
+          },
+          "after": "start of target",
+          "output": "\"This is the start of the banner role container\"",
+          "results": [
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_role",
+              "result": "fail"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_boundaries",
+              "result": "fail"
+            }
+          ]
+        },
+        {
+          "command": "previous_item",
+          "css_target": "role=\"banner\"",
+          "before": {
+            "mode": "auto",
+            "virtual_location": "after target",
+            "focus_location": "after target"
+          },
+          "after": "end of target",
+          "output": "\"This is the end of the banner role container\"",
+          "results": [
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_role",
+              "result": "fail"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_boundaries",
+              "result": "fail"
+            }
+          ]
+        }
+      ]
+    },
+    "nvda": {
+      "chrome": [
+        {
+          "command": "next_landmark",
+          "css_target": "role=\"banner\"",
+          "before": {
+            "mode": "auto",
+            "virtual_location": "before target",
+            "focus_location": "before target"
+          },
+          "after": "target",
+          "output": "\"banner, landmark, This is the start of the banner role container\"",
+          "results": [
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_role",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "provide_shortcuts",
+              "result": "pass"
+            }
+          ]
+        },
+        {
+          "command": "open_element_list",
+          "css_target": "role=\"banner\"",
+          "before": {
+            "mode": "auto",
+            "virtual_location": "before target",
+            "focus_location": "before target"
+          },
+          "after": "target",
+          "output": "Elements landmarks list includes \"banner\"",
+          "results": [
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_role",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "provide_shortcuts",
+              "result": "pass"
+            }
+          ]
+        },
+        {
+          "command": "next_focusable_item",
+          "css_target": "role=\"banner\" > button",
+          "before": {
+            "mode": "auto",
+            "virtual_location": "before target",
+            "focus_location": "before target"
+          },
+          "after": "target",
+          "output": "\"banner, landmark, Header button 1, button\"",
+          "results": [
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_role",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_boundaries",
+              "result": "pass"
+            }
+          ]
+        },
+        {
+          "command": "previous_focusable_item",
+          "css_target": "role=\"banner\" > button",
+          "before": {
+            "mode": "auto",
+            "virtual_location": "after target",
+            "focus_location": "after target"
+          },
+          "after": "target",
+          "output": "\"banner, landmark, Header button 2, button\"",
+          "results": [
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_role",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_boundaries",
+              "result": "pass"
+            }
+          ]
+        },
+        {
+          "command": "next_item",
+          "css_target": "role=\"banner\"",
+          "before": {
+            "mode": "auto",
+            "virtual_location": "before target",
+            "focus_location": "before target"
+          },
+          "after": "start of target",
+          "output": "\"banner, landmark, This is the start of the banner role container\"",
+          "results": [
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_role",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_boundaries",
+              "result": "pass"
+            }
+          ]
+        },
+        {
+          "command": "previous_item",
+          "css_target": "role=\"banner\"",
+          "before": {
+            "mode": "auto",
+            "virtual_location": "after target",
+            "focus_location": "after target"
+          },
+          "after": "end of target",
+          "output": "\"banner, landmark, This is the end of the banner landmark container\"",
+          "results": [
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_role",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_boundaries",
+              "result": "pass"
+            }
+          ]
+        }
+      ],
+      "edge": [
+        {
+          "command": "next_landmark",
+          "css_target": "role=\"banner\"",
+          "before": {
+            "mode": "auto",
+            "virtual_location": "before target",
+            "focus_location": "before target"
+          },
+          "after": "target",
+          "output": "\"banner, landmark, This is the start of the banner role container\"",
+          "results": [
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_role",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "provide_shortcuts",
+              "result": "pass"
+            }
+          ]
+        },
+        {
+          "command": "open_element_list",
+          "css_target": "role=\"banner\"",
+          "before": {
+            "mode": "auto",
+            "virtual_location": "before target",
+            "focus_location": "before target"
+          },
+          "after": "target",
+          "output": "Elements landmarks list includes \"banner\"",
+          "results": [
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_role",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "provide_shortcuts",
+              "result": "pass"
+            }
+          ]
+        },
+        {
+          "command": "next_focusable_item",
+          "css_target": "role=\"banner\" > button",
+          "before": {
+            "mode": "auto",
+            "virtual_location": "before target",
+            "focus_location": "before target"
+          },
+          "after": "target",
+          "output": "\"banner, landmark, Button 1, button\"",
+          "results": [
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_role",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_boundaries",
+              "result": "pass"
+            }
+          ]
+        },
+        {
+          "command": "previous_focusable_item",
+          "css_target": "role=\"banner\" > button",
+          "before": {
+            "mode": "auto",
+            "virtual_location": "after target",
+            "focus_location": "after target"
+          },
+          "after": "target",
+          "output": "\"banner, landmark, Header button 2, button\"",
+          "results": [
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_role",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_boundaries",
+              "result": "pass"
+            }
+          ]
+        },
+        {
+          "command": "next_item",
+          "css_target": "role=\"banner\"",
+          "before": {
+            "mode": "auto",
+            "virtual_location": "before target",
+            "focus_location": "before target"
+          },
+          "after": "start of target",
+          "output": "\"banner, landmark, This is the start of the banner landmark container\"",
+          "results": [
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_role",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_boundaries",
+              "result": "pass"
+            }
+          ]
+        },
+        {
+          "command": "previous_item",
+          "css_target": "role=\"banner\"",
+          "before": {
+            "mode": "auto",
+            "virtual_location": "after target",
+            "focus_location": "after target"
+          },
+          "after": "end of target",
+          "output": "\"banner, landmark, This is the end of the banner role container\"",
+          "results": [
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_role",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_boundaries",
+              "result": "pass"
+            }
+          ]
+        }
+      ],
+      "firefox": [
+        {
+          "command": "next_landmark",
+          "css_target": "role=\"banner\"",
+          "before": {
+            "mode": "auto",
+            "virtual_location": "before target",
+            "focus_location": "before target"
+          },
+          "after": "target",
+          "output": "\"banner, landmark, This is the start of the banner role container\"",
+          "results": [
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_role",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "provide_shortcuts",
+              "result": "pass"
+            }
+          ]
+        },
+        {
+          "command": "open_element_list",
+          "css_target": "role=\"banner\"",
+          "before": {
+            "mode": "auto",
+            "virtual_location": "before target",
+            "focus_location": "before target"
+          },
+          "after": "target",
+          "output": "Elements landmarks list includes \"banner\"",
+          "results": [
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_role",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "provide_shortcuts",
+              "result": "pass"
+            }
+          ]
+        },
+        {
+          "command": "next_focusable_item",
+          "css_target": "role=\"banner\" > button",
+          "before": {
+            "mode": "auto",
+            "virtual_location": "before target",
+            "focus_location": "before target"
+          },
+          "after": "target",
+          "output": "\"banner, landmark, Header button 1, button\"",
+          "results": [
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_role",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_boundaries",
+              "result": "pass"
+            }
+          ]
+        },
+        {
+          "command": "previous_focusable_item",
+          "css_target": "role=\"banner\" > button",
+          "before": {
+            "mode": "auto",
+            "virtual_location": "after target",
+            "focus_location": "after target"
+          },
+          "after": "target",
+          "output": "\"banner, landmark, Header button 2, button\"",
+          "results": [
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_role",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_boundaries",
+              "result": "pass"
+            }
+          ]
+        },
+        {
+          "command": "next_item",
+          "css_target": "role=\"banner\"",
+          "before": {
+            "mode": "auto",
+            "virtual_location": "before target",
+            "focus_location": "before target"
+          },
+          "after": "start of target",
+          "output": "\"banner, landmark, This is the start of the banner role container\"",
+          "results": [
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_role",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_boundaries",
+              "result": "pass"
+            }
+          ]
+        },
+        {
+          "command": "previous_item",
+          "css_target": "role=\"banner\"",
+          "before": {
+            "mode": "auto",
+            "virtual_location": "after target",
+            "focus_location": "after target"
+          },
+          "after": "end of target",
+          "output": "\"banner, landmark, This is the end of the banner role container\"",
+          "results": [
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_role",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_boundaries",
+              "result": "pass"
+            }
+          ]
+        }
+      ]
+    },
+    "talkback": {
+      "and_chr": [
+        {
+          "command": "next_landmark",
+          "css_target": "role=\"banner\"",
+          "before": {
+            "mode": "auto",
+            "virtual_location": "before target",
+            "focus_location": "before target"
+          },
+          "after": "target",
+          "output": "\"banner, This is the start of the banner role container...\"",
+          "results": [
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_role",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "provide_shortcuts",
+              "result": "pass"
+            }
+          ]
+        },
+        {
+          "command": "next_item",
+          "css_target": "role=\"banner\"",
+          "before": {
+            "mode": "auto",
+            "virtual_location": "before target",
+            "focus_location": "before target"
+          },
+          "after": "start of target",
+          "output": "\"This is the start of the banner role container\"",
+          "results": [
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_role",
+              "result": "fail"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_boundaries",
+              "result": "fail"
+            }
+          ]
+        },
+        {
+          "command": "previous_item",
+          "css_target": "role=\"banner\"",
+          "before": {
+            "mode": "auto",
+            "virtual_location": "after target",
+            "focus_location": "after target"
+          },
+          "after": "end of target",
+          "output": "\"This is the end of the banner role container\"",
+          "results": [
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_role",
+              "result": "fail"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_boundaries",
+              "result": "fail"
+            }
+          ]
+        }
+      ]
+    },
+    "vo_ios": {
+      "ios_saf": [
+        {
+          "command": "next_landmark",
+          "css_target": "role=\"banner\"",
+          "before": {
+            "mode": "auto",
+            "virtual_location": "before target",
+            "focus_location": "before target"
+          },
+          "after": "target",
+          "output": "\"This is the start of the banner role container, banner, Landmark\"",
+          "results": [
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_role",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "provide_shortcuts",
+              "result": "pass"
+            }
+          ]
+        },
+        {
+          "command": "next_item",
+          "css_target": "role=\"banner\"",
+          "before": {
+            "mode": "auto",
+            "virtual_location": "before target",
+            "focus_location": "before target"
+          },
+          "after": "start of target",
+          "output": "\"This is the start of the banner role container, banner, Landmark\"",
+          "results": [
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_role",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_boundaries",
+              "result": "pass"
+            }
+          ]
+        },
+        {
+          "command": "previous_item",
+          "css_target": "role=\"banner\"",
+          "before": {
+            "mode": "auto",
+            "virtual_location": "after target",
+            "focus_location": "after target"
+          },
+          "after": "end of target",
+          "output": "\"This is the end of the banner role container, end, banner\"",
+          "results": [
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_role",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_boundaries",
+              "result": "pass"
+            }
+          ]
+        }
+      ]
+    },
+    "vo_macos": {
+      "safari": [
+        {
+          "command": "open_element_list",
+          "css_target": "role=\"banner\"",
+          "before": {
+            "mode": "auto",
+            "virtual_location": "before target",
+            "focus_location": "before target"
+          },
+          "after": "target",
+          "output": "Landmarks list includes \"banner\"",
+          "results": [
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_role",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "provide_shortcuts",
+              "result": "pass"
+            }
+          ]
+        },
+        {
+          "command": "next_focusable_item",
+          "css_target": "role=\"banner\" > button",
+          "before": {
+            "mode": "auto",
+            "virtual_location": "before target",
+            "focus_location": "before target"
+          },
+          "after": "target",
+          "output": "\"Header button 1, button, banner\"",
+          "results": [
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_role",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_boundaries",
+              "result": "pass"
+            }
+          ]
+        },
+        {
+          "command": "previous_focusable_item",
+          "css_target": "role=\"banner\" > button",
+          "before": {
+            "mode": "auto",
+            "virtual_location": "after target",
+            "focus_location": "after target"
+          },
+          "after": "target",
+          "output": "\"Header button 2, button, banner\"",
+          "results": [
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_role",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_boundaries",
+              "result": "pass"
+            }
+          ]
+        },
+        {
+          "command": "next_item",
+          "css_target": "role=\"banner\"",
+          "before": {
+            "mode": "auto",
+            "virtual_location": "before target",
+            "focus_location": "before target"
+          },
+          "after": "start of target",
+          "output": "\"banner\"",
+          "results": [
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_role",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_boundaries",
+              "result": "pass"
+            }
+          ]
+        },
+        {
+          "command": "previous_item",
+          "css_target": "role=\"banner\"",
+          "before": {
+            "mode": "auto",
+            "virtual_location": "after target",
+            "focus_location": "after target"
+          },
+          "after": "end of target",
+          "output": "\"end of, banner\"",
+          "results": [
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_role",
+              "result": "pass"
+            },
+            {
+              "feature_id": "aria/banner_role",
+              "feature_assertion_id": "convey_boundaries",
+              "result": "pass"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "history": [
+    {
+      "date": "2021-12-21",
+      "message": "Test created"
+    }
+  ],
+  "versions": {
+    "jaws": {
+      "browsers": {
+        "chrome": {
+          "at_version": "2022.2112.24",
+          "browser_version": "96",
+          "os_version": "21H1",
+          "date": "2021-12-21"
+        },
+        "edge": {
+          "at_version": "2022.2112.24",
+          "browser_version": "96",
+          "os_version": "21H1",
+          "date": "2021-12-21"
+        },
+        "firefox": {
+          "at_version": "2022.2112.24",
+          "browser_version": "95",
+          "os_version": "21H1",
+          "date": "2021-12-21"
+        }
+      }
+    },
+    "narrator": {
+      "browsers": {
+        "edge": {
+          "at_version": "21H1",
+          "browser_version": "96",
+          "os_version": "21H1",
+          "date": "2021-12-21"
+        }
+      }
+    },
+    "nvda": {
+      "browsers": {
+        "chrome": {
+          "at_version": "2021.3",
+          "os_version": "21H1",
+          "browser_version": "96",
+          "date": "2021-12-21"
+        },
+        "edge": {
+          "at_version": "2021.3",
+          "os_version": "21H1",
+          "browser_version": "96",
+          "date": "2021-12-21"
+        },
+        "firefox": {
+          "at_version": "2021.3",
+          "browser_version": "95",
+          "os_version": "21H1",
+          "date": "2021-12-21"
+        }
+      }
+    },
+    "talkback": {
+      "browsers": {
+        "and_chr": {
+          "at_version": "12.1",
+          "browser_version": "96",
+          "os_version": "12",
+          "date": "2021-12-21"
+        }
+      }
+    },
+    "vo_ios": {
+      "browsers": {
+        "ios_saf": {
+          "at_version": "15.1",
+          "browser_version": "15.1",
+          "os_version": "15.1",
+          "date": "2021-12-21"
+        }
+      }
+    },
+    "vo_macos": {
+      "browsers": {
+        "safari": {
+          "at_version": "11.6.1",
+          "browser_version": "15.1",
+          "os_version": "11.6.1",
+          "date": "2021-12-21"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Next ARIA landmark: banner.

I'm annoyed because Firefox + JAWS stubbornly refused to leave forms mode, so I couldn't check the shortcuts or next/previous read mode scenarios. Any thoughts? Switched away to another app and back, switched browser tabs, tried every JAWS command under the sun for forms mode, exit forms mode, virtual cursor...

Pulled out those tests so it'd compile, happy to reintroduce if I've missed something obvious.

Interesting that JAWS appears to have less support for banner boundaries than navigation. 🤔 

In case I don't hear anything prior, happy Christmas! 🎄 