### PR TITLE
Updated results for tech/aria/heading-role-no-level

### DIFF
--- a/data/tests/tech/aria/heading-role-no-level.json
+++ b/data/tests/tech/aria/heading-role-no-level.json
@@ -412,7 +412,7 @@
             "focus_location": "before target"
           },
           "after": "target",
-          "output": "Level 0 aria heading with missing aria-level attribute, expanded 1 of 1",
+          "output": "nested under the h1",
           "results": [
             {
               "feature_id": "aria/heading_role",


### PR DESCRIPTION
Updated the results for tech/aria/heading-role-no-level based on the results provided in issue #301. 

Closes #301 