### PR TITLE
test(role-note): test added

### DIFF
--- a/data/tech/aria/note_role.json
+++ b/data/tech/aria/note_role.json
@@ -9,6 +9,49 @@
       "url": "https://www.w3.org/TR/wai-aria-1.1/#note"
     }
   ],
-  "assertions": [],
-  "date_updated": "2019-01-06"
+  "assertions": [
+    {
+      "id": "convey_role",
+      "strength": {
+        "sr": "MUST",
+        "vc": "NA",
+        "kb": "NA"
+      },
+      "rationale": "Users need to be aware of the note context",
+      "css_target": "*[role=\"note\"]",
+      "preconditions": [],
+      "operation_modes": [
+        "sr/reading"
+      ]
+    },
+    {
+      "id": "convey_name",
+      "title": "convey its name",
+      "strength": {
+        "sr": "MUST",
+        "vc": "NA",
+        "kb": "NA"
+      },
+      "rationale": "convey the name of the note",
+      "css_target": "*[role=\"note\"]",
+      "preconditions": [],
+      "operation_modes": [
+        "sr/reading"
+      ]
+    },
+    {
+      "id": "convey_boundaries",
+      "title": "convey boundaries",
+      "rationale": "Users need to know when they enter and exit a note so that they can differentiate it from surrounding content.",
+      "examples": [
+        "Screen readers might announce the starting boundary by conveying the role.",
+        "Screen readers might announce the ending boundary by conveying something like \"leaving note\"."
+      ],
+      "css_target": "*[role=\"note\"]",
+      "operation_modes": [
+        "sr/reading"
+      ]
+    }
+  ],
+  "date_updated": "2025-09-12"
 }

--- a/data/tests/html/aria/note-role.html
+++ b/data/tests/html/aria/note-role.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>Note role test suite</title>
+    <style>
+        [role=note] {
+            border: 1px solid #52e052;
+            margin: 2em;
+            padding: 1em;
+            background: #e9fbe9;
+        }
+    </style>
+</head>
+<body>
+
+    <h1>Note role test suite</h1>
+
+    <p>This is a test suite for the note role.</p>
+
+    <h2>Example 1: named note role</h2>
+
+    <button>Tab stop before</button>
+
+    <div role="note" aria-labelledby="target-1">
+        <h3 id="target-1">Example Note</h3>
+        <p>Content within the note</p>
+        <a href="#">Learn more</a>
+    </div>
+
+    <button>Tab stop after</button>
+
+</body>
+</html>

--- a/data/tests/tech/aria/role-note-named.json
+++ b/data/tests/tech/aria/role-note-named.json
@@ -1,0 +1,376 @@
+{
+  "title": "named note role",
+  "description": "This test checks a named note role",
+  "html_file": "aria/note-role.html",
+  "assertions": [
+    {
+      "feature_id": "aria/note_role",
+      "feature_assertion_id": "convey_role",
+      "applied_to": "html/div_element"
+    },
+    {
+      "feature_id": "aria/note_role",
+      "feature_assertion_id": "convey_name",
+      "applied_to": "html/div_element"
+    },
+    {
+      "feature_id": "aria/note_role",
+      "feature_assertion_id": "convey_boundaries",
+      "applied_to": "html/div_element"
+    }
+  ],
+  "commands": {
+    "jaws": {
+      "chrome": [
+        {
+          "command": "next_item",
+          "css_target": "#target-1",
+          "before": {
+            "mode": "auto",
+            "focus_location": "before target",
+            "virtual_location": "before target"
+          },
+          "after": "target",
+          "output": "\"Example Note, note\"",
+          "results": [
+            {
+              "feature_id": "aria/note_role",
+              "feature_assertion_id": "convey_role",
+              "applied_to": "html/div_element",
+              "result": "pass",
+              "notes": null
+            },
+            {
+              "feature_id": "aria/note_role",
+              "feature_assertion_id": "convey_name",
+              "applied_to": "html/div_element",
+              "result": "fail",
+              "notes": "Announces just \" Note\""
+            },
+            {
+              "feature_id": "aria/note_role",
+              "feature_assertion_id": "convey_boundaries",
+              "applied_to": "html/div_element",
+              "result": "pass",
+              "notes": null
+            }
+          ]
+        }
+      ],
+      "edge": [
+        {
+          "command": "next_item",
+          "css_target": "#target-1",
+          "before": {
+            "mode": "auto",
+            "focus_location": "before target",
+            "virtual_location": "before target"
+          },
+          "after": "target",
+          "output": "\"Example Note, note\"",
+          "results": [
+            {
+              "feature_id": "aria/note_role",
+              "feature_assertion_id": "convey_role",
+              "applied_to": "html/div_element",
+              "result": "pass",
+              "notes": null
+            },
+            {
+              "feature_id": "aria/note_role",
+              "feature_assertion_id": "convey_name",
+              "applied_to": "html/div_element",
+              "result": "fail",
+              "notes": "Announces just \" Note\""
+            },
+            {
+              "feature_id": "aria/note_role",
+              "feature_assertion_id": "convey_boundaries",
+              "applied_to": "html/div_element",
+              "result": "pass",
+              "notes": null
+            }
+          ]
+        }
+      ]
+    },
+    "narrator": {
+      "edge": [
+        {
+          "command": "next_item",
+          "css_target": "#target-1",
+          "before": {
+            "mode": "auto",
+            "focus_location": "before target",
+            "virtual_location": "before target"
+          },
+          "after": "target",
+          "output": "\"Example Note, note\"",
+          "results": [
+            {
+              "feature_id": "aria/note_role",
+              "feature_assertion_id": "convey_role",
+              "applied_to": "html/div_element",
+              "result": "fail",
+              "notes": null
+            },
+            {
+              "feature_id": "aria/note_role",
+              "feature_assertion_id": "convey_name",
+              "applied_to": "html/div_element",
+              "result": "fail",
+              "notes": null
+            },
+            {
+              "feature_id": "aria/note_role",
+              "feature_assertion_id": "convey_boundaries",
+              "applied_to": "html/div_element",
+              "result": "fail",
+              "notes": null
+            }
+          ]
+        }
+      ]
+    },
+    "nvda": {
+      "chrome": [
+        {
+          "command": "next_item",
+          "css_target": "#target-1",
+          "before": {
+            "mode": "auto",
+            "focus_location": "before target",
+            "virtual_location": "before target"
+          },
+          "after": "target",
+          "output": "\"Example Note, note\"",
+          "results": [
+            {
+              "feature_id": "aria/note_role",
+              "feature_assertion_id": "convey_role",
+              "applied_to": "html/div_element",
+              "result": "fail",
+              "notes": null
+            },
+            {
+              "feature_id": "aria/note_role",
+              "feature_assertion_id": "convey_name",
+              "applied_to": "html/div_element",
+              "result": "fail",
+              "notes": null
+            },
+            {
+              "feature_id": "aria/note_role",
+              "feature_assertion_id": "convey_boundaries",
+              "applied_to": "html/div_element",
+              "result": "fail",
+              "notes": null
+            }
+          ]
+        }
+      ],
+      "edge": [
+        {
+          "command": "next_item",
+          "css_target": "#target-1",
+          "before": {
+            "mode": "auto",
+            "focus_location": "before target",
+            "virtual_location": "before target"
+          },
+          "after": "target",
+          "output": "\"Example Note, note\"",
+          "results": [
+            {
+              "feature_id": "aria/note_role",
+              "feature_assertion_id": "convey_role",
+              "applied_to": "html/div_element",
+              "result": "fail",
+              "notes": null
+            },
+            {
+              "feature_id": "aria/note_role",
+              "feature_assertion_id": "convey_name",
+              "applied_to": "html/div_element",
+              "result": "fail",
+              "notes": null
+            },
+            {
+              "feature_id": "aria/note_role",
+              "feature_assertion_id": "convey_boundaries",
+              "applied_to": "html/div_element",
+              "result": "fail",
+              "notes": null
+            }
+          ]
+        }
+      ],
+      "firefox": [
+        {
+          "command": "next_item",
+          "css_target": "#target-1",
+          "before": {
+            "mode": "auto",
+            "focus_location": "before target",
+            "virtual_location": "before target"
+          },
+          "after": "target",
+          "output": "\"Example Note, note\"",
+          "results": [
+            {
+              "feature_id": "aria/note_role",
+              "feature_assertion_id": "convey_role",
+              "applied_to": "html/div_element",
+              "result": "fail",
+              "notes": null
+            },
+            {
+              "feature_id": "aria/note_role",
+              "feature_assertion_id": "convey_name",
+              "applied_to": "html/div_element",
+              "result": "fail",
+              "notes": null
+            },
+            {
+              "feature_id": "aria/note_role",
+              "feature_assertion_id": "convey_boundaries",
+              "applied_to": "html/div_element",
+              "result": "fail",
+              "notes": null
+            }
+          ]
+        }
+      ]
+    },
+    "vo_macos": {
+      "safari": [
+        {
+          "command": "next_item",
+          "css_target": "#target-1",
+          "before": {
+            "mode": "auto",
+            "focus_location": "before target",
+            "virtual_location": "before target"
+          },
+          "after": "target",
+          "output": "\"Example Note, note \"",
+          "results": [
+            {
+              "feature_id": "aria/note_role",
+              "feature_assertion_id": "convey_role",
+              "applied_to": "html/div_element",
+              "result": "pass",
+              "notes": null
+            },
+            {
+              "feature_id": "aria/note_role",
+              "feature_assertion_id": "convey_name",
+              "applied_to": "html/div_element",
+              "result": "pass",
+              "notes": null
+            },
+            {
+              "feature_id": "aria/note_role",
+              "feature_assertion_id": "convey_boundaries",
+              "applied_to": "html/div_element",
+              "result": "pass",
+              "notes": null
+            }
+          ]
+        },
+        {
+          "command": "next_item",
+          "css_target": "#target-1",
+          "before": {
+            "mode": "auto",
+            "focus_location": "before target",
+            "virtual_location": "before target"
+          },
+          "after": "target",
+          "output": "\"end of, example note, note\"",
+          "results": [
+            {
+              "feature_id": "aria/note_role",
+              "feature_assertion_id": "convey_boundaries",
+              "applied_to": "html/div_element",
+              "result": "pass",
+              "notes": null
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "history": [
+    {
+      "date": "2025-09-12",
+      "message": "test added"
+    }
+  ],
+  "versions": {
+    "jaws": {
+      "browsers": {
+        "chrome": {
+          "at_version": "2025.2412.50",
+          "browser_version": "137",
+          "os_version": "Windows 10 Pro version 2009",
+          "date": "2025-09-12"
+        },
+        "edge": {
+          "at_version": "2025.2412.50",
+          "browser_version": "137",
+          "os_version": "Windows 10 Pro version 2009",
+          "date": "2025-09-12"
+        },
+        "firefox": {
+          "at_version": "2025.2412.50",
+          "os_version": "Windows 10 Pro version 2009",
+          "browser_version": "139",
+          "date": "2025-09-12"
+        }
+      }
+    },
+    "narrator": {
+      "browsers": {
+        "edge": {
+          "at_version": "Windows 10 Pro version 2009",
+          "os_version": "Windows 10 Pro version 2009",
+          "browser_version": "137",
+          "date": "2025-09-12"
+        }
+      }
+    },
+    "nvda": {
+      "browsers": {
+        "chrome": {
+          "at_version": "2025.1.1",
+          "os_version": "Windows 10 Pro version 2009",
+          "browser_version": "137",
+          "date": "2025-09-12"
+        },
+        "edge": {
+          "at_version": "2025.1.1",
+          "os_version": "Windows 10 Pro version 2009",
+          "browser_version": "137",
+          "date": "2025-09-12"
+        },
+        "firefox": {
+          "at_version": "2025.1.1",
+          "os_version": "Windows 10 Pro version 2009",
+          "browser_version": "139",
+          "date": "2025-09-12"
+        }
+      }
+    },
+    "vo_macos": {
+      "browsers": {
+        "safari": {
+          "at_version": "15.5",
+          "os_version": "15.5",
+          "browser_version": "18.5",
+          "date": "2025-09-12"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This commit adds comprehensive testing support for the ARIA `note role`

Added 3 key assertions for the note role:

- convey_role: Screen readers must communicate the note role to users
- convey_name: Screen readers must convey the accessible name of the note
- convey_boundaries: Screen readers must indicate when users enter/exit the note region

Added support for following AT:

- JAWS (Chrome, Edge)
- Narrator (Edge)
- NVDA (Chrome, Edge, Firefox)
- VoiceOver macOS (Safari)