### PR TITLE
add test for html_svg_inline_with_title orca/firefox

### DIFF
--- a/data/latest_versions.json
+++ b/data/latest_versions.json
@@ -17,8 +17,8 @@
       "os_version": "Windows 11 version 21H2"
     },
     "orca": {
-      "at_version": "42.0",
-      "os_version": "Ubuntu 22.04"
+      "at_version": "46.3",
+      "os_version": "Ubuntu 24.04 LTS"
     },
     "talkback": {
       "at_version": "12.5",
@@ -60,7 +60,7 @@
       "version": "104"
     },
     "firefox": {
-      "version": "104"
+      "version": "133.0.3"
     },
     "and_chr": {
       "version": "103"

--- a/data/tests/html_svg_inline_with_title.json
+++ b/data/tests/html_svg_inline_with_title.json
@@ -408,7 +408,28 @@
         }
       ]
     },
-    "orca": {},
+    "orca": {
+      "firefox": [
+        {
+          "command": "next_item",
+          "css_target": "svg",
+          "before": {
+            "mode": "auto",
+            "virtual_location": "before target",
+            "focus_location": "before target"
+          },
+          "after": "target",
+          "output": "\"red square image\"",
+          "results": [
+            {
+              "feature_id": "svg/title_element",
+              "feature_assertion_id": "convey_name",
+              "result": "pass"
+            }
+          ]
+        }
+      ]
+    },
     "vc_ios": {},
     "vc_macos": {},
     "wsr": {}
@@ -433,6 +454,10 @@
     {
       "date": "2021-08-07",
       "message": "Added Narrator results for NVDA and JAWS, updated NVDA+Chrome results."
+    },
+    {
+      "date": "2025-01-12",
+      "message": "Added test case and result for Orca+Firefox."
     }
   ],
   "versions": {
@@ -493,6 +518,16 @@
           "browser_version": "88",
           "os_version": "Windows 10 version 20h2",
           "date": "2021-05-30"
+        }
+      }
+    },
+    "orca": {
+      "browsers": {
+        "firefox": {
+          "at_version": "46.3",
+          "browser_version": "133.0.3",
+          "os_version": "Ubuntu 24.04 LTS",
+          "date": "2025-01-04"
         }
       }
     },


### PR DESCRIPTION
Noticed this particular combination had no results in a11ysupport, but when I tried testing using orca/firefox on the same test case I was able to confirm that it was working. So this PR adds the missing test and its results.

I've included some details of the test below. Happy to make edits to the PR if need be.

1. **The name of the test**: HTML SVG element with SVG title element
2. **The AT name**: orca
3. **The AT version**: 46.3
4. **The Browser Name**:  Firefox
5. **The Browser version**: 133.0.3
6. **The OS version**: Ubuntu 24.04 LTS
7. **The specific command(s) used to access the target element with the AT (keys used, touch gestures, or voice command)**: Down arrow to focus on the `svg` element.
8. **The output announced by the screen reader for each specific command (if using a screen reader)**: "red square image"
9. **Whether or not you think the test passes or fails and why**: Orca conveys the name given in the title element ("red square").