### PR TITLE
Updated tests for aria-errormessage-with-aria-invalid-true

### DIFF
--- a/data/tests/tech/aria/aria-errormessage-with-aria-invalid-true.json
+++ b/data/tests/tech/aria/aria-errormessage-with-aria-invalid-true.json
@@ -596,7 +596,7 @@
             "focus_location": "before target"
           },
           "after": "target",
-        "output": "\"Input with aria-invalid=\"false\", edit has autocomplete blank \"",
+          "output": "\"Input with aria-invalid=\"false\", edit has autocomplete blank \"",
           "results": [
             {
               "feature_id": "aria/aria-errormessage_attribute",
@@ -657,13 +657,13 @@
             "focus_location": "before target"
           },
           "after": "target",
-          "output": "\"Edit box, input with aria-invalid=\"true\"\"",
+          "output": "\"Error: Invalid entry example error text. Input with aria-invalid=\"true\". Edit box\"",
           "results": [
             {
               "feature_id": "aria/aria-errormessage_attribute",
               "feature_assertion_id": "convey_pertinent",
               "applied_to": "html/input(type-text)_element",
-              "result": "fail"
+              "result": "pass"
             }
           ]
         },
@@ -719,7 +719,7 @@
             "focus_location": "before target"
           },
           "after": "target",
-          "output": "\"Input with aria-invalid=\"true\", text field, invalid date, example error text, double tap to edit\"",
+          "output": "\"Input with aria-invalid=\"true\", text field, invalid data, example error text, double tap to edit\"",
           "results": [
             {
               "feature_id": "aria/aria-errormessage_attribute",
@@ -915,6 +915,10 @@
     {
       "date": "2023-06-20",
       "message": "Updated all results"
+    },
+    {
+      "date": "2025-12-24",
+      "message": "Updated results for TalkBack+Chrome, iOS VoiceOver+Safari, and macOS VoiceOver+Safari"
     }
   ],
   "versions": {
@@ -991,30 +995,30 @@
     "talkback": {
       "browsers": {
         "and_chr": {
-          "at_version": "14",
-          "browser_version": "114",
-          "os_version": "13",
-          "date": "2023-06-20"
+          "at_version": "16.2",
+          "browser_version": "143",
+          "os_version": "16",
+          "date": "2025-12-24"
         }
       }
     },
     "vo_ios": {
       "browsers": {
         "ios_saf": {
-          "at_version": "16.5",
-          "browser_version": "16.5",
-          "os_version": "16.5",
-          "date": "2023-06-20"
+          "at_version": "18.5",
+          "browser_version": "18.5",
+          "os_version": "18.5",
+          "date": "2025-12-24"
         }
       }
     },
     "vo_macos": {
       "browsers": {
         "safari": {
-          "at_version": "13.4",
-          "browser_version": "16.5",
-          "os_version": "13.4",
-          "date": "2023-06-20"
+          "at_version": "15.7.3",
+          "browser_version": "18.6",
+          "os_version": "15.7.3",
+          "date": "2025-12-24"
         }
       }
     }


### PR DESCRIPTION
Updating test results for aria-errormessage:
- TalkBack+Chrome: now has support
- iOS VoiceOver+Safari: updated typo in output (same support as before)
- macOS VoiceOver+Safari: same support as before, only updated to modern AT/browser versions
