### PR TITLE
Update test date for apg/modal-dialog

### DIFF
--- a/data/tests/apg/modal-dialog-example.json
+++ b/data/tests/apg/modal-dialog-example.json
@@ -1567,6 +1567,10 @@
     {
       "date": "2022-01-13",
       "message": "Updates results"
+    },
+    {
+      "date": "2025-08-15",
+      "message": "Updated NVDA+Chrome results."
     }
   ],
   "versions": {
@@ -1611,10 +1615,10 @@
     "nvda": {
       "browsers": {
         "chrome": {
-          "at_version": "2022.4",
-          "os_version": "Windows 11 version 22h2",
-          "browser_version": "108",
-          "date": "2023-01-13"
+          "at_version": "2024.3",
+          "os_version": "Windows 11 version 23h2",
+          "browser_version": "129",
+          "date": "2024-10-10"
         },
         "edge": {
           "at_version": "2022.4",


### PR DESCRIPTION
Updated test date for NVDA+Chrome. 

Closes issue #294 