### PR TITLE
Update test date for apg/aria-1-2-combobox

### DIFF
--- a/data/tests/apg/aria-1-2-combobox-with-list-autocomplete-example.json
+++ b/data/tests/apg/aria-1-2-combobox-with-list-autocomplete-example.json
@@ -4522,6 +4522,10 @@
     {
       "date": "2023-08-22",
       "message": "Updated results. Support was largely similar to when it was last tested, except that both VoiceOver for MacOS and Talkback for Android appear to have lost support for options within a listbox."
+    },
+    {
+      "date": "2025-08-15",
+      "message": "Updated NVDA+Edge version."
     }
   ],
   "versions": {
@@ -4572,10 +4576,10 @@
           "date": "2023-08-22"
         },
         "edge": {
-          "at_version": "2023.1",
-          "os_version": "Windows 11 version 22h2",
-          "browser_version": "115",
-          "date": "2023-08-22"
+          "at_version": "2024.3",
+          "os_version": "Windows 11 version 23h2",
+          "browser_version": "130.0.2849.27",
+          "date": "2024-10-08"
         },
         "firefox": {
           "at_version": "2023.1",


### PR DESCRIPTION
Updated test result date for NVDA+Edge.

Closes #293 